### PR TITLE
Handle 8 byte operands in envi/archs/i386/emu.py:i_div()

### DIFF
--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -761,6 +761,19 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
             self.setRegister(REG_EAX, quot)
             self.setRegister(REG_EDX, rem)
 
+        elif oper.tsize == 8:
+            rax = self.getRegisterByName("rax")
+            rdx = self.getRegisterByName("rdx")
+            tot = (rdx << 64) + rax
+            quot = tot / val
+            rem = tot % val
+
+            if tot > (2**64)-1:
+                raise Exception('division exception')
+
+            self.setRegisterByName("rax", quot)
+            self.setRegisterByName("rdx", rem)
+
         else:
             raise envi.UnsupportedInstruction(self, op)
 


### PR DESCRIPTION
`envi/archs/i386/emu.py:i_div()` does currently not handle `div` instructions for 8 byte operands. Hence, the Amd64WorkspaceEmulator raises the Exception `envi.UnsupportedInstruction`.
This change adds support for 8 byte operands.