### PR TITLE
emulators: add stacksize parameter

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -189,7 +189,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         """
         return self.frefs.get((va,idx))
 
-    def getEmulator(self, logwrite=False, logread=False):
+    def getEmulator(self, logwrite=False, logread=False, stacksize=4096):
         """
         Get an instance of a WorkspaceEmulator for this workspace.
 
@@ -205,7 +205,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         if eclass == None:
             raise Exception("WorkspaceEmulation not supported on %s yet!" % arch)
 
-        return eclass(self, logwrite=logwrite, logread=logread)
+        return eclass(self, logwrite=logwrite, logread=logread, stacksize=stacksize)
 
     def addLibraryDependancy(self, libname):
         """

--- a/vivisect/impemu/platarch/amd64.py
+++ b/vivisect/impemu/platarch/amd64.py
@@ -19,9 +19,9 @@ class Amd64WorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_amd64.Amd64Emulat
         e_amd64.REG_RDI, e_amd64.REG_R8,  e_amd64.REG_R9,
     ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, stacksize=4096):
         e_amd64.Amd64Emulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, stacksize=stacksize)
         self.setEmuOpt('i386:reponce',True)
 
     def getRegister(self, index):

--- a/vivisect/impemu/platarch/arm.py
+++ b/vivisect/impemu/platarch/arm.py
@@ -5,9 +5,9 @@ class ArmWorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_arm.ArmEmulator):
 
     taintregs = [ x for x in range(13) ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, stacksize=4096):
         e_arm.ArmEmulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, stacksize=stacksize)
 
 '''
 st0len gratuitously from wikipedia:

--- a/vivisect/impemu/platarch/i386.py
+++ b/vivisect/impemu/platarch/i386.py
@@ -9,7 +9,7 @@ class i386WorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_i386.IntelEmulator
         e_i386.REG_EDI,
     ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, stacksize=4096):
         e_i386.IntelEmulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, stacksize=stacksize)
         self.setEmuOpt('i386:reponce',True)

--- a/vivisect/impemu/platarch/msp430.py
+++ b/vivisect/impemu/platarch/msp430.py
@@ -5,9 +5,9 @@ class Msp430WorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_msp430e.Msp430Em
 
     taintregs = [ x for x in range(2, 16) ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, stacksize=4096):
         e_msp430e.Msp430Emulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, stacksize=4096)
 
 '''
 st0len gratuitously from mspgcc:

--- a/vivisect/impemu/platarch/windows.py
+++ b/vivisect/impemu/platarch/windows.py
@@ -103,8 +103,8 @@ class Windowsi386Emulator(WindowsMixin, v_i_i386.i386WorkspaceEmulator):
         e_i386.REG_EDI,
     ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
-        v_i_i386.i386WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+    def __init__(self, vw, logwrite=False, logread=False, stacksize=4096):
+        v_i_i386.i386WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, stacksize=stacksize)
         WindowsMixin.__init__(self)
 
     @imphook('ntdll.seh3_prolog')


### PR DESCRIPTION
add  keyword parameter to each *Emulator class, keeping the default at 4096.
this helps during emulation of functions with a large number of stack variables.