### PR TITLE
move badops into the envi architecture where it belongs.

### DIFF
--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -78,6 +78,7 @@ class ArchitectureModule:
         self._arch_id = getArchByName(archname)
         self._arch_name = archname
         self._arch_maxinst = maxinst
+        self._arch_badopbytes = ['\x00\x00\x00\x00\x00']
 
     def getArchId(self):
         '''
@@ -139,6 +140,22 @@ class ArchitectureModule:
         allr = [rname for rname in regctx.getRegisterNames()]
         return [ ('all', allr), ]
 
+    def archGetBadOps(self, byteslist=None):
+        '''
+        Returns a list of opcodes which are indicators of wrong disassembly.
+        byteslist is None to use the architecture default, or can be a custom list.
+        '''
+        if byteslist == None:
+            byteslist = self._arch_badopbytes
+
+        badops = []
+        for badbytes in byteslist:
+            try:
+                self.badops.append(self.archParseOpcode(badbytes))
+            except:
+                pass
+
+        return badops
     def getEmulator(self):
         """
         Return a default instance of an emulator for the given arch.

--- a/vivisect/analysis/amd64/emulation.py
+++ b/vivisect/analysis/amd64/emulation.py
@@ -20,11 +20,11 @@ class AnalysisMonitor(viv_monitor.AnalysisMonitor):
         viv_monitor.AnalysisMonitor.__init__(self, vw, fva)
         self.addDynamicBranchHandler(vag_switch.analyzeJmp)
         self.retbytes = None
-        self.badop = vw.arch.archParseOpcode("\x00\x00\x00\x00\x00")
+        self.badops = vw.arch.archGetBadOps()
 
     def prehook(self, emu, op, starteip):
 
-        if op == self.badop:
+        if op in self.badops:
             raise Exception("Hit known BADOP at 0x%.8x %s" % (starteip, repr(op) ))
 
         viv_monitor.AnalysisMonitor.prehook(self, emu, op, starteip)

--- a/vivisect/analysis/generic/emucode.py
+++ b/vivisect/analysis/generic/emucode.py
@@ -26,10 +26,7 @@ class watcher(viv_imp_monitor.EmulationMonitor):
         self.lastop = None
         self.badcode = False
 
-        try:
-            self.badops = [vw.arch.archParseOpcode("\x00\x00\x00\x00\x00")]
-        except:
-            self.badops = []
+        self.badops = vw.arch.archGetBadOps()
 
     def logAnomaly(self, emu, eip, msg):
         self.badcode = True

--- a/vivisect/analysis/i386/calling.py
+++ b/vivisect/analysis/i386/calling.py
@@ -44,10 +44,10 @@ class AnalysisMonitor(viv_imp_monitor.AnalysisMonitor):
     def __init__(self, vw, fva):
         viv_imp_monitor.AnalysisMonitor.__init__(self, vw, fva)
         self.retbytes = None
-        self.badop = vw.arch.archParseOpcode("\x00\x00\x00\x00\x00")
+        self.badops = vw.arch.archGetBadOps()
 
     def prehook(self, emu, op, starteip):
-        if op == self.badop:
+        if op in self.badops:
             raise Exception("Hit known BADOP at 0x%.8x %s" % (starteip, repr(op) ))
 
         viv_imp_monitor.AnalysisMonitor.prehook(self, emu, op, starteip)


### PR DESCRIPTION
all envi architecture modules get a list of bytes that create bad opcodes, and a function to return them.  this allows for each architecture to return it's own list of bytes, and even the flexibility to provide specially decoded opcodes (say, maybe the Arm and Thumb equivalents of the same bytes).