### PR TITLE
store the calling va before applying CallFunction effect

### DIFF
--- a/vivisect/symboliks/effects.py
+++ b/vivisect/symboliks/effects.py
@@ -256,6 +256,7 @@ class CallFunction(SymbolikEffect):
             self.argsyms = [ x.reduce(emu=emu) for x in self.argsyms ]
 
     def applyEffect(self, emu):
+        emu.setMeta('calling_va', self.va)
         funcsym = self.funcsym.update(emu)
 
         # If we have argsyms, the function's work has been broken out


### PR DESCRIPTION
this allows the special handler function to know whence it was called.  this has a variety of uses, including handling thunk_bx calls, which simply place the return pointer into ebx.