### PR TITLE
codeblocks analysis: handle mis-identified pointers found within unrelated instructions

### DIFF
--- a/vivisect/analysis/generic/codeblocks.py
+++ b/vivisect/analysis/generic/codeblocks.py
@@ -47,6 +47,23 @@ def analyzeFunction(vw, funcva):
 
             lva,lsize,ltype,linfo = loc
 
+            if ltype == LOC_POINTER and lva != va:
+                # pointer analysis mis-identified a pointer,
+                # so clear and re-analyze instructions.
+
+                vw.delLocation(va)
+
+                # assume we're add a valid instruction, which is most likely.
+                vw.makeCode(va)
+
+                loc = vw.getLocation(va)
+                if loc is None:
+                    blocks[start] = va - start
+                    brefs.append( (va, False) )
+                    break
+                    
+                lva,lsize,ltype,linfo = loc
+
             # If it's not an op, terminate
             if ltype != LOC_OP:
                 blocks[start] = va - start                     

--- a/vivisect/analysis/generic/codeblocks.py
+++ b/vivisect/analysis/generic/codeblocks.py
@@ -47,7 +47,7 @@ def analyzeFunction(vw, funcva):
 
             lva,lsize,ltype,linfo = loc
 
-            if ltype == LOC_POINTER and lva != va:
+            if ltype == LOC_POINTER:
                 # pointer analysis mis-identified a pointer,
                 # so clear and re-analyze instructions.
 


### PR DESCRIPTION
The pointer analysis module can mis-identify pointers, which can confuse subsequent analysis modules. This PR improves handling in the codeblocks analysis module when a valid sequence of instructions was previously marked as a `LOC_POINTER`.

The motivating x86-32 sample had the following sequence of bytes within a function:

```
74 18 8B 40 10
```

within which the pointer analysis module had marked the the "pointer" 0x10048b18 (a valid address). However, the correct interpretation of the bytes is:

```
.text:10069FFF 74 18                                   jz      short loc_1006A019
.text:1006A001 8B 40 10                                mov     eax, [eax+10h]
```

The motivating sample had approximately ten misidentified pointers across ~700KB of code.

This PR updates the codeblocks analysis module to identify likely mistaken pointers and re-run code analysis, yielding a more correct sequence of basic blocks. I think there is still the potential for misbehavior, but I suspect its now less likely.
