### PR TITLE
EASY: naming funcs and exports/symbols with an address to avoid collisions

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -717,7 +717,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         """
         Add an already created export object.
         """
-        rname = "%s.%s" % (filename,name)
+        rname = "%s.%s_%x" % (filename,name,va)
         if self.vaByName(rname) != None:
             raise Exception("Duplicate Name: %s" % rname)
         self._fireEvent(VWE_ADDEXPORT, (va,etype,name,filename))

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -329,7 +329,7 @@ class VivWorkspaceCore(object,viv_impapi.ImportApi):
         va, etype, name, filename = einfo
         self.exports.append(einfo)
         self.exports_by_va[va] = einfo
-        fullname = "%s.%s" % (filename,name)
+        fullname = "%s.%s_%x" % (filename,name,va)
         self.makeName(va, fullname)
 
     def _handleSETMETA(self, einfo):

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -324,7 +324,7 @@ def loadElfIntoWorkspace(vw, elf, filename=None):
         if addbase: sva += baseaddr
         if vw.isValidPointer(sva) and len(s.name):
             try:
-                vw.makeName(sva, s.name, filelocal=True)
+                vw.makeName(sva, "%s_%x" % (s.name,sva), filelocal=True)
             except Exception, e:
                 print "WARNING:",e
 


### PR DESCRIPTION
adding the address to names allows for each item to be named whatever… it was supposed to be, and not just the first one to hit the analysis pipeline.

i'm open to suggestions for alternate methods of collision-avoidance :)

this is particularly important when dealing with certain PDBs.