### PR TITLE
PE/__init__.py: parseExports check funcbytes existence

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -885,6 +885,11 @@ class PE(object):
             return
     
         funcbytes = self.readAtOffset(funcoff, funcsize)
+
+        if not funcbytes:
+            self.IMAGE_EXPORT_DIRECTORY = None
+            return
+
         funclist = struct.unpack("%dI" % (len(funcbytes) / 4), funcbytes)
 
         # named function exports


### PR DESCRIPTION
I came across some packed samples that throw off `parseExports`:
```
  File "vivisect/PE/__init__.py", line 408, in getDllName
    if self.IMAGE_EXPORT_DIRECTORY != None:
  File "vivisect/PE/__init__.py", line 1072, in __getattr__
    self.parseExports()
  File "vivisect/PE/__init__.py", line 890, in parseExports
    funclist = struct.unpack("%dI" % (len(funcbytes) / 4), funcbytes)
TypeError: object of type 'NoneType' has no len()
```
Samples:
- https://virustotal.com/en/file/223cb9a6d6364e8c4df79286a60352c26c180fcd0c96540b6313c7b53ee732eb/analysis/
- https://virustotal.com/en/file/6652b205c1a1fa96384b12fdf7146850822b7af909ac819d9028095072f0d70f/analysis/

The files indicate `NumberOfFunctions` but the respective `AddressOfFunctions` offsets are empty or cannot be read.