### PR TITLE
Forcing string return for __str__ 

### DIFF
--- a/vstruct/primitives.py
+++ b/vstruct/primitives.py
@@ -196,7 +196,7 @@ class v_number(v_prim):
     def __str__(self):
         v = self.vsGetValue()
         if self._vs_enum is not None:
-            return self._vs_enum.vsReverseMapping(v, default=str(v))
+            return str(self._vs_enum.vsReverseMapping(v, default=str(v)))
         return str(v)
 
     ##################################################################


### PR DESCRIPTION
This allows passing in a v_bitmask for the enum parameter to a v_number field, since a v_bitmask returns a list of labels from vsReverseMapping() which breaks calls to tree().