### PR TITLE
Fix for subregister subtraction

### DIFF
--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -1597,6 +1597,8 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
 
     def i_sub(self, op):
         x = self.integerSubtraction(op)
+        dsize = op.opers[0].tsize
+        x = e_bits.unsigned(x, dsize)
         if x != None:
             self.setOperValue(op, 0, x)
 


### PR DESCRIPTION
Given eax = 0x5af9a2 and ebx = 0xee:
`sub al, bl` sets eax to the value 0xffffffb4 (-0x4c).
Debugging output:
```
dsize/ssize: 1 1
unsigned: 238 162 -0x4c
signed: -18 -94 -0x4c
```

This patch ensures that subtractions on subregisters only affect the subregister, e.g.
`sub al, bl ; al <- al - bl`.

For the example above eax is set to the value 0x5af9b4.
