### PR TITLE
Add string constants for mem read from segment

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -764,8 +764,10 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         maxlen = len(bytes) - offset
         count = 0
         while count < maxlen:
-            # If we hit another thing, then probably not...
-            if self.getLocation(va+count) != None:
+            # If we hit another thing, then probably not.
+            # Ignore when count==0 so detection can check something
+            # already set as a location.
+            if (count > 0) and (self.getLocation(va+count) != None):
                 return -1
             c = bytes[offset+count]
             # The "strings" algo basically says 4 or more...
@@ -797,8 +799,10 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         maxlen = len(bytes) + offset
         count = 0
         while count < maxlen:
-            # If we hit another thing, then probably not...
-            if self.getLocation(va+count) != None:
+            # If we hit another thing, then probably not.
+            # Ignore when count==0 so detection can check something
+            # already set as a location.
+            if (count > 0) and (self.getLocation(va+count) != None):
                 return -1
 
             c0 = bytes[offset+count]
@@ -999,16 +1003,6 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                     continue
                 if ref != None and self.isValidPointer(ref):
                     self.addXref(va, ref, REF_PTR)
-                    # Save the content if it points to a string constant
-                    # in a defined memory segment.
-                    if self.getSegment(ref) :
-                        sz = self.detectString(ref)
-                        if sz > 0 :
-                            self.addLocation(ref, sz, LOC_STRING)
-                        else :
-                            sz = self.detectUnicode(ref)
-                            if sz > 0 :
-                                self.addLocation(ref, sz, LOC_UNI)
 
         return loc
 

--- a/vivisect/analysis/__init__.py
+++ b/vivisect/analysis/__init__.py
@@ -61,6 +61,8 @@ def addAnalysisModules(vw):
         vw.addAnalysisModule("vivisect.analysis.generic.funcentries")
         vw.addAnalysisModule('vivisect.analysis.ms.msvcfunc')
 
+        vw.addAnalysisModule('vivisect.analysis.generic.strconst')
+
     elif fmt == 'elf': # ELF ########################################################
 
         vw.addAnalysisModule("vivisect.analysis.elf")

--- a/vivisect/analysis/generic/strconst.py
+++ b/vivisect/analysis/generic/strconst.py
@@ -1,0 +1,43 @@
+import envi
+from vivisect.const import *
+
+
+def analyze(vw):
+    '''
+    Find string constants used in function calls and add them to the
+    workspace location set.  The goal is to identify string constants
+    for symboliks parsing, where they become string arguments.
+
+    Functions and xrefs have already been identified.  Analysis of opcodes
+    is closely related to the makeOpcode() logic in vivisect/__init__.py.
+    '''
+
+    for fva in vw.getFunctions():
+        for va, size, funcva in vw.getFunctionBlocks(fva):
+            maxva = va+size
+            while va < maxva:
+                op = vw.parseOpcode(va)
+                for o in op.opers:
+                    if o.isDeref():
+                        continue
+                    ref = o.getOperValue(op, None)
+
+                    # Candidates will be listed with the Xrefs thanks to
+                    # logic in makeOpcode().
+                    if not (vw.getXrefsTo(ref) and vw.getXrefsFrom(va)):
+                        continue
+
+                    # String constants must be in a defined memory segment.
+                    if not vw.getSegment(ref):
+                        continue
+
+                    sz = vw.detectString(ref)
+                    if sz > 0:
+                        vw.addLocation(ref, sz, LOC_STRING)
+                    else:
+                        sz = vw.detectUnicode(ref)
+                        if sz > 0:
+                            vw.addLocation(ref, sz, LOC_UNI)
+
+                va += len(op)
+    return


### PR DESCRIPTION
Call addLocation() when an operand touches memory, the pointer to memory is in a defined segment, and the content appears to be a string. This will allow the string to be picked up in symboliks as the strconst argument of a function call.

Testing on 500 binaries that generate 1.5 million symbolic calls showed this change increases the number of strconsts from 30,500 to 41,000.
