### PR TITLE
envi expression takes complex names

### DIFF
--- a/envi/expression.py
+++ b/envi/expression.py
@@ -1,9 +1,40 @@
 """
 Unified expression helpers.
 """
+class ExpressionFail(Exception):
+    def __init__(self, pycode):
+        Exception.__init__(self)
+        self.pycode = pycode
+
+    def __repr__(self):
+        return "ExpressionFail: %r is not a valid expression in this context" % self.pycode
+
+    def __str__(self): 
+        return self.__repr__()
 
 def evaluate(pycode, locals):
-    return eval(pycode, {}, locals)
+    try:
+        val = eval(pycode, {}, locals)
+    except NameError, e:
+        try:
+            # check through the keys for anything we might want to replace
+            keys = locals.keys()
+
+            # sort the keys in reverse order so that longer matching strings take priority
+            keys.sort(reverse=True)
+
+            # replace the substrings with the string versions of the lookup value
+            for key in keys:
+                if key in pycode:
+                    pval = locals.get(key)
+                    pycode = pycode.replace(key, str(pval))
+            
+            val = eval(pycode, {}, locals)
+
+        except NameError, e:
+            raise ExpressionFail(pycode)
+
+    return val
 
 class ExpressionLocals(dict):
     """


### PR DESCRIPTION
initial solution:>>> import envi.expression as e_expr
>>> x={'foo(bar)': 0x40, 'foo':0x60}
>>> print e_expr.evaluate('foo(bar) + 1', x)
65
>>> print e_expr.evaluate('foo + 1', x)
97
>>> print e_expr.evaluate('32 + 1', x)
33

the question is whether we want this, where an effort is made first to resolve the expression without help, before performing replacement... or if we want to simply make evaluate() do replacement first.