### PR TITLE
viv: dump QWebView-derived MemCanvas classes to HTML files (Memory View

### DIFF
--- a/envi/qt/memcanvas.py
+++ b/envi/qt/memcanvas.py
@@ -193,9 +193,8 @@ class VQMemoryCanvas(QtWebKit.QWebView, e_memcanvas.MemoryCanvas):
         if self._canv_curva:
             self.initMemWindowMenu(va, menu)
 
-        position = event.pos()
-        if position.x() < 50 and position.y() < 50:
-            menu.addAction("Save frame to HTML", ACT(self._menuSaveToHtml))
+        viewmenu = menu.addMenu('view   ')
+        viewmenu.addAction("Save frame to HTML", ACT(self._menuSaveToHtml))
 
         menu.exec_(event.globalPos())
 

--- a/vivisect/qt/funcgraph.py
+++ b/vivisect/qt/funcgraph.py
@@ -83,9 +83,9 @@ class VQVivFuncgraphCanvas(vq_memory.VivCanvasBase):
         else:
             menu = QtGui.QMenu(parent=self)
 
-        position = event.pos()
-        if position.x() < 50 and position.y() < 50:
-            menu.addAction("Save frame to HTML", ACT(self._menuSaveToHtml))
+        viewmenu = menu.addMenu('view   ')
+        viewmenu.addAction("Save frame to HTML", ACT(self._menuSaveToHtml))
+        #TODO: Refresh menu item :)
 
         menu.exec_(event.globalPos())
 


### PR DESCRIPTION
and FuncGraph View and Symboliks View).  Sadly, we can't currently
easily do this for the CallGraph or Tree Views (eg. Functions, Workspace
Names).  perhaps the TreeViews will be added later.  not sure about
CallGraph, it's a different animal altogether.
