### PR TITLE
Addressing issue #160: self.attached = False

### DIFF
--- a/vtrace/__init__.py
+++ b/vtrace/__init__.py
@@ -306,6 +306,7 @@ class Trace(e_mem.IMemory, e_reg.RegisterContext, e_resolv.SymbolResolver, objec
         self.requireAttached()
         self.requireNotExited()
         self.platformKill()
+        self.attached = False
 
     def detach(self):
         '''


### PR DESCRIPTION
I added self.attached = False to vtrace.kill(), which in my testing prevented release() from erroneously calling detach().