### PR TITLE
added optional parameter of graph to getSymbolikPaths

### DIFF
--- a/vivisect/symboliks/analysis.py
+++ b/vivisect/symboliks/analysis.py
@@ -546,6 +546,9 @@ class SymbolikAnalysisContext:
         effects in an emulator instance and yield
         emu, effects tuples...
         '''
+        if paths and not graph:
+            raise Exception('Must provide a graph when providing pre computed paths!')
+
         if not graph:
             graph = self.getSymbolikGraph(fva)
 

--- a/vivisect/symboliks/analysis.py
+++ b/vivisect/symboliks/analysis.py
@@ -540,13 +540,14 @@ class SymbolikAnalysisContext:
             patheffs = vg_pathcore.getNodeProp(pathnode, 'patheffs')
             yield emu, patheffs
 
-    def getSymbolikPaths(self, fva, paths=None, args=None, maxpath=1000):
+    def getSymbolikPaths(self, fva, graph=None, paths=None, args=None, maxpath=1000):
         '''
         For each path through the function, run all symbolik
         effects in an emulator instance and yield
         emu, effects tuples...
         '''
-        graph = self.getSymbolikGraph(fva)
+        if not graph:
+            graph = self.getSymbolikGraph(fva)
 
         if args == None:
             argdef = self.vw.getFunctionArgs( fva )


### PR DESCRIPTION
This fixes an issue where when a user specifies list of paths to getSymbolikPaths, the function creates a new symbolik graph. The new graph wont have edge id's that line up with the supplied paths and therefore will exception on line 583. 

The fix requires when specifying paths to also specify a graph otherwise an exception is thrown.