### PR TITLE
envi.Emulator to use getBytesDef to get memory map and offset info fo…

### DIFF
--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -605,6 +605,15 @@ class Emulator(e_reg.RegisterContext, e_mem.MemoryObject):
         self.setRegisterSnap(regs)
         self.setMemorySnap(mem)
 
+    def parseOpcode(self, va, arch=ARCH_DEFAULT):
+        '''
+        Parse an opcode from the specified virtual address.
+
+        Example: op = m.parseOpcode(0x7c773803)
+        '''
+        off, b = self.getByteDef(va)
+        return self.imem_archs[ (arch & ARCH_MASK) >> 16 ].archParseOpcode(b, off, va)
+
     def executeOpcode(self, opobj):
         """
         This is the core method for the 

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -605,15 +605,6 @@ class Emulator(e_reg.RegisterContext, e_mem.MemoryObject):
         self.setRegisterSnap(regs)
         self.setMemorySnap(mem)
 
-    def parseOpcode(self, va, arch=ARCH_DEFAULT):
-        '''
-        Parse an opcode from the specified virtual address.
-
-        Example: op = m.parseOpcode(0x7c773803)
-        '''
-        off, b = self.getByteDef(va)
-        return self.imem_archs[ (arch & ARCH_MASK) >> 16 ].archParseOpcode(b, off, va)
-
     def executeOpcode(self, opobj):
         """
         This is the core method for the 

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -298,8 +298,8 @@ class IMemory:
 
         Example: op = m.parseOpcode(0x7c773803)
         '''
-        b = self.readMemory(va, 16)
-        return self.imem_archs[ arch >> 16 ].archParseOpcode(b, 0, va)
+        off, b = self.getByteDef(va)
+        return self.imem_archs[ (arch & ARCH_MASK) >> 16 ].archParseOpcode(b, off, va)
 
 class MemoryCache(IMemory):
     '''

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -298,8 +298,8 @@ class IMemory:
 
         Example: op = m.parseOpcode(0x7c773803)
         '''
-        off, b = self.getByteDef(va)
-        return self.imem_archs[ (arch & envi.ARCH_MASK) >> 16 ].archParseOpcode(b, off, va)
+        b = self.readMemory(va, 16)
+        return self.imem_archs[ arch >> 16 ].archParseOpcode(b, 0, va)
 
 class MemoryCache(IMemory):
     '''
@@ -468,6 +468,15 @@ class MemoryObject(IMemory):
                 offset = va - mva
                 return (offset, mbytes)
         raise envi.SegmentationViolation(va)
+
+    def parseOpcode(self, va, arch=envi.ARCH_DEFAULT):
+        '''
+        Parse an opcode from the specified virtual address.
+
+        Example: op = m.parseOpcode(0x7c773803)
+        '''
+        off, b = self.getByteDef(va)
+        return self.imem_archs[ (arch & envi.ARCH_MASK) >> 16 ].archParseOpcode(b, off, va)
 
 class MemoryFile:
     '''

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -299,7 +299,7 @@ class IMemory:
         Example: op = m.parseOpcode(0x7c773803)
         '''
         off, b = self.getByteDef(va)
-        return self.imem_archs[ (arch & ARCH_MASK) >> 16 ].archParseOpcode(b, off, va)
+        return self.imem_archs[ (arch & envi.ARCH_MASK) >> 16 ].archParseOpcode(b, off, va)
 
 class MemoryCache(IMemory):
     '''

--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -148,13 +148,13 @@ class WorkspaceEmulator:
         """
         self.emumon = emumon
 
-    def parseOpcode(self, pc):
+    def parseOpcode(self, va, arch=envi.ARCH_DEFAULT):
         # We can make an opcode *faster* with the workspace because of
         # getByteDef etc... use it.
-        op = self.opcache.get(pc)
+        op = self.opcache.get(va)
         if op == None:
-            op = envi.Emulator.parseOpcode(self, pc)
-            self.opcache[pc] = op
+            op = envi.Emulator.parseOpcode(self, va, arch=arch)
+            self.opcache[va] = op
         return op
 
     def checkCall(self, starteip, endeip, op):


### PR DESCRIPTION
…r parseOpcode (like VivWorkspace).

this is both faster and more flexible.
ArmEmulator requires this, but since it's faster (saves a string creation each instruction) and since Emulator is based on the same bytes/offset model as VivWorkspace, i see no reason not to make envi.Emulator use this method as well.