### PR TITLE
Emulator metadata

### DIFF
--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -535,6 +535,7 @@ class Emulator(e_reg.RegisterContext, e_mem.MemoryObject):
     """
     def __init__(self, archmod=None):
 
+        self.metadata = {}
         e_mem.MemoryObject.__init__(self, arch=archmod._arch_id)
         e_reg.RegisterContext.__init__(self)
 
@@ -576,6 +577,15 @@ class Emulator(e_reg.RegisterContext, e_mem.MemoryObject):
         if not self._emu_opts.has_key(opt):
             raise Exception('Unknown Emu Opt: %s' % opt)
         return self._emu_opts.get(opt)
+
+    def getMeta(self, name, default=None):
+        return self.metadata.get(name, default)
+
+    def setMeta(self, name, value):
+        """
+        Set a meta key,value pair for this workspace.
+        """
+        self.metadata[name] = value
 
     def getArchModule(self):
         raise Exception('Emulators *must* implement getArchModule()!')

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -84,13 +84,16 @@ def getRelScriptsFromPath(scriptpaths):
     '''
     scripts = []
     for basedir in scriptpaths:
-        baselen = len(basedir) + 1
+        baselen = len(basedir)
 
         for dirname,subdirs,subfiles in os.walk(basedir):
             for subfile in subfiles:
                 subpath = os.path.join(dirname,subfile)
                 if isValidScript(subpath):
-                    scripts.append(subpath[baselen:])
+                    script = subpath[baselen:]
+                    if script.startswith('/'):
+                        script = script[1:]
+                    scripts.append(script)
 
     return scripts
 
@@ -522,6 +525,7 @@ class EnviCli(Cmd):
 
         if len(argv) and argv[0] == "?":
             scripts = getRelScriptsFromPath(self.scriptpaths)
+            scripts.sort()
             self.vprint('Scripts available in script paths:\n\t' + '\n\t'.join(scripts))
             return
 

--- a/envi/cli.py
+++ b/envi/cli.py
@@ -84,16 +84,13 @@ def getRelScriptsFromPath(scriptpaths):
     '''
     scripts = []
     for basedir in scriptpaths:
-        baselen = len(basedir)
+        baselen = len(basedir) + 1
 
         for dirname,subdirs,subfiles in os.walk(basedir):
             for subfile in subfiles:
                 subpath = os.path.join(dirname,subfile)
                 if isValidScript(subpath):
-                    script = subpath[baselen:]
-                    if script.startswith('/'):
-                        script = script[1:]
-                    scripts.append(script)
+                    scripts.append(subpath[baselen:])
 
     return scripts
 
@@ -525,7 +522,6 @@ class EnviCli(Cmd):
 
         if len(argv) and argv[0] == "?":
             scripts = getRelScriptsFromPath(self.scriptpaths)
-            scripts.sort()
             self.vprint('Scripts available in script paths:\n\t' + '\n\t'.join(scripts))
             return
 


### PR DESCRIPTION
allow the storing of metadata in an envi.Emulator.  simple dictionary access makes the emulator more drop-in compatible with a VivWorkspace/VivCli.