### PR TITLE
Add setup.py to install to Python site-packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swp
 *.py~
 .hg*
+build
+dist
+*.egg-info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pycparser

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup, find_packages
+
+
+setup(
+    name='vivisect',
+    author='',
+    author_email='',
+    version='',
+    url='https://github.com/vivisect/vivisect',
+    py_modules=[''],
+    packages=find_packages(),
+    scripts=['vdbbin', 'vivbin',],
+    description='',
+    zip_safe=False,
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python'
+        'Topic :: Security',
+        'Topic :: Software Development :: Debuggers',
+        'Topic :: Software Development :: Disassemblers',
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ setup(
     url='https://github.com/vivisect/vivisect',
     py_modules=[''],
     packages=find_packages(),
+    package_data={
+        '': ['*.dll', '*.dylib', '*.yes', '*.cfg', '*.lyt',
+             '*.c', '*.h', 'Makefile',],
+        },
     scripts=['vdbbin', 'vivbin',],
     description='',
     zip_safe=False,

--- a/vdb/extensions/__init__.py
+++ b/vdb/extensions/__init__.py
@@ -3,7 +3,7 @@ import imp
 import sys
 import traceback
 
-import vdb.ext
+import vdb.ext as vdbext
 
 __all__ = ['loadExtensions','windows','i386','darwin','amd64','gdbstub','arm','android','winkern',]
 
@@ -28,8 +28,10 @@ def loadExtensions(vdb, trace):
         mod.vdbExtension(vdb, trace)
 
     extdir = os.getenv('VDB_EXT_PATH')
-    if extdir == None:
+    if not extdir:
         extdir = os.path.abspath(os.path.join('vdb', 'ext'))
+        if not os.path.isdir(extdir):
+            extdir = os.path.dirname(vdbext.__file__)
 
     for dirname in extdir.split(';'):
 


### PR DESCRIPTION
Added a `setup.py` file to allow installing vivisect as a Python package. Some additional items, specify `vdbbin` and `vivbin` as `python_scripts`, so that you can run them from anywhere on the command line (scripts are added to your `PATH`).

Also added a `requirements.txt` file and some additional gitignore entries.