### PR TITLE
add initStackMemory method to emulator baseclass

### DIFF
--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -48,16 +48,9 @@ class WorkspaceEmulator:
         self.emumon = None
         self.psize = self.getPointerSize()
 
-        self.stack_map_mask = e_bits.sign_extend(0xfff00000, 4, vw.psize)
-        self.stack_map_base = e_bits.sign_extend(0xbfb00000, 4, vw.psize)
-        self.stack_pointer = self.stack_map_base + 4096
-
         # Possibly need an "options" API?
         self._safe_mem = True   # Should we be forgiving about memory accesses?
         self._func_only = True  # is this emulator meant to stay in one function scope?
-
-        # Map in a memory map for the stack
-        self.addMemoryMap(self.stack_map_base, 6, "[stack]", init_stack_map)
 
         # Map in all the memory associated with the workspace
         for va, size, perms, fname in vw.getMemoryMaps():
@@ -69,14 +62,6 @@ class WorkspaceEmulator:
             regval = self.setVivTaint( 'uninitreg', regidx )
             self.setRegister(regidx, regval)
 
-        self.setStackCounter(self.stack_pointer)
-
-        # Create some pre-made taints for positive stack indexes
-        # NOTE: This is *ugly* for speed....
-        taints = [ self.setVivTaint('funcstack', i * self.psize) for i in xrange(20) ]
-        taintbytes = ''.join([ e_bits.buildbytes(taint,self.psize) for taint in taints ])
-        self.writeMemory(self.stack_pointer, taintbytes )
-
         for name in dir(self):
             val = getattr(self, name, None)
             if val == None:
@@ -87,6 +72,42 @@ class WorkspaceEmulator:
                 continue
 
             self.hooks[impname] = val
+
+        self._isStackInitialized = False
+        self.stack_map_mask = None
+        self.stack_map_base = None
+        self.stack_pointer = None
+
+    def initStackMemory(self, stacksize=4096):
+        '''
+        Setup and initialize stack memory.
+        You may call this prior to reading or writing memory to the emulator.
+
+        Lazily called during readMemory/writeMemory if not initialized
+          by user.
+        '''
+        self.stack_map_mask = e_bits.sign_extend(0xfff00000, 4, self.vw.psize)
+        self.stack_map_base = e_bits.sign_extend(0xbfb00000, 4, self.vw.psize)
+        self.stack_pointer = self.stack_map_base + stacksize
+
+        # Map in a memory map for the stack
+        stack_map = init_stack_map
+        if stacksize != 4096:
+            stack_map = ''
+            for i in xrange(stacksize):
+                stack_map += struct.pack("<I", self.stack_map_base+(i*4))
+
+        self.addMemoryMap(self.stack_map_base, 6, "[stack]", stack_map)
+        self.setStackCounter(self.stack_pointer)
+
+        # Create some pre-made taints for positive stack indexes
+        # NOTE: This is *ugly* for speed....
+        taints = [ self.setVivTaint('funcstack', i * self.psize) for i in xrange(20) ]
+        taintbytes = ''.join([ e_bits.buildbytes(taint,self.psize) for taint in taints ])
+
+        # note we set this flag prior to `.writeMemory(...)`
+        self._isStackInitialized = True
+        self.writeMemory(self.stack_pointer, taintbytes)
 
     def stopEmu(self):
         '''
@@ -484,6 +505,9 @@ class WorkspaceEmulator:
         Try to write the bytes to the memory object, otherwise, dont'
         complain...
         """
+        if not self._isStackInitialized:
+            self.initStackMemory()
+
         if self.logwrite:
             wlog = vg_path.getNodeProp(self.curpath, 'writelog')
             wlog.append((self.getProgramCounter(),va,bytes))
@@ -505,6 +529,8 @@ class WorkspaceEmulator:
         return self.uninit_use.keys()
 
     def readMemory(self, va, size):
+        if not self._isStackInitialized:
+            self.initStackMemory()
 
         if self.logread:
             rlog = vg_path.getNodeProp(self.curpath, 'readlog')


### PR DESCRIPTION
Call `initStackMemory` prior to `.readMemory`/`.writeMemory` to configure emulator stack memory. Currently, this is only the stack size. Emulator subclasses may provide a more specific implementation for their architecture, if necessary.

To avoid making many breaking changes to the existing API, this new method is invoked lazily on the first call to `.readMemory` or `.writeMemory`.

Note, cannot externally access `.stack_pointer` member (or friends) prior to the first call to `.initStackMemory`/`.readMemory`. This is a potential breaking change, though I'm not sure if member variables are intended to be accessible.

Of course, using a non-default stacksize means that the stack memory is re-initialized each time, and this is slow. In the script that prompted this patch, using a default stacksize emulates 250 functions in 5 seconds, and with a stacksize of 32 pages, runs in 15 seconds. So, perhaps can add an `initialStackMemoryContents` option to the `initStackMemory` method in a future revision.