### PR TITLE
allow rvaToOffset to return offset before first section

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -437,6 +437,8 @@ class PE(object):
     def rvaToOffset(self, rva):
         if self.inmem:
             return rva
+        if rva >= 0 and rva < self.IMAGE_NT_HEADERS.OptionalHeader.SizeOfHeaders:
+            return rva
         for s in self.sections:
             sbase = s.VirtualAddress
             ssize = max(s.SizeOfRawData, s.VirtualSize)


### PR DESCRIPTION
I came across an issue when trying to retrieve bytes _before_ the first PE section using ```readAtRva```. Currently, if you try to read bytes before the first section, it starts reading from offset 0. Here's an example:

```python
>>> import PE
>>> fbytes = open('cmd.exe', 'rb').read()
>>> pe = PE.peFromBytes(fbytes)
>>> repr(fbytes[0x40:0x60])
"'\\x0e\\x1f\\xba\\x0e\\x00\\xb4\\t\\xcd!\\xb8\\x01L\\xcd!This program canno'"
>>> repr(pe.readAtRva(0x40, 0x20))
"'MZ\\x90\\x00\\x03\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\xff\\xff\\x00\\x00\\xb8\\x00\\x00\\x00\\x00\\x00\\x00\\x00@\\x00\\x00\\x00\\x00\\x00\\x00\\x00'"
>>> pe.rvaToOffset(0x40)
0
```

The issue is in the ```rvaToOffset``` function which returns 0 if the input rva is not within one of the PE sections.

This PR fixes this issue by checking if the rva is below the ```IMAGE_NT_HEADERS.OptionalHeader.SizeOfHeaders```. There are many other ways to address this problem. Let me know if you'd like to handle this in a different way. Here's the result after my change:

```python
>>> import PE
>>> fbytes = open('cmd.exe', 'rb').read()
>>> pe = PE.peFromBytes(fbytes)
>>> repr(pe.readAtRva(0x40, 0x20))
"'\\x0e\\x1f\\xba\\x0e\\x00\\xb4\\t\\xcd!\\xb8\\x01L\\xcd!This program canno'"
>>> pe.readAtRva(0x40, 0x20) == fbytes[0x40:0x60]
True
```