### PR TITLE
 envi i386: fix i386SibOper getOperAddr range

### DIFF
--- a/envi/archs/i386/disasm.py
+++ b/envi/archs/i386/disasm.py
@@ -457,6 +457,11 @@ class i386SibOper(envi.DerefOper):
         if self.index != None:
             ret += (emu.getRegister(self.index) * self.scale)
 
+        if emu.imem_psize == 4:
+            ret &= 0xFFFFFFFF
+        elif emu.imem_psize == 8:
+            ret &= 0xFFFFFFFFFFFFFFFF
+
         # Handle x86 segmentation
         base, size = emu.getSegmentInfo(op)
         ret += base

--- a/envi/archs/i386/disasm.py
+++ b/envi/archs/i386/disasm.py
@@ -457,11 +457,6 @@ class i386SibOper(envi.DerefOper):
         if self.index != None:
             ret += (emu.getRegister(self.index) * self.scale)
 
-        if emu.imem_psize == 4:
-            ret &= 0xFFFFFFFF
-        elif emu.imem_psize == 8:
-            ret &= 0xFFFFFFFFFFFFFFFF
-
         # Handle x86 segmentation
         base, size = emu.getSegmentInfo(op)
         ret += base


### PR DESCRIPTION
Fix the `i386SibOper.getOperAddr` method that does not correctly compute the sum of
two registers that might contain a negative number. Essentially, mask the result to the pointer
size of the architecture.

This patch uses `emu.imem_psize` to fetch the architecture pointer size. Might not be
the correct method, but its a way I stumbled across.

motivating example:
```
.text:10003FDC 010 E8 16 07 00 00                call    malloc
...
.text:10003FF0 010 8B 7D 08                      mov     edi, [ebp+pEncrypted]
.text:10003FF3 010 2B F8                         sub     edi, eax
.text:10003FF5 010 53                            push    ebx
.text:10003FF6
.text:10003FF6                   loc_10003FF6:                           ; CODE XREF: decode+44j
.text:10003FF6 014 8B 45 FC                      mov     eax, [ebp+buf]
.text:10003FF9 014 8D 0C 06                      lea     ecx, [esi+eax]  ; buf[i]
.text:10003FFC 014 33 D2                         xor     edx, edx
.text:10003FFE 014 6A 0B                         push    0Bh
.text:10004000 018 8B C6                         mov     eax, esi
.text:10004002 018 5B                            pop     ebx
.text:10004003 014 F7 F3                         div     ebx             ; edx = esi % len(key)
.text:10004005 014 8A 82 74 8B 00 10             mov     al, ds:byte_10008B74[edx]
.text:1000400B 014 32 04 0F                      xor     al, [edi+ecx]   <----- HERE
```

simplifying a bunch of instructions:
```
eax = malloc()    ; pointer, lets say 0x2000
edi = pBuffer     ; pointer, lets say 0x1000
sub edi, eax      ; 0x1000 - 0x2000 => negative value, 0xFFFFF000

mov ecx, eax
xor al [edi+ecx]    ; 0xFFFFF000 + 0x2000 => ???
```
in the existing code, the result is `0x100001000`, while the correct result is `0x100001000 & 0xFFFFFFFF == 0x1000`
