### PR TITLE
Viv memcanvas starts at a valid VA, fixing a lot of render bugs.

### DIFF
--- a/envi/memcanvas/__init__.py
+++ b/envi/memcanvas/__init__.py
@@ -196,6 +196,12 @@ class MemoryCanvas(object):
 
         return True
 
+    def _loc_helper(self, va):
+        '''
+        allows subclassess to make the starting VA make more contextual sense.
+        '''
+        return (va, 0)
+
     def renderMemoryUpdate(self, va, size):
 
         maxva = va + size
@@ -255,7 +261,8 @@ class MemoryCanvas(object):
     def renderMemoryPrepend(self, size):
         firstva, firstsize = self._canv_rendvas[0]
 
-        va = firstva - size
+        va, szdiff = self._loc_helper(firstva - size)
+        size += szdiff
 
         self._beginRenderPrepend()
 

--- a/envi/qt/memcanvas.py
+++ b/envi/qt/memcanvas.py
@@ -55,8 +55,8 @@ class VQMemoryCanvas(QtWebKit.QWebView, e_memcanvas.MemoryCanvas):
                 raise Exception('Invalid Address:%s' % hex(va))
 
             origva = va
-            va = max(va - size, vmap[0])
-            size += size
+            va, szdiff = self._loc_helper(max(va - size, vmap[0]))
+            size += size + szdiff
 
         ret = e_memcanvas.MemoryCanvas.renderMemory(self, va, size, rend=rend)
 

--- a/vivisect/qt/memory.py
+++ b/vivisect/qt/memory.py
@@ -291,6 +291,18 @@ class VQVivMemoryCanvas(VivCanvasBase):
         nav = self.parent() # our parent is always a VQVivMemoryWindow (nav target)
         viv_q_ctxmenu.buildContextMenu(self.vw, va=va, menu=menu, nav=nav)
 
+    def _loc_helper(self, va):
+        '''
+        we assume we're being handed a valid va since renderMemory checks for valid MemoryMap
+        '''
+        nloc = self.mem.getLocation(va)
+        if nloc == None:
+            return va, 0
+
+        nva, nvsz, nvt, nvti = nloc
+        return (nva, va-nva)
+        
+
 class VQVivMemoryView(e_mem_qt.VQMemoryWindow, viv_base.VivEventCore):
 
     def __init__(self, vw, vwqgui):


### PR DESCRIPTION
the existing code arbitrarily slams in some offset from the va we want
as the starting va.  for viv, if that is in the middle of a string, the
size of the string gets slammed in, causing all offsets to be wrong.  if
a long string exists just prior to the thing you want to see, often your
object doesn't get rendered.
