### PR TITLE
Addressing race condition from issue #159

### DIFF
--- a/vtrace/platforms/win32.py
+++ b/vtrace/platforms/win32.py
@@ -1378,8 +1378,8 @@ class WindowsMixin:
         if ((not self.exited) and
             self.getCurrentBreakpoint() != None):
             self._clearBreakpoints()
-            self.platformContinue()
             self.platformSendBreak()
+            self.platformContinue()
             self.platformWait()
         if not kernel32.DebugActiveProcessStop(self.pid):
             raiseWin32Error("DebugActiveProcessStop")


### PR DESCRIPTION
I've swapped the calls to platformSendBreak() and platformContinue() within platformDetach(). In my testing, the result was that kernel32.DebugBreakProcess() returned TRUE and platformContinue() / DebugActiveProcessStop() were able to proceed without having the debuggee terminate out from under vtrace.