### PR TITLE
Make memory taint byte configurable

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -212,11 +212,12 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         """
         return self.frefs.get((va,idx))
 
-    def getEmulator(self, logwrite=False, logread=False):
+    def getEmulator(self, logwrite=False, logread=False, taintbyte='A'):
         """
         Get an instance of a WorkspaceEmulator for this workspace.
 
         Use logread/logwrite to enable memory access tracking.
+        taintbyte specifies data returned if invalid memory is read.
         """
         plat = self.getMeta('Platform')
         arch = self.getMeta('Architecture')
@@ -228,7 +229,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         if eclass == None:
             raise Exception("WorkspaceEmulation not supported on %s yet!" % arch)
 
-        return eclass(self, logwrite=logwrite, logread=logread)
+        return eclass(self, logwrite=logwrite, logread=logread, taintbyte=taintbyte)
 
     def getCachedEmu(self, emuname):
         """

--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -27,7 +27,7 @@ class WorkspaceEmulator:
 
     taintregs = []
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, taintbyte='A'):
 
         self.vw = vw
         self.funcva = None # Set if using runFunction
@@ -46,6 +46,7 @@ class WorkspaceEmulator:
         self.opcache = {}
         self.emumon = None
         self.psize = self.getPointerSize()
+        self.taintbyte = taintbyte  # Define byte(s) returned if invalid memory is read
 
         # Possibly need an "options" API?
         self._safe_mem = True   # Should we be forgiving about memory accesses?
@@ -563,7 +564,7 @@ class WorkspaceEmulator:
         # Read from the emulator's pages if we havent resolved it yet
         probeok = self.probeMemory(va, size, e_mem.MM_READ)
         if self._safe_mem and not probeok:
-            return 'A' * size
+            return self.taintbyte * size
 
         return e_mem.MemoryObject.readMemory(self, va, size)
 

--- a/vivisect/impemu/platarch/amd64.py
+++ b/vivisect/impemu/platarch/amd64.py
@@ -19,9 +19,9 @@ class Amd64WorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_amd64.Amd64Emulat
         e_amd64.REG_RDI, e_amd64.REG_R8,  e_amd64.REG_R9,
     ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, taintbyte='A'):
         e_amd64.Amd64Emulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, taintbyte=taintbyte)
         self.setEmuOpt('i386:reponce',True)
 
     def getRegister(self, index):

--- a/vivisect/impemu/platarch/arm.py
+++ b/vivisect/impemu/platarch/arm.py
@@ -5,9 +5,9 @@ class ArmWorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_arm.ArmEmulator):
 
     taintregs = [ x for x in range(13) ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, taintbyte='A'):
         e_arm.ArmEmulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, taintbyte=taintbyte)
 
 '''
 st0len gratuitously from wikipedia:

--- a/vivisect/impemu/platarch/h8.py
+++ b/vivisect/impemu/platarch/h8.py
@@ -7,7 +7,7 @@ class H8WorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_h8.H8Emulator):
         e_h8.REG_ER0, e_h8.REG_ER1, e_h8.REG_ER2,
     ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, taintbyte='A'):
         e_h8.H8Emulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, taintbyte=taintbyte)
 

--- a/vivisect/impemu/platarch/i386.py
+++ b/vivisect/impemu/platarch/i386.py
@@ -9,7 +9,7 @@ class i386WorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_i386.IntelEmulator
         e_i386.REG_EDI,
     ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, taintbyte='A'):
         e_i386.IntelEmulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, taintbyte=taintbyte)
         self.setEmuOpt('i386:reponce',True)

--- a/vivisect/impemu/platarch/msp430.py
+++ b/vivisect/impemu/platarch/msp430.py
@@ -5,9 +5,9 @@ class Msp430WorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_msp430e.Msp430Em
 
     taintregs = [ x for x in range(2, 16) ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
+    def __init__(self, vw, logwrite=False, logread=False, taintbyte='A'):
         e_msp430e.Msp430Emulator.__init__(self)
-        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+        v_i_emulator.WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, taintbyte=taintbyte)
 
 '''
 st0len gratuitously from mspgcc:

--- a/vivisect/impemu/platarch/windows.py
+++ b/vivisect/impemu/platarch/windows.py
@@ -103,8 +103,8 @@ class Windowsi386Emulator(WindowsMixin, v_i_i386.i386WorkspaceEmulator):
         e_i386.REG_EDI,
     ]
 
-    def __init__(self, vw, logwrite=False, logread=False):
-        v_i_i386.i386WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread)
+    def __init__(self, vw, logwrite=False, logread=False, taintbyte='A'):
+        v_i_i386.i386WorkspaceEmulator.__init__(self, vw, logwrite=logwrite, logread=logread, taintbyte=taintbyte)
         WindowsMixin.__init__(self)
 
     @imphook('ntdll.seh3_prolog')


### PR DESCRIPTION
It would be handy if the memory taint byte for the emulator could be configurable. For example, during function emulation in FLOSS we would like to set the taint byte to a value outside of the ASCII range. This allows us to easier distinguish between tainted memory and decoded strings.
