### PR TITLE
symboliks read/writeSymMemory and solve() support for vals list

### DIFF
--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -459,6 +459,11 @@ class Mem(SymbolikBase):
         return False
 
     def _solve(self, emu=None, vals=None):
+        if emu != None:
+            val = emu.readSymMemory(self.kids[0], self.kids[1], vals=vals)
+            if val and val.isDiscrete():
+                return val.solve()
+        
         addrval = self.kids[0].solve(emu=emu, vals=vals)
         sizeval = self.kids[1].solve(emu=emu, vals=vals)
         # FIXME higher entropy!

--- a/vivisect/symboliks/emulator.py
+++ b/vivisect/symboliks/emulator.py
@@ -93,14 +93,14 @@ class SymbolikEmulator:
     def getRandomSeed(self):
         return self._sym_rseed
 
-    def readSymMemory(self, symaddr, symsize):
+    def readSymMemory(self, symaddr, symsize, vals=None):
         '''
         The readSymMemory API is designed to read from the given
         symbolik address for the specified symbolik length.  If the
         current symbolik emulator has no knowledge of the state of
         the given memory symbol, None is returned.
         '''
-        addrval = symaddr.solve(emu=self)
+        addrval = symaddr.solve(emu=self, vals=vals)
 
         # check for a previous write first...
         symmem = self._sym_mem.get(addrval)
@@ -121,10 +121,10 @@ class SymbolikEmulator:
 
         return None
 
-    def writeSymMemory(self, symaddr, symval):
+    def writeSymMemory(self, symaddr, symval, vals=None):
         # FIXME handle memory offsets etc...
         # FIXME handle write size.. (using isDiscrete?)
-        addrval = symaddr.solve(emu=self)
+        addrval = symaddr.solve(emu=self, vals=vals)
         #sizeval = symsize.solve(slvctx=self)
         self._sym_mem[addrval] = (symaddr, symval)
 


### PR DESCRIPTION
allow previous "vals list" work to flow into read/writeSymMemory, and solve() for Mem objects.
