### PR TITLE
WIP generator-based PDB symbols - PLEASE REVIEW AND COMMENT

### DIFF
--- a/vivisect/parsers/pe.py
+++ b/vivisect/parsers/pe.py
@@ -372,12 +372,11 @@ def loadPeIntoWorkspace(vw, pe, filename=None):
 
         s = vt_win32.Win32SymbolParser(-1, filename, baseaddr)
 
-        # We don't want exports or whatever because we already have them
-        s.symopts |= vt_win32.SYMOPT_EXACT_SYMBOLS
-        s.parse()
+        # We don't want exports or whatever because we already have them... actually, fails on Chrome pdbs
+        #s.symopts |= vt_win32.SYMOPT_EXACT_SYMBOLS
 
         # Add names for any symbols which are missing them
-        for symname, symva, size, flags in s.symbols:
+        for symname, symva, size, flags in s.genSymbols():
 
             if not vw.isValidPointer(symva):
                 continue

--- a/vtrace/platforms/win32.py
+++ b/vtrace/platforms/win32.py
@@ -2270,17 +2270,17 @@ class Win32SymbolParser:
         self._bgEnumThread = threading.Thread(target=self._do_SymEnumSymbols)
         self._bgEnumThread.setDaemon(True)
         self._bgEnumThread.start()
-        print("kick_do_SymEnumSymbols: setting up locks")
+        #print("kick_do_SymEnumSymbols: setting up locks")
         self._symEnumLock.acquire()
 
 
     def _do_SymEnumSymbols(self):
         try:
             self.symbol = None
-            print("_do_SymEnumSymbols: symInit")
+            #print("_do_SymEnumSymbols: symInit")
             self.symInit()
 
-            print("_do_SymEnumSymbols: SymEnumSymbols")
+            #print("_do_SymEnumSymbols: SymEnumSymbols")
             dbghelp.SymEnumSymbols(self.phandle,
                         self.loadbase,
                         None,
@@ -2296,7 +2296,7 @@ class Win32SymbolParser:
 
         finally:
             self.symbol = -1
-        print "_do_SymEnumSymbols: DONE"
+        #print "_do_SymEnumSymbols: DONE"
         self._symEnumLock.release()
 
 
@@ -2308,17 +2308,17 @@ class Win32SymbolParser:
         self._bgTypeThread = threading.Thread(target=self._do_SymEnumTypes)
         self._bgTypeThread.setDaemon(True)
         self._bgTypeThread.start()
-        print("kick_do_SymEnumTypes: setting up locks")
+        #print("kick_do_SymEnumTypes: setting up locks")
         self._typeEnumLock.acquire()
 
 
     def _do_SymEnumTypes(self):
         try:
             self._sym_type = None
-            print("_do_SymEnumTypes: symInit")
+            #print("_do_SymEnumTypes: symInit")
             self.symInit()
 
-            print("_do_SymEnumTypes: SymEnumTypes")
+            #print("_do_SymEnumTypes: SymEnumTypes")
             dbghelp.SymEnumTypes(self.phandle,
                         self.loadbase,
                         SYMCALLBACK(self.typeEnumCallback),
@@ -2333,6 +2333,6 @@ class Win32SymbolParser:
 
         finally:
             self._sym_type = -1
-        print "_do_SymEnumTypes: DONE"
+        #print "_do_SymEnumTypes: DONE"
         self._typeEnumLock.release()
 


### PR DESCRIPTION
initial stab at streamlining and "generatifying" win32 pdb symbols.

this approach involves locks and threads to generate symbols around the dbghelp.dll's callback structure.
a cleaner approach would be to have the calling library provide a callback function, however that's not as pythonic and i hadn't discussed it with visi as i had the generators.

note: either approach breaks symbol-caching.  such a construct should live outside this pdb parsing world.  symbol access should be primitive, with caching built around the capability itself.  i suggest caching symbols in vtrace, and only the ones desired.

in order to get symbols out of certain important pdbs (ref: chrome.dll), i had to disable the EXACT symbol matching flag.  this can be enabled or disabled, whatever... but if symbols are missed that are not existing in the shipped bin, we're missing out.  i'm open to ideas here.