### PR TITLE
string detection: if string location already defined, use those results

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -770,7 +770,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             if (count > 0):
                 loc = self.getLocation(va+count)
                 if loc and loc[L_LTYPE] == LOC_STRING:
-                    return loc[L_VA] - va + loc[L_SIZE]
+                    return loc[L_VA] - va + count + loc[L_SIZE]
                 return -1
             c = bytes[offset+count]
             # The "strings" algo basically says 4 or more...
@@ -808,7 +808,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             if (count > 0):
                 loc = self.getLocation(va+count)
                 if loc and loc[L_LTYPE] == LOC_UNICODE:
-                    return loc[L_VA] - va + loc[L_SIZE]
+                    return loc[L_VA] - va + count + loc[L_SIZE]
                 return -1
 
             c0 = bytes[offset+count]

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -767,7 +767,10 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             # If we hit another thing, then probably not.
             # Ignore when count==0 so detection can check something
             # already set as a location.
-            if (count > 0) and (self.getLocation(va+count) != None):
+            if (count > 0):
+                loc = self.getLocation(va+count)
+                if loc and loc[L_LTYPE] == LOC_STRING:
+                    return loc[L_VA] - va + loc[L_SIZE]
                 return -1
             c = bytes[offset+count]
             # The "strings" algo basically says 4 or more...
@@ -802,7 +805,10 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             # If we hit another thing, then probably not.
             # Ignore when count==0 so detection can check something
             # already set as a location.
-            if (count > 0) and (self.getLocation(va+count) != None):
+            if (count > 0):
+                loc = self.getLocation(va+count)
+                if loc and loc[L_LTYPE] == LOC_UNICODE:
+                    return loc[L_VA] - va + loc[L_SIZE]
                 return -1
 
             c0 = bytes[offset+count]

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -770,7 +770,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             if (count > 0):
                 loc = self.getLocation(va+count)
                 if loc and loc[L_LTYPE] == LOC_STRING:
-                    return loc[L_VA] - va + count + loc[L_SIZE]
+                    return loc[L_VA] - (va + count) + loc[L_SIZE]
                 return -1
             c = bytes[offset+count]
             # The "strings" algo basically says 4 or more...
@@ -808,7 +808,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             if (count > 0):
                 loc = self.getLocation(va+count)
                 if loc and loc[L_LTYPE] == LOC_UNICODE:
-                    return loc[L_VA] - va + count + loc[L_SIZE]
+                    return loc[L_VA] - (va + count) + loc[L_SIZE]
                 return -1
 
             c0 = bytes[offset+count]

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -807,7 +807,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             # already set as a location.
             if (count > 0):
                 loc = self.getLocation(va+count)
-                if loc and loc[L_LTYPE] == LOC_UNICODE:
+                if loc and loc[L_LTYPE] == LOC_UNI:
                     return loc[L_VA] - (va + count) + loc[L_SIZE]
                 return -1
 


### PR DESCRIPTION
improve the workspace string detection routines to better handle when the requested address collides with an existing string location. if so, use the existing string location's length.