### PR TITLE
fixed creating workspaces using a PE memobj with no filename/backing …

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -1073,8 +1073,13 @@ class MemObjFile:
     def seek(self, offset):
         self.offset = self.baseaddr + offset
 
-    def read(self, size):
-        ret = self.memobj.readMemory(self.offset, size)
+    def read(self, size=None):
+        if size != None:
+            ret = self.memobj.readMemory(self.offset, size)
+        else:
+            va, mapsize, _, _ = self.memobj.getMemoryMap(self.offset)
+            size = mapsize - self.offset
+            ret = self.memobj.readMemory(self.offset, size)
         self.offset += size
         return ret
         

--- a/vivisect/parsers/pe.py
+++ b/vivisect/parsers/pe.py
@@ -100,7 +100,7 @@ def loadPeIntoWorkspace(vw, pe, filename=None):
         fvivname = "pe_%.8x" % baseaddr
 
     fhash = "unknown hash"
-    if os.path.exists(filename):
+    if filename and os.path.exists(filename):
         fhash = v_parsers.md5File(filename)
 
     fname = vw.addFile(fvivname.lower(), baseaddr, fhash)
@@ -357,7 +357,7 @@ def loadPeIntoWorkspace(vw, pe, filename=None):
                     vw.vprint("SEHandlerTable parse error")
 
     # Last but not least, see if we have symbol support and use it if we do
-    if vt_win32.dbghelp:
+    if filename and os.path.exists(filename) and vt_win32.dbghelp:
 
         s = vt_win32.Win32SymbolParser(-1, filename, baseaddr)
 


### PR DESCRIPTION
The vivisect pe parser allows None type filenames, but os.path.exists() will create an exception if None is passed to it. Added a check to ensure a filename exists before calling os.path.exists() in vivisect/parsers/pe.py. 

The PE MemObjFile class does not properly handle an fd.read() and was causing an exception in vivisect/parsers/pe.py when loading from a PE memobj.