### PR TITLE
vamp signature updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,17 @@ framework for PE/Elf/Mach-O/Blob binary formats on various architectures.
 To start with, you probably want to run a "bulk analysis" pass on a binary
 using:
 
-> python vivbin -B <binaryfile>
+```
+python vivbin -B <binaryfile>
+```
 
 which will leave you with <binaryfile>.viv
 
 Then run:
 
-> python vivbin <binaryfile>.viv
+```
+python vivbin <binaryfile>.viv
+```
 
 to open the GUI and begin reverse engineering.  As with most vtoys, the ui
 relies fairly heavily on right-click context menus and various memory

--- a/envi/bytesig.py
+++ b/envi/bytesig.py
@@ -113,22 +113,28 @@ class SignatureTree:
             # just check the byte sequence.
             if len(sigs) == 1:
                 sbytes, smasks, sobj = sigs[0]
+                is_match = True
                 for i in xrange(depth, len(sbytes)):
                     realoff = offset + i
+                    # we still have pieces of the signature left to match, but bytes wasn't long enough
+                    if realoff >= len(bytes):
+                        is_match = False
+                        break
                     masked = ord(bytes[realoff]) & smasks[i]
                     if masked != sbytes[i]:
-                        sigs = None
-                if sigs != None:
+                        is_match = False
+                        break
+                if is_match:
                     matches.append(sigs[0])
-                #return sobj
+                break
 
             # There are still more choices, keep branching.
             node = None # Lets go find a new one
             for sig in sigs:
                 sbytes, smasks, sobj = sig
-                # we've reached the end of this signature, so we're just going to mask the rest
                 if offset+depth >= len(bytes):
                     continue
+                # we've reached the end of this signature, so we're just going to mask the rest
                 masked = ord(bytes[offset+depth]) & smasks[depth]
                 if sbytes[depth] == masked: # We have a winner!
                     # FIXME find the *best* winner! (because of masking)

--- a/envi/bytesig.py
+++ b/envi/bytesig.py
@@ -106,9 +106,7 @@ class SignatureTree:
         node = self.basenode
         while True:
             depth, sigs, choices, term = node
-            if len(term) != 0:
-                for t in term:
-                    matches.append(t)
+            matches.extend(term)
             # Once we get down to one sig, there are no more branches,
             # just check the byte sequence.
             if len(sigs) == 1:

--- a/envi/tests/test_bytesig.py
+++ b/envi/tests/test_bytesig.py
@@ -2,24 +2,16 @@ import unittest
 import traceback
 import envi.bytesig
 
-
 class SignatureTests(unittest.TestCase):
     def test_signature_subset(self):
         signature_base = '\x55\xe9\xd8\x01\xfe\xff\x32\x77\x89\x4f\x55'
         sigtree = envi.bytesig.SignatureTree()
         sigtree.addSignature(signature_base)
 
-        try:
-            sigtree.getSignature('\x55\xe9')
-        except IndexError, e:
-            self.fail("%s" % (traceback.format_exc(),))
-
-        try:
-            sigtree.addSignature(signature_base[:7], val=signature_base[:7])
-            sigtree.addSignature(signature_base[:4], val=signature_base[:4])
-            sigtree.addSignature(signature_base + '\xfe\x38', val=signature_base + '\xfe\x38')
-        except IndexError, e:
-            self.fail("%s" % (traceback.format_exc(),))
+        sigtree.getSignature('\x55\xe9')
+        sigtree.addSignature(signature_base[:7], val=signature_base[:7])
+        sigtree.addSignature(signature_base[:4], val=signature_base[:4])
+        sigtree.addSignature(signature_base + '\xfe\x38', val=signature_base + '\xfe\x38')
 
         self.assertTrue(sigtree.getSignature('\x55\xe9\xd8\x01\xfe\xff\x32\x00\x99\x36\x5f\x21\xfd') == signature_base[:7])
         self.assertTrue(sigtree.getSignature('\x55\xe9\xd8\x01\xfe\xff\x32') == signature_base[:7])

--- a/envi/tests/test_bytesig.py
+++ b/envi/tests/test_bytesig.py
@@ -8,12 +8,19 @@ class SignatureTests(unittest.TestCase):
         signature_base = '\x55\xe9\xd8\x01\xfe\xff\x32\x77\x89\x4f\x55'
         sigtree = envi.bytesig.SignatureTree()
         sigtree.addSignature(signature_base)
+
+        try:
+            sigtree.getSignature('\x55\xe9')
+        except IndexError, e:
+            self.fail("%s" % (traceback.format_exc(),))
+
         try:
             sigtree.addSignature(signature_base[:7], val=signature_base[:7])
             sigtree.addSignature(signature_base[:4], val=signature_base[:4])
             sigtree.addSignature(signature_base + '\xfe\x38', val=signature_base + '\xfe\x38')
         except IndexError, e:
             self.fail("%s" % (traceback.format_exc(),))
+
         self.assertTrue(sigtree.getSignature('\x55\xe9\xd8\x01\xfe\xff\x32\x00\x99\x36\x5f\x21\xfd') == signature_base[:7])
         self.assertTrue(sigtree.getSignature('\x55\xe9\xd8\x01\xfe\xff\x32') == signature_base[:7])
         self.assertTrue(sigtree.getSignature('\x55\xe9\xd8\x01\xfe\x00') == signature_base[:4])

--- a/envi/tests/test_bytesig.py
+++ b/envi/tests/test_bytesig.py
@@ -1,0 +1,20 @@
+import unittest
+import traceback
+import envi.bytesig
+
+
+class SignatureTests(unittest.TestCase):
+    def test_signature_subset(self):
+        signature_base = '\x55\xe9\xd8\x01\xfe\xff\x32\x77\x89\x4f\x55'
+        sigtree = envi.bytesig.SignatureTree()
+        sigtree.addSignature(signature_base)
+        try:
+            sigtree.addSignature(signature_base[:7], val=signature_base[:7])
+            sigtree.addSignature(signature_base[:4], val=signature_base[:4])
+            sigtree.addSignature(signature_base + '\xfe\x38', val=signature_base + '\xfe\x38')
+        except IndexError, e:
+            self.fail("%s" % (traceback.format_exc(),))
+        self.assertTrue(sigtree.getSignature('\x55\xe9\xd8\x01\xfe\xff\x32\x00\x99\x36\x5f\x21\xfd') == signature_base[:7])
+        self.assertTrue(sigtree.getSignature('\x55\xe9\xd8\x01\xfe\xff\x32') == signature_base[:7])
+        self.assertTrue(sigtree.getSignature('\x55\xe9\xd8\x01\xfe\x00') == signature_base[:4])
+        self.assertTrue(sigtree.getSignature('\x55') == None)

--- a/vivisect/parsers/pe.py
+++ b/vivisect/parsers/pe.py
@@ -113,7 +113,11 @@ def loadPeIntoWorkspace(vw, pe, filename=None):
     vw.setFileMeta(fname, 'SymbolCacheHash', symhash)
 
     # Add file version info if VS_VERSIONINFO has it
-    vs = pe.getVS_VERSIONINFO()
+    try:
+        vs = pe.getVS_VERSIONINFO()
+    except Exception, e:
+        vs = None
+        vw.vprint('Failed to load version info resource due to %s' % (repr(e),))
     if vs != None:
         vsver = vs.getVersionValue('FileVersion')
         if vsver != None and len(vsver):

--- a/vivisect/vamp/__init__.py
+++ b/vivisect/vamp/__init__.py
@@ -44,7 +44,7 @@ def genSigAndMask(vw, funcva, startva=None):
     fsize = 0
     if startva == None:
         startva = funcva
-    # Figgure out the size of the first linear chunk
+    # Figure out the size of the first linear chunk
     # in this function...
     cb = vw.getCodeBlock(startva)
     if cb[2] != funcva:

--- a/vivisect/vamp/__init__.py
+++ b/vivisect/vamp/__init__.py
@@ -44,10 +44,11 @@ def genSigAndMask(vw, funcva, startva=None):
     fsize = 0
     if startva == None:
         startva = funcva
+    func_blocks = [cbva for cbva, _, _ in vw.getFunctionBlocks(funcva)]
     # Figure out the size of the first linear chunk
     # in this function...
     cb = vw.getCodeBlock(startva)
-    if cb[2] != funcva:
+    if cb[CB_VA] not in func_blocks:
         raise Exception("startva not in given func")
     while cb != None:
         cbva, cbsize, cbfunc = cb
@@ -59,7 +60,7 @@ def genSigAndMask(vw, funcva, startva=None):
     if fsize == 0:
         raise Exception("0 length function??!?1")
 
-    bytes = vw.readMemory(startva, fsize)
+    bytez = vw.readMemory(startva, fsize)
 
     sig = ""
     mask = ""
@@ -67,7 +68,7 @@ def genSigAndMask(vw, funcva, startva=None):
     while i < fsize:
         rtype = vw.getRelocation(funcva + i)
         if rtype == None:
-            sig += bytes[i]
+            sig += bytez[i]
             mask += "\xff"
             i += 1
         elif rtype == RTYPE_BASERELOC:

--- a/vivisect/vamp/__init__.py
+++ b/vivisect/vamp/__init__.py
@@ -33,7 +33,7 @@ class Signature:
 
 from vivisect.const import *
 
-def genSigAndMask(vw, funcva):
+def genSigAndMask(vw, funcva, startva=None):
 
     """
     Generate an envi bytesig signature and mask for the given
@@ -42,10 +42,13 @@ def genSigAndMask(vw, funcva):
     """
 
     fsize = 0
-
+    if startva == None:
+        startva = funcva
     # Figgure out the size of the first linear chunk
     # in this function...
-    cb = vw.getCodeBlock(funcva)
+    cb = vw.getCodeBlock(startva)
+    if cb[2] != funcva:
+        raise Exception("startva not in given func")
     while cb != None:
         cbva, cbsize, cbfunc = cb
         if cbfunc != funcva:
@@ -56,7 +59,7 @@ def genSigAndMask(vw, funcva):
     if fsize == 0:
         raise Exception("0 length function??!?1")
 
-    bytes = vw.readMemory(funcva, fsize)
+    bytes = vw.readMemory(startva, fsize)
 
     sig = ""
     mask = ""

--- a/vivisect/vamp/__init__.py
+++ b/vivisect/vamp/__init__.py
@@ -33,7 +33,7 @@ class Signature:
 
 from vivisect.const import *
 
-def genSigAndMask(vw, funcva, startva=None):
+def genSigAndMask(vw, funcva):
 
     """
     Generate an envi bytesig signature and mask for the given
@@ -42,14 +42,16 @@ def genSigAndMask(vw, funcva, startva=None):
     """
 
     fsize = 0
-    if startva == None:
-        startva = funcva
+    if funcva not in vw.getFunctions():
+        funcva = vw.getFunction(funcva)
+        if funcva == None:
+            raise Exception('Given funcva not a function or within a known function')
     func_blocks = [cbva for cbva, _, _ in vw.getFunctionBlocks(funcva)]
     # Figure out the size of the first linear chunk
     # in this function...
-    cb = vw.getCodeBlock(startva)
+    cb = vw.getCodeBlock(funcva)
     if cb[CB_VA] not in func_blocks:
-        raise Exception("startva not in given func")
+        raise Exception("funcva not in given func")
     while cb != None:
         cbva, cbsize, cbfunc = cb
         if cbfunc != funcva:
@@ -60,7 +62,7 @@ def genSigAndMask(vw, funcva, startva=None):
     if fsize == 0:
         raise Exception("0 length function??!?1")
 
-    bytez = vw.readMemory(startva, fsize)
+    bytez = vw.readMemory(funcva, fsize)
 
     sig = ""
     mask = ""


### PR DESCRIPTION
* Adds a small test for the envi/bytesig.py code
* In the case where you had signatures A, B, and C, where A is a subset of B, and B is a subset of C, you'd get various IndexErrors when either adding them to the know sigs or matching against them.
* Fix a display issue in the README
* For the genSigAndMask, allow for making signatures in the middle of a function (to support cases where the first code block is really just a jump to the rest of the function)