### PR TITLE
List script path

### DIFF
--- a/envi/cli.py
+++ b/envi/cli.py
@@ -52,12 +52,12 @@ class CliExtMeth:
     def __call__(self, line):
         return self.func(self.cli, line)
 
-def validateScript(scriptpath):
+def isValidScript(scriptpath):
     '''
     Takes in a filepath
     Returns whether the file is valid python (ie. suvives import)
     '''
-    if not os.path.isfile():
+    if not os.path.isfile(scriptpath):
         return False
 
     with open(scriptpath, 'rb') as f:
@@ -83,21 +83,14 @@ def getRelScriptsFromPath(scriptpaths):
     "barmazing/bazthis.py" and the do_script() handler can use that.
     '''
     scripts = []
-    todo = [(path, len(path)+1) for path in scriptpaths]
+    for basedir in scriptpaths:
+        baselen = len(basedir) + 1
 
-    while len(todo):
-        curpath, baselen = todo.pop()
-
-        for filething in os.listdir(curpath):
-            fullpath = os.sep.join([curpath, filething])
-            if os.path.isdir(fullpath):
-                todo.append((fullpath, baselen))
-                continue
-
-            if not validateScript(fullpath):
-                continue
-
-            scripts.append(fullpath[baselen:])
+        for dirname,subdirs,subfiles in os.walk(basedir):
+            for subfile in subfiles:
+                subpath = os.path.join(dirname,subfile)
+                if isValidScript(subpath):
+                    scripts.append(subpath[baselen:])
 
     return scripts
 

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -478,7 +478,7 @@ class EnviCli(Cmd):
         locals = self.getExpressionLocals()
         locals['argv'] = argv
 
-        if line.startswith("?"):
+        if len(argv) and argv[0] == "?":
             scripts = []
             for scriptdir in self.scriptpaths:
                 # FIXME: filter on more than just ".py".  something internal

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -73,7 +73,7 @@ def validateScript(scriptpath):
 
 def getRelScriptsFromPath(scriptpaths):
     '''
-    Takes in a list of base paths (eg. VIV_SCRIPT_DIR list) and recurses the 
+    Takes in a list of base paths (eg. ENVI_SCRIPT_PATH list) and recurses the 
     directories looking for valid python files (ie. they don't throw errors
     on import).
 

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -482,8 +482,8 @@ class EnviCli(Cmd):
             scripts = []
             for scriptdir in self.scriptpaths:
                 # FIXME: filter on more than just ".py".  something internal
-                potential_scripts = [py for py in os.listdir(scriptdir) if self.validate_script(py)]
-                scripts.extend(potential_scripts)
+                pscripts = [py for py in os.listdir(scriptdir) if self.validate_script(scriptdir + os.sep + py)]
+                scripts.extend(pscripts)
 
             self.vprint('Scripts available in script paths:\n\t' + '\n\t'.join(scripts))
             return

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -101,13 +101,6 @@ def getRelScriptsFromPath(scriptpaths):
 
     return scripts
 
-
-
-    for scriptdir in self.scriptpaths:
-        # FIXME: filter on more than just ".py".  something internal
-        scripts.extend(pscripts)
-
-
 cfgdefs = {
     'cli':{
         'verbose':False,

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -804,7 +804,6 @@ class EnviCli(Cmd):
             cobj = compile(contents, scriptpath, 'exec')
             return True
         except Exception, e:
-            self.vprint( traceback.format_exc() )
             pass
         
         return False

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -476,6 +476,17 @@ class EnviCli(Cmd):
         locals = self.getExpressionLocals()
         locals['argv'] = argv
 
+        if line.startswith("?"):
+            scripts = []
+            for scriptdir in self.scriptpaths:
+                # FIXME: filter on more than just ".py".  something internal
+                potential_scripts = [py[:-3] for py in os.listdir(scriptdir) if py.endswith('.py')]
+                scripts.extend(potential_scripts)
+
+            self.vprint('Scripts available script paths:\n\t' + '\n\t'.join(scripts))
+            return
+
+
         # TODO: unify vdb.extensions.loadExtensions VDB_EXT_PATH with this
         # TODO: where should env var parsing live?
         scriptpath = None

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -468,6 +468,8 @@ class EnviCli(Cmd):
               all be strings)
 
         Usage: script <scriptfile> [<argv[0]>, ...]
+            
+        or     script ?
         '''
         if len(line) == 0:
             return self.do_help('script')
@@ -480,7 +482,7 @@ class EnviCli(Cmd):
             scripts = []
             for scriptdir in self.scriptpaths:
                 # FIXME: filter on more than just ".py".  something internal
-                potential_scripts = [py[:-3] for py in os.listdir(scriptdir) if py.endswith('.py')]
+                potential_scripts = [py for py in os.listdir(scriptdir) if py.endswith('.py')]
                 scripts.extend(potential_scripts)
 
             self.vprint('Scripts available script paths:\n\t' + '\n\t'.join(scripts))

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -482,10 +482,10 @@ class EnviCli(Cmd):
             scripts = []
             for scriptdir in self.scriptpaths:
                 # FIXME: filter on more than just ".py".  something internal
-                potential_scripts = [py for py in os.listdir(scriptdir) if py.endswith('.py')]
+                potential_scripts = [py for py in os.listdir(scriptdir) if self.validate_script(py)]
                 scripts.extend(potential_scripts)
 
-            self.vprint('Scripts available script paths:\n\t' + '\n\t'.join(scripts))
+            self.vprint('Scripts available in script paths:\n\t' + '\n\t'.join(scripts))
             return
 
 
@@ -795,6 +795,19 @@ class EnviCli(Cmd):
 
         showmem()
         self.setEmptyMethod(showmem)
+
+    def validate_script(self, scriptpath):
+        try:
+            with open(scriptpath, 'rb') as f:
+                contents = f.read()
+
+            cobj = compile(contents, scriptpath, 'exec')
+            return True
+        except Exception, e:
+            self.vprint( traceback.format_exc() )
+            pass
+        
+        return False
 
 class EnviMutableCli(EnviCli):
     """

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -57,10 +57,13 @@ def validateScript(scriptpath):
     Takes in a filepath
     Returns whether the file is valid python (ie. suvives import)
     '''
-    try:
-        with open(scriptpath, 'rb') as f:
-            contents = f.read()
+    if not os.path.isfile():
+        return False
 
+    with open(scriptpath, 'rb') as f:
+        contents = f.read()
+
+    try:
         cobj = compile(contents, scriptpath, 'exec')
         return True
     except Exception, e:


### PR DESCRIPTION
who wants to remember all the scripts they ever used?  why not have viv list the scripts available in the path.  typing "script ?" at the cli lists the scripts available in the path.  

alternative possibility is to simply call this in case the script arg isn't found (which would almost always catch the "?" case)

future improvement: allow partial name matching.