### PR TITLE
elf getNotes() parsing bugfix

### DIFF
--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -544,7 +544,7 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
             plat = e.getPlatform()
         '''
         for note in self.getNotes():
-            if note.name == 'GNU\x00' and note.ntype == 1:
+            if note.name == 'GNU' and note.ntype == 1:
                 desc0 = int(note.desc[0])
                 return osnotes.get(desc0,'unknown')
 

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -544,7 +544,7 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
             plat = e.getPlatform()
         '''
         for note in self.getNotes():
-            if note.name == 'GNU' and note.ntype == 1:
+            if note.name == 'GNU\x00' and note.ntype == 1:
                 desc0 = int(note.desc[0])
                 return osnotes.get(desc0,'unknown')
 

--- a/vstruct/defs/elf.py
+++ b/vstruct/defs/elf.py
@@ -170,8 +170,8 @@ class ElfNote(vstruct.VStruct):
         self.namesz = v_uint32(bigend=bigend)
         self.descsz = v_uint32(bigend=bigend)
         self.ntype  = v_uint32(bigend=bigend)
-        self.name   = v_str()
-        self.desc   = v_str()
+        self.name   = v_bytes()
+        self.desc   = vstruct.VArray()
 
     def pcb_namesz(self):
         # padded to 4 byte alignment
@@ -180,6 +180,6 @@ class ElfNote(vstruct.VStruct):
 
     def pcb_descsz(self):
         # padded to 4 byte alignment
-        descsz = ((self.descsz +3) /4) *4
-        self['desc'].vsSetLength( descsz )
-
+        descct = ((self.descsz +3) /4)
+        elems = [ v_uint32() for i in xrange(descct) ]
+        self.desc = vstruct.VArray(elems=elems)

--- a/vstruct/defs/elf.py
+++ b/vstruct/defs/elf.py
@@ -175,13 +175,11 @@ class ElfNote(vstruct.VStruct):
 
     def pcb_namesz(self):
         # padded to 4 byte alignment
-        namesz = self.namesz
-        namesz += (namesz % 4)
+        namesz = ((self.namesz +3) /4) *4
         self['name'].vsSetLength( namesz )
 
     def pcb_descsz(self):
         # padded to 4 byte alignment
-        descsz = self.descsz
-        descsz += (descsz % 4)
+        descsz = ((self.descsz +3) /4) *4
         self['desc'].vsSetLength( descsz )
 

--- a/vstruct/defs/elf.py
+++ b/vstruct/defs/elf.py
@@ -170,13 +170,18 @@ class ElfNote(vstruct.VStruct):
         self.namesz = v_uint32(bigend=bigend)
         self.descsz = v_uint32(bigend=bigend)
         self.ntype  = v_uint32(bigend=bigend)
-        self.name   = v_bytes()
-        self.desc   = vstruct.VArray()
+        self.name   = v_str()
+        self.desc   = v_str()
 
     def pcb_namesz(self):
-        self['name'].vsSetLength( self.namesz )
+        # padded to 4 byte alignment
+        namesz = self.namesz
+        namesz += (namesz % 4)
+        self['name'].vsSetLength( namesz )
 
     def pcb_descsz(self):
-        elems = [ v_uint32() for i in xrange(self.descsz / 4) ]
-        self.desc = vstruct.VArray(elems=elems)
+        # padded to 4 byte alignment
+        descsz = self.descsz
+        descsz += (descsz % 4)
+        self['desc'].vsSetLength( descsz )
 


### PR DESCRIPTION
correctly handles padded strings aligned to 4-bytes (as defined in Elf Specs)
(described here: https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-18048.html)

one solution, using v_str's which i believe is more accurate.
however, this is not technically backwards-compatible (ie. anyone who accesses description bytes will access a v_str instead of an array of v_uint32's).

i don't think many people use this functionality so i'm not incredibly concerned about changing it.  within Viv, getPlatform() accesses getNotes(), but only uses the name and type fields.

question is:  what's the most accurate way to model this?

i'm happy to put this back to using v_bytes and VArray of v_uint32 if that's what is most accurate, and only fix the padding issues.