### PR TITLE
EASY: arch mod-va hooks

### DIFF
--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -164,7 +164,7 @@ class ArchitectureModule:
         This hook allows an architecture to correct VA and Architecture, such 
         as is necessary for ARM/Thumb.
         '''
-        return va, info
+        return va, {}
 
     def archModifyXrefAddr(self, tova, reftype, rflags):
         '''

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -156,6 +156,26 @@ class ArchitectureModule:
         allr = [rname for rname in regctx.getRegisterNames()]
         return [ ('all', allr), ]
 
+    def archModifyFuncAddr(self, va, arch):
+        '''
+        Returns a potentially modified set of (va, arch).
+        Default: return the same va, arch
+
+        This hook allows an architecture to correct VA and Architecture, such 
+        as is necessary for ARM/Thumb.
+        '''
+        return va, arch
+
+    def archModifyXrefAddr(self, tova, reftype, rflags):
+        '''
+        Returns a potentially modified set of (tova, reftype, rflags).
+        Default: return the same tova, reftype, rflags
+
+        This hook allows an architecture to modify an Xref before it's set, 
+        which can be helpful for ARM/Thumb.
+        '''
+        return tova, reftype, rflags
+
     def archGetBadOps(self, byteslist=None):
         '''
         Returns a list of opcodes which are indicators of wrong disassembly.

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -156,15 +156,15 @@ class ArchitectureModule:
         allr = [rname for rname in regctx.getRegisterNames()]
         return [ ('all', allr), ]
 
-    def archModifyFuncAddr(self, va, arch):
+    def archModifyFuncAddr(self, va, info):
         '''
-        Returns a potentially modified set of (va, arch).
-        Default: return the same va, arch
+        Can modify the VA and context based on architecture-specific info.
+        Default: return the same va, info
 
         This hook allows an architecture to correct VA and Architecture, such 
         as is necessary for ARM/Thumb.
         '''
-        return va, arch
+        return va, info
 
     def archModifyXrefAddr(self, tova, reftype, rflags):
         '''

--- a/envi/archs/arm/__init__.py
+++ b/envi/archs/arm/__init__.py
@@ -54,10 +54,8 @@ class ArmModule(envi.ArchitectureModule):
 
     def archModifyFuncAddr(self, va, info):
         if va & 1:
-            retval = dict(info)
-            retval['arch'] = envi.ARCH_THUMB2
-            return va & -2, retval
-        return va, info
+            return va & -2, {'arch' : envi.ARCH_THUMB2}
+        return va, {}
 
     def archModifyXrefAddr(self, tova, reftype, rflags):
         if tova & 1:

--- a/envi/archs/arm/__init__.py
+++ b/envi/archs/arm/__init__.py
@@ -52,6 +52,18 @@ class ArmModule(envi.ArchitectureModule):
         self._arch_dis.setEndian(endian)
         self._arch_thumb_dis.setEndian(endian)
 
+    def archModifyFuncAddr(self, va, info):
+        if va & 1:
+            info['arch'] = envi.ARCH_THUMB
+            return va & -2, info
+        return va, info
+
+    def archModifyXrefAddr(self, tova, reftype, rflags):
+        if tova & 1:
+            return tova & -2, reftype, rflags
+        return tova, reftype, rflags
+
+
 
 
 from envi.archs.arm.emu import *

--- a/envi/archs/arm/__init__.py
+++ b/envi/archs/arm/__init__.py
@@ -54,8 +54,9 @@ class ArmModule(envi.ArchitectureModule):
 
     def archModifyFuncAddr(self, va, info):
         if va & 1:
-            info['arch'] = envi.ARCH_THUMB2
-            return va & -2, info
+            retval = dict(info)
+            retval['arch'] = envi.ARCH_THUMB2
+            return va & -2, retval
         return va, info
 
     def archModifyXrefAddr(self, tova, reftype, rflags):

--- a/envi/archs/arm/__init__.py
+++ b/envi/archs/arm/__init__.py
@@ -54,7 +54,7 @@ class ArmModule(envi.ArchitectureModule):
 
     def archModifyFuncAddr(self, va, info):
         if va & 1:
-            info['arch'] = envi.ARCH_THUMB
+            info['arch'] = envi.ARCH_THUMB2
             return va & -2, info
         return va, info
 

--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -262,7 +262,8 @@ class CodeFlowContext(object):
             ... callbacks flow along ...
         '''
         # Architecture gets to decide on actual final VA and Architecture (ARM/THUMB/etc...)
-        va, arch = self._mem.arch.archModifyFuncAddr(va, arch)
+        info = { 'arch' : arch }
+        va, arch = self._mem.arch.archModifyFuncAddr(va, info)
 
         # Check if this is already a known function.
         if self._funcs.get(va) != None:

--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -261,6 +261,9 @@ class CodeFlowContext(object):
             cf.addEntryPoint( 0x77c70308 )
             ... callbacks flow along ...
         '''
+        # Architecture gets to decide on actual final VA and Architecture (ARM/THUMB/etc...)
+        va, arch = self._mem.arch.archModifyFuncAddr(va, arch)
+
         # Check if this is already a known function.
         if self._funcs.get(va) != None:
             return

--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -263,7 +263,8 @@ class CodeFlowContext(object):
         '''
         # Architecture gets to decide on actual final VA and Architecture (ARM/THUMB/etc...)
         info = { 'arch' : arch }
-        va, arch = self._mem.arch.archModifyFuncAddr(va, info)
+        va, info = self._mem.arch.archModifyFuncAddr(va, info)
+        arch = info.get('arch', envi.ARCH_DEFAULT)
 
         # Check if this is already a known function.
         if self._funcs.get(va) != None:

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1475,7 +1475,10 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         (see REF_ macros).  This will *not* trigger any analysis.
         Callers are expected to do their own xref analysis (ie, makeCode() etc)
         """
-        ref = (fromva,tova,reftype,rflags)
+        # Architecture gets to decide on actual final VA (ARM/THUMB/etc...)
+        va, reftype, rflags = self.arch.archModifyXrefAddr(tova, reftype, rflags)
+
+        ref = (fromva, tova, reftype, rflags)
         if ref in self.getXrefsFrom(fromva):
             return
         self._fireEvent(VWE_ADDXREF, (fromva, tova, reftype, rflags))

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1476,7 +1476,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         Callers are expected to do their own xref analysis (ie, makeCode() etc)
         """
         # Architecture gets to decide on actual final VA (ARM/THUMB/etc...)
-        va, reftype, rflags = self.arch.archModifyXrefAddr(tova, reftype, rflags)
+        tova, reftype, rflags = self.arch.archModifyXrefAddr(tova, reftype, rflags)
 
         ref = (fromva, tova, reftype, rflags)
         if ref in self.getXrefsFrom(fromva):


### PR DESCRIPTION
allow architectures to modify Xref and Function parameters *before* Xrefs and Functions are created.