### PR TITLE
__dir__() for chaining proxies and basic introspection

### DIFF
--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -1066,6 +1066,12 @@ class CobraProxy:
         authinfo = self._cobra_kwargs.get('authinfo') 
         return CobraClientSocket(builder, retrymax=retrymax, sflags=self._cobra_sflags, authinfo=authinfo, pool=self._cobra_sockpool)
 
+    def __dir__(self):
+        '''
+        return a list of proxied method names
+        '''
+        return self._cobra_methods.keys()
+
     def __getstate__(self):
         return self.__dict__
 


### PR DESCRIPTION
here is a **dir**() method that returns the list of method names handled by the proxy
motivations:
- tab completion on the proxy instance in ipython  (i know, wimpy but still nice)
- enables chaining of CobraProxy to another CobraProxy
