### PR TITLE
Make it easier to get a thread's cobra socket

### DIFF
--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -1020,11 +1020,13 @@ class CobraProxy:
             return True
         return False
 
-    def _cobra_getsock(self):
+    def _cobra_getsock(self, thr=None):
         if self._cobra_spoolcnt:
             sock = self._cobra_sockpool.get()
         else:
-            thr = currentThread()
+            if not thr: # if thread isn't specified, use the current thread
+                thr = currentThread()
+                
             tsocks = getattr(thr, 'cobrasocks', None)
             if tsocks == None:
                 tsocks = {}


### PR DESCRIPTION
Modify CobraProxy's _cobra_getsock method to allow caller to specify the thread the socket should be pulled from (defaulting to currentThread(), which was always the thread used before this change.