### PR TITLE
Symboliks const checks instead of isinstance

### DIFF
--- a/vivisect/const.py
+++ b/vivisect/const.py
@@ -192,6 +192,7 @@ SYMT_MEM            = 3
 SYMT_SEXT           = 4
 SYMT_CONST          = 5
 SYMT_LOOKUP         = 6
+SYMT_NOT            = 7
 
 SYMT_OPER           = 0x00010000
 SYMT_OPER_ADD       = SYMT_OPER | 1

--- a/vivisect/symboliks/archind.py
+++ b/vivisect/symboliks/archind.py
@@ -50,7 +50,7 @@ def wipeAstArch(symctx, symobjs, emu=None, wipeva=False):
     # a tree walker to frob reg vars
     def normast(path,oldsym,ctx):
         # are we wipping away consts?
-        if wipeva and isinstance(oldsym,Const):
+        if wipeva and oldsym.symtype == SYMT_CONST:
             if symctx.vw.isValidPointer(oldsym.value):
                 # check for function thunks
                 if symctx.vw.isFunction(oldsym.value):
@@ -62,8 +62,7 @@ def wipeAstArch(symctx, symobjs, emu=None, wipeva=False):
                 idtova[newobj._sym_id] = oldsym
                 return newobj
 
-        # FIXME isinstance shit...
-        if not isinstance(oldsym,Var):
+        if oldsym.symtype != SYMT_VAR:
             return None
 
         # check if this is a register

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -342,7 +342,7 @@ class cnot(SymbolikBase):
     Mostly used to wrap the reverse of a contraint which is based on
     a variable.
     '''
-    symtype     = SYMT_SEXT
+    symtype     = SYMT_NOT
 
     def __init__(self, v1):
         SymbolikBase.__init__(self)
@@ -359,22 +359,19 @@ class cnot(SymbolikBase):
         return int( not bool( self.kids[0].solve(emu=emu, vals=vals)) )
 
     def update(self, emu):
-        # FIXME dependancy loop...
-        from vivisect.symboliks.constraints import Constraint
         v1 = self.kids[0].update(emu=emu)
-        if isinstance(v1, Constraint):
+        if v1.efftype == EFFTYPE_CONSTRAIN:
             return v1.reverse()
         return cnot(v1)
 
     def _reduce(self, emu=None):
-        # FIXME dependancy loop...
-        from vivisect.symboliks.constraints import Constraint
         #self.kids[0] = self.kids[0].reduce(emu=emu)
 
-        if isinstance( self.kids[0], Constraint):
-            return self.kids[0].reverse()
+        kidzero = self.kids[0]
+        if kidzero.symtype == SYMT_CON:
+            return kidzero.reverse()
 
-        if isinstance( self.kids[0], cnot):
+        if kidzero,efftype == SYMT_NOT cnot):
             return self.kids[0].kids[0]
 
     def getWidth(self):

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -371,7 +371,7 @@ class cnot(SymbolikBase):
         if kidzero.symtype == SYMT_CON:
             return kidzero.reverse()
 
-        if kidzero,efftype == SYMT_NOT cnot):
+        if kidzero.efftype == SYMT_NOT:
             return self.kids[0].kids[0]
 
     def getWidth(self):


### PR DESCRIPTION
bugfix: CNOT symtype should not be SYMT_SEXT
and removing "isinstance" calls, replacing with symtype checks.  this brings dramatic performance enhancements while removing circular import/dependencies.