### PR TITLE
pe parser: fix export parsing

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -873,6 +873,10 @@ class PE(object):
         if not funcoff or funcsize > 0x7FFF or ((ordoff > 0) ^ (nameoff > 0)):
             self.IMAGE_EXPORT_DIRECTORY = None
             return
+        
+        if funczise == 0:
+            self.IMAGE_EXPORT_DIRECTORY = None
+            return
     
         funcbytes = self.readAtOffset(funcoff, funcsize)
         funclist = struct.unpack("%dI" % (len(funcbytes) / 4), funcbytes)


### PR DESCRIPTION
this patch fixes a bug in the PE parser identified when analyzing the Zeus sample with MD5 hash EA039A854D20D7734C5ADD48F1A51C34. This sample has a bunch of entries in the export name and ordinal tables, but no entries in the export address table. 

vivisect already correctly handles the case when the address table is smaller than the function table, but missed the edge case when the address table has no size.