### PR TITLE
make vw.parseOpcode use getCodeBlock to hand the entire memory map in…

### DIFF
--- a/envi/memory.py
+++ b/envi/memory.py
@@ -430,6 +430,18 @@ class MemoryObject(IMemory):
     def getMemoryMaps(self):
         return [ mmap for mva, mmaxva, mmap, mbytes in self._map_defs ]
 
+    def getMemoryBlock(self, va):
+        '''
+        Returns the memory map that contains va as a string, along with the offset from the base
+        '''
+        for mva, mmaxva, mmap, mbytes in self._map_defs:
+            if va >= mva and va < mmaxva:
+                mva, msize, mperms, mfname = mmap
+                if not mperms & MM_READ:
+                    raise envi.SegmentationViolation(va)
+                offset = va - mva
+                return mbytes, offset
+
     def readMemory(self, va, size):
 
         for mva, mmaxva, mmap, mbytes in self._map_defs:

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -430,18 +430,6 @@ class MemoryObject(IMemory):
     def getMemoryMaps(self):
         return [ mmap for mva, mmaxva, mmap, mbytes in self._map_defs ]
 
-    def getMemoryBlock(self, va):
-        '''
-        Returns the memory map that contains va as a string, along with the offset from the base
-        '''
-        for mva, mmaxva, mmap, mbytes in self._map_defs:
-            if va >= mva and va < mmaxva:
-                mva, msize, mperms, mfname = mmap
-                if not mperms & MM_READ:
-                    raise envi.SegmentationViolation(va)
-                offset = va - mva
-                return mbytes, offset
-
     def readMemory(self, va, size):
 
         for mva, mmaxva, mmap, mbytes in self._map_defs:

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -899,7 +899,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
 
         note: differs from the IMemory interface by checking loclist
         '''
-        b = self.readMemory(va, 16)
+        b, off = self.getMemoryBlock(va)
         if arch == envi.ARCH_DEFAULT:
             loctup = self.getLocation(va)
             # XXX - in the case where we've set a location on what should be an 
@@ -908,7 +908,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             if loctup != None and loctup[ L_TINFO ] and loctup[ L_LTYPE ] == LOC_OP:
                 arch = loctup[ L_TINFO ]
 
-        return self.imem_archs[ (arch & envi.ARCH_MASK) >> 16 ].archParseOpcode(b, 0, va)
+        return self.imem_archs[ (arch & envi.ARCH_MASK) >> 16 ].archParseOpcode(b, off, va)
 
     def makeOpcode(self, va, op=None, arch=envi.ARCH_DEFAULT):
         """

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -899,7 +899,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
 
         note: differs from the IMemory interface by checking loclist
         '''
-        b, off = self.getMemoryBlock(va)
+        off, b = self.getByteDef(va)
         if arch == envi.ARCH_DEFAULT:
             loctup = self.getLocation(va)
             # XXX - in the case where we've set a location on what should be an 


### PR DESCRIPTION
…to archParseOpcode() so that ARM/THUMB MODE can make sense of parsing opcodes that start on odd VA's