### PR TITLE
PE imports fix for "inmem" PEs with no OFT

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -755,6 +755,9 @@ class PE(object):
                 if ibn_rva & self.high_bit_mask:
                     funcname = ordlookup.ordLookup(libname, ibn_rva & 0x7fffffff)
 
+                elif not self.checkRva(ibn_rva):
+                    break
+
                 else:
                     # RP BUG FIX - we can't use this API on this call because we can have binaries that put their import table
                     # right at the end of the file, statically saying the imported function name is 128 will cause use to potentially


### PR DESCRIPTION
I'm receiving an exception when attempting to parse an "inmem" (dumped from memory) PE's imports when the OriginalFirstThunk is NULL. It is common for Borland executables and some packers clear the OriginalFirstThunk and rely solely on the FirstThunk for its imports. For inmem PEs, this is a problem as the PE loader will overwrite the FirstThunk array with the resolved function addresses. At this point, there is not a good way to retrieve the import names.

Currently, the PE class will create an exception as follows:

```Python
>>> import PE
>>> fd = file('out.exe', 'rb') # out.exe is a memory dump of a UPX packed PE
>>> pe = PE.PE(fd, inmem=True)
>>> for imp in pe.getImports():
...     print imp
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "Z:\vivisect\PE\__init__.py", line 418, in getImports
    return self.imports
  File "Z:\vivisect\PE\__init__.py", line 1034, in __getattr__
    self.parseImports()
  File "Z:\vivisect\PE\__init__.py", line 767, in parseImports
    bytes = self.readAtRva(ibn_rva, len(ibn), shortok=True)
  File "Z:\vivisect\vstruct\__init__.py", line 383, in __len__
    ret += len(fobj)
ValueError: __len__() should return >= 0
```

The current PE class code looks at the OriginalFirstThunk, sees it is NULL, and uses the FirstThunk instead. This is the correct approach for disk PEs, but may not work for inmem PEs.

```Python
        imp_by_name = x.OriginalFirstThunk
            if imp_by_name == 0:
                imp_by_name = x.FirstThunk
```

The value retrieved from the FirstThunk table (IAT) is assumed to be an RVA, not a resolved function address. This eventually causes an exception.

My proposed solution would be to perform a check on the retrieved address value. If the address is not a valid RVA, then we break.

The pefile project also will break when encountering this problem:
```Python
            try:
                # If the RVA is invalid all would blow up. Some EXEs seem to be
                # specially nasty and have an invalid RVA.
                data = self.get_data(rva, Structure(self.__IMAGE_IMPORT_DESCRIPTOR_format__).sizeof() )
            except PEFormatError, e:
                self.__warnings.append(
                    'Error parsing the import directory at RVA: 0x%x' % ( rva ) )
                break
```