### PR TITLE
PE: don't parse a negative number of relocations

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -824,6 +824,9 @@ class PE(object):
             if chunksize > len(relbytes):
                 return
             
+            if relcnt < 0:
+                return
+            
             rels = struct.unpack("<%dH" % relcnt, relbytes[8:chunksize])
             for r in rels:
                 rtype = r >> 12


### PR DESCRIPTION
if the parsed relocation chunk size is less than eight, the vivisect PE parser can compute that there are a negative number of relocations to extract, which raises a struct error. For example, consider th file with MD5 `4693a5f60cc3477db7f34a5c738fb7ac` :

```
Traceback (most recent call last):
  File "/usr/local/bin/floss", line 9, in <module>
    load_entry_point('floss==1.2.0', 'console_scripts', 'floss')()
  File "/usr/local/lib/python2.7/dist-packages/floss-1.2.0-py2.7.egg/floss/main.py", line 546, in main
    vw = viv_utils.getWorkspace(sample_file_path)
  File "/usr/local/lib/python2.7/dist-packages/viv_utils-0.3.2-py2.7.egg/viv_utils/__init__.py", line 35, in getWorkspace
    vw.loadFromFile(fp)
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/vivisect/__init__.py", line 2134, in loadFromFile
    fname = mod.parseFile(self, filename)
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/vivisect/parsers/pe.py", line 30, in parseFile
    return loadPeIntoWorkspace(vw, pe, filename)
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/vivisect/parsers/pe.py", line 301, in loadPeIntoWorkspace
    for rva,rtype in pe.getRelocations():
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/PE/__init__.py", line 796, in getRelocations
    return self.relocations
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/PE/__init__.py", line 1080, in __getattr__
    self.parseRelocations()
  File "/usr/local/lib/python2.7/dist-packages/vivisect-0.0.0-py2.7.egg/PE/__init__.py", line 827, in parseRelocations
    rels = struct.unpack("<%dH" % relcnt, relbytes[8:chunksize])
struct.error: bad char in struct format
```

This patch ensures that the relocation count is greater than zero, or aborts relocation parsing.