### PR TITLE
Reloc modifies memory

### DIFF
--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -544,7 +544,7 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
             plat = e.getPlatform()
         '''
         for note in self.getNotes():
-            if note.name == 'GNU\x00' and note.ntype == 1:
+            if note.name == 'GNU' and note.ntype == 1:
                 desc0 = int(note.desc[0])
                 return osnotes.get(desc0,'unknown')
 

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -544,7 +544,7 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
             plat = e.getPlatform()
         '''
         for note in self.getNotes():
-            if note.name == 'GNU' and note.ntype == 1:
+            if note.name == 'GNU\x00' and note.ntype == 1:
                 desc0 = int(note.desc[0])
                 return osnotes.get(desc0,'unknown')
 

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -209,10 +209,10 @@ class IMemory:
 
     def writeMemoryPtr(self, va, val):
         '''
-        Read a pointer from memory at the specified address.
+        Write a pointer to memory at the specified address.
 
         Example:
-            ptr = t.readMemoryPtr(addr)
+            ptr = t.writeMemoryPtr(addr, val)
         '''
         return self.writeMemValue(va, val, self.imem_psize)
 

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -204,9 +204,8 @@ class IMemory:
         '''
         Write a number from memory of the given size.
         '''
-        efmt = e_bits.fmt_chars[self.getEndian()]
-        fmt = efmt[size]
-        return self.writeMemoryFormat(addr, fmt, val)
+        bytez = e_bits.buildbytes(val, size, self.getEndian())
+        return self.writeMemory(addr, bytez)
 
     def writeMemoryPtr(self, va, val):
         '''

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -162,6 +162,9 @@ class IMemory:
         return (0,0xffffffff)
 
     def readMemValue(self, addr, size):
+        '''
+        Read a number from memory of the given size.
+        '''
         #FIXME: use getBytesDef (and implement a dummy wrapper in VTrace for getBytesDef)
         bytes = self.readMemory(addr, size)
         if bytes == None:
@@ -196,6 +199,23 @@ class IMemory:
             fmt = fmt.replace("P","Q")
         mbytes = struct.pack(fmt, *args)
         self.writeMemory(va, mbytes)
+
+    def writeMemValue(self, addr, val, size):
+        '''
+        Write a number from memory of the given size.
+        '''
+        efmt = e_bits.fmt_chars[self.getEndian()]
+        fmt = efmt[size]
+        return self.writeMemoryFormat(addr, fmt, val)
+
+    def writeMemoryPtr(self, va, val):
+        '''
+        Read a pointer from memory at the specified address.
+
+        Example:
+            ptr = t.readMemoryPtr(addr)
+        '''
+        return self.writeMemValue(va, val, self.imem_psize)
 
     def getMemoryMap(self, va):
         '''

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -223,14 +223,15 @@ class VivWorkspaceCore(object,viv_impapi.ImportApi):
         if rtype == RTYPE_BASERELOC:
             fnm = self.getFileByVa(rva)
             imgbase = self.getFileMeta(fnm, 'imagebase')
-            rbase = imgbase
 
             ptr = self.readMemoryPtr(rva)
-            ptr += rbase
-            ptr &= e_bits.u_maxes[self.psize]
+            ptr += imgbase
+            if ptr != (ptr & e_bits.u_maxes[self.psize]):
+                logger.warn('RTYPE_BASERELOC calculated a bad pointer: 0x%x (imgbase: 0x%x)', ptr, imgbase)
+
             self.writeMemoryPtr(rva, ptr)
 
-        logger.info('_handleADDRELOC: %x -> %x (map: 0x%x)', rva, ptr, rbase)
+            logger.info('_handleADDRELOC: %x -> %x (map: 0x%x)', rva, ptr, imgbase)
 
 
     def _handleADDMODULE(self, einfo):

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -1,9 +1,11 @@
 import Queue
+import logging
 import traceback
 import threading
 import collections
 
 import envi
+import envi.bits as e_bits
 import envi.memory as e_mem
 import envi.pagelookup as e_page
 import envi.codeflow as e_codeflow
@@ -21,6 +23,8 @@ from envi.threads import firethread
 
 from vivisect.exc import *
 from vivisect.const import *
+
+logger = logging.getLogger(__name__)
 
 """
 Mostly this is a place to scuttle away some of the inner workings
@@ -212,8 +216,22 @@ class VivWorkspaceCore(object,viv_impapi.ImportApi):
         self.segments.append(einfo)
 
     def _handleADDRELOC(self, einfo):
-        self.reloc_by_va[einfo[0]] = einfo[1]
+        rva, rtype = einfo
+        self.reloc_by_va[rva] = rtype
         self.relocations.append(einfo)
+
+        if rtype == RTYPE_BASERELOC:
+            fnm = self.getFileByVa(rva)
+            imgbase = self.getFileMeta(fnm, 'imagebase')
+            rbase = imgbase
+
+            ptr = self.readMemoryPtr(rva)
+            ptr += rbase
+            ptr &= e_bits.u_maxes[self.psize]
+            self.writeMemoryPtr(rva, ptr)
+
+        logger.info('_handleADDRELOC: %x -> %x (map: 0x%x)', rva, ptr, rbase)
+
 
     def _handleADDMODULE(self, einfo):
         print('DEPRICATED (ADDMODULE) ignored: %s' % einfo)


### PR DESCRIPTION
handle BASERELOC relocation types by reading the pointer from memory, adding the file base to it and writing the new pointer bytes to memory.  should handle endianness and pointer-size seamlessly.

also creates writeMemValue() and writeMemoryPtr() to the IMemory class to match their read* counterparts.