### PR TITLE
Replace some calls to `print()` with appropriate calls to loggers

### DIFF
--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -5,6 +5,7 @@ ArchitectureModule, Opcode, Operand, and Emulator objects.
 
 import types
 import struct
+import logging
 import platform
 
 # TODO: move into const.py
@@ -293,7 +294,7 @@ class Operand:
         NOTE: This API may be passed a None emu and should return what it can
               (or None if it can't be resolved)
         """
-        print "%s needs to implement getOperValue!" % self.__class__.__name__
+        logging.getLogger("operand").warning("%s needs to implement getOperValue!", self.__class__.__name__)
         return None
 
     def setOperValue(self, op, emu, val):
@@ -302,7 +303,7 @@ class Operand:
         the given emulator/workspace/trace to assign things like
         memory and registers.
         """
-        print("%s needs to implement setOperValue! (0x%.8x: %s) " % (self.__class__.__name__, op.va, repr(op)))
+        logging.getLogger("operand").warning("%s needs to implement setOperValue! (0x%.8x: %s) ", self.__class__.__name__, op.va, repr(op))
 
     def isDeref(self):
         """
@@ -336,7 +337,7 @@ class Operand:
         NOTE: This API may be passed a None emu and should return what it can
               (or None if it can't be resolved)
         """
-        print("%s needs to implement getOperAddr!" % self.__class__.__name__)
+        logging.getLogger("operand").warning("%s needs to implement getOperAddr!", self.__class__.__name__)
         return None
 
     def repr(self, op):

--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -2,6 +2,7 @@
 A module to contain code flow analysis for envi opcode objects...
 '''
 import copy
+import logging
 import traceback
 import envi
 import envi.memory as e_mem
@@ -154,10 +155,10 @@ class CodeFlowContext(object):
             try:
                 op = self._mem.parseOpcode(va, arch=arch)
             except envi.InvalidInstruction, e:
-                print 'parseOpcode error at 0x%.8x: %s' % (va,e)
+                logging.getLogger("envi/codeflow.addCodeFlow").warning('parseOpcode error at 0x%.8x: %s', (va,e))
                 continue 
             except Exception, e:
-                print 'parseOpcode error at 0x%.8x: %s' % (va,e)
+                logging.getLogger("envi/codeflow.addCodeFlow").warning('parseOpcode error at 0x%.8x: %s', (va,e))
                 continue
 
             branches = op.getBranches()

--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -155,10 +155,10 @@ class CodeFlowContext(object):
             try:
                 op = self._mem.parseOpcode(va, arch=arch)
             except envi.InvalidInstruction, e:
-                logging.getLogger("envi/codeflow.addCodeFlow").warning('parseOpcode error at 0x%.8x: %s', (va,e))
+                logging.getLogger("envi/codeflow.addCodeFlow").warning('parseOpcode error at 0x%.8x: %s', va,e)
                 continue 
             except Exception, e:
-                logging.getLogger("envi/codeflow.addCodeFlow").warning('parseOpcode error at 0x%.8x: %s', (va,e))
+                logging.getLogger("envi/codeflow.addCodeFlow").warning('parseOpcode error at 0x%.8x: %s', va,e)
                 continue
 
             branches = op.getBranches()

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -13,6 +13,7 @@ import string
 import struct
 import weakref
 import hashlib
+import logging
 import itertools
 import traceback
 import threading
@@ -873,7 +874,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             except envi.InvalidInstruction, msg:
                 #FIXME something is just not right about this...
                 bytes = self.readMemory(va, 16)
-                print "Invalid Instruct Attempt At:",hex(va),bytes.encode("hex")
+                logging.getLogger("vivisect.VivWorkspace.makeOpcode").warning("Invalid Instruct Attempt At: %s %s", hex(va), bytes.encode("hex"))
                 raise InvalidLocation(va,msg)
 
             except Exception, msg:
@@ -1949,7 +1950,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         if filelocal:
             segtup = self.getSegment(va)
             if segtup == None:
-                print "Failed to find file for 0x%.8x (%s) (and filelocal == True!)"  % (va, name)
+                logging.getLogger("vivisect.VivWorkspace.makeName").warning("Failed to find file for 0x%.8x (%s) (and filelocal == True!)", va, name)
             if segtup != None:
                 fname = segtup[SEG_FNAME]
                 if fname != None:

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -551,7 +551,6 @@ class VivWorkspaceCore(object,viv_impapi.ImportApi):
             self.setMeta('DefaultCall', defcall)
 
     def _mcb_bigend(self, name, value):
-        print('OH HAI')
         self.bigend = bool(value)
 
     def _mcb_Platform(self, name, value):

--- a/vivisect/parsers/pe.py
+++ b/vivisect/parsers/pe.py
@@ -1,5 +1,6 @@
 
 import os
+import logging
 import PE
 import vstruct
 import vivisect
@@ -286,7 +287,7 @@ def loadPeIntoWorkspace(vw, pe, filename=None):
                 vw.markDeadData(secbase, secbase+len(secbytes))
 
         except Exception, e:
-            print "Error Loading Section (%s size:%d rva:%.8x offset: %d): %s" % (secname,secfsize,secrva,secoff,e)
+            logging.getLogger("parsers.pe.loadPE").warning("Error Loading Section (%s size:%d rva:%.8x offset: %d): %s", secname, secfsize, secrva, secoff, e)
 
     vw.addExport(entry, EXP_FUNCTION, '__entry', fname)
     vw.addEntryPoint(entry)


### PR DESCRIPTION
Replace some calls to `print()` with appropiate calls to loggers. When using vivisect to bulk process files, the calls to `print` create a lot of noise on stdout that is difficult to filter. Using the `logging` module makes it easy to filter interesting status messages.