### PR TITLE
Rakuyo sym fixes

### DIFF
--- a/vivisect/symboliks/archs/i386.py
+++ b/vivisect/symboliks/archs/i386.py
@@ -10,6 +10,7 @@ import vivisect.symboliks.translator as vsym_trans
 from vivisect.const import *
 from vivisect.symboliks.common import *
 
+
 def getSegmentSymbol(op):
     if op.prefixes & e_i386.PREFIX_CS:
         return Var('cs', 4)
@@ -23,6 +24,7 @@ def getSegmentSymbol(op):
         return Var('fs', 4)
     if op.prefixes & e_i386.PREFIX_GS:
         return Var('gs', 4)
+
 
 class ArgDefSymEmu(object):
     '''
@@ -276,11 +278,12 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
 
         obj = o_and(v1, v2, v1.getWidth())
 
-        u = UNK(v1, v2)
-        self.effSetVariable('eflags_gt', u)
-        self.effSetVariable('eflags_lt', u)
+        self.effSetVariable('eflags_gt', gt(v1, v2))
+        self.effSetVariable('eflags_lt', lt(v1, v2))
         self.effSetVariable('eflags_sf', lt(obj, Const(0, self._psize)))  # v1 & v2 < 0
         self.effSetVariable('eflags_eq', eq(obj, Const(0, self._psize)))  # v1 & v2 == 0
+        self.effSetVariable('eflags_of', Const(0, self._psize))
+        self.effSetVariable('eflags_cf', Const(0, self._psize))
 
         self.setOperObj(op, 0, obj)
 
@@ -477,11 +480,10 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
     def i_inc(self, op):
         v1 = self.getOperObj(op, 0)
         obj = o_add(v1, Const(1, self._psize), v1.getWidth())
-        u = UNK(obj, Const(1, self._psize))
-        self.effSetVariable('eflags_gt', u)
-        self.effSetVariable('eflags_lt', u)
-        self.effSetVariable('eflags_sf', u)
-        self.effSetVariable('eflags_eq', u)
+        self.effSetVariable('eflags_gt', gt(v1, obj))
+        self.effSetVariable('eflags_lt', lt(v1, obj))
+        self.effSetVariable('eflags_sf', gt(v1, obj))
+        self.effSetVariable('eflags_eq', eq(onj, Const(0, self._psize)))
         self.setOperObj(op, 0, obj)
 
     def i_int3(self, op):
@@ -653,9 +655,11 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
         v1 = self.getOperObj(op, 0)
         v2 = self.getOperObj(op, 1)
         obj = o_or(v1, v2, v1.getWidth())
-        u = UNK(v1, v2)
-        self.effSetVariable('eflags_gt', u)
-        self.effSetVariable('eflags_lt', u)
+
+        self.effSetVariable('eflags_gt', gt(v1, v2))
+        self.effSetVariable('eflags_lt', lt(v1, v2))
+        self.effSetVariable('eflags_of', Const(0, self._psize))
+        self.effSetVariable('eflags_cf', Const(0, self._psize))
         self.effSetVariable('eflags_sf', lt(obj, Const(0, self._psize))) # v1 | v2 < 0
         self.effSetVariable('eflags_eq', eq(obj, Const(0, self._psize))) # v1 & v2 == 0
         self.setOperObj(op, 0, obj)
@@ -676,11 +680,6 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
         v1 = self.getOperObj(op, 0)
         v2 = self.getOperObj(op, 1)
         obj = o_xor(v1, v2, v1.getWidth())
-        u = UNK(v1, v2)
-        self.effSetVariable('eflags_gt', u)
-        self.effSetVariable('eflags_lt', u)
-        self.effSetVariable('eflags_sf', lt(obj, Const(0, self._psize))) # v1 & v2 < 0
-        self.effSetVariable('eflags_eq', eq(obj, Const(0, self._psize))) # v1 & v2 == 0
         self.setOperObj(op, 0, obj)
 
     def i_ret(self, op):
@@ -698,9 +697,24 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
         # Arithmetic shifts are multiplies and divides!
         res = o_div(v1, o_pow(Const(2, self._psize), v2, self._psize), v1.getWidth())
 
-        u = UNK(v1, v2)
-        self.effSetVariable('eflags_gt', u)
-        self.effSetVariable('eflags_lt', u)
+        if v2.isDiscrete():
+            bit = v2.solve()
+            if bit == 1:
+                self.effSetVariable('eflags_of', Const(0, self._psize))
+            if bit != 0:
+                power = o_pow(Const(2, self._psize), Const(bit, self._psize), self._psize)
+                cf = o_div(v1 & power, power, v1.getWidth())
+                self.effSetVariable('eflags_cf', cf)
+        # TODO: I'm hesitant to put this in here blindly, because on a shift of 0, we'd generate an effect
+        # that doesn't happen
+        #else:
+        #    power = o_pow(Const(2, self._psize), v2, self._psize)
+        #    cf = o_div(v1 & power, power, v1.getWidth())
+        #    cf = v1 & (o_pow(2, self._psize), v2, self._psize - 1)
+
+
+        self.effSetVariable('eflags_gt', gt(v1, v2))
+        self.effSetVariable('eflags_lt', lt(v1, v2))
         self.effSetVariable('eflags_sf', lt(res, Const(0, self._psize))) # v1 | v2 < 0
         self.effSetVariable('eflags_eq', eq(res, Const(0, self._psize))) # v1 & v2 == 0
 
@@ -835,31 +849,38 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
             #v2 = v2 & 0xff
 
         # No effect (not even flags) if shift is 0
-        #if v2.solve() == 0:
-            #return
+        if v2.isDiscrete() and v2.solve() == 0:
+            return
 
-        self.setOperObj(op, 0, v1 << v2)
+        res = v1 << v2
+        self.setOperObj(op, 0, res)
 
-        u = UNK(v1, v2) # COP OUT FOR NOW...
-        self.effSetVariable('eflags_gt', u)
-        self.effSetVariable('eflags_lt', u)
-        self.effSetVariable('eflags_sf', u)
-        self.effSetVariable('eflags_eq', u)
+        self.effSetVariable('eflags_gt', gt(res, Const(0, self._psize)))
+        self.effSetVariable('eflags_lt', lt(res, Const(0, self._psize)))
+        self.effSetVariable('eflags_sf', lt(res, Const(0, self._psize)))
+        self.effSetVariable('eflags_eq', eq(res, Const(0, self._psize)))
 
     def i_shr(self, op):
         v1 = self.getOperObj(op, 0)
         v2 = self.getOperObj(op, 1)
 
-        #if v2.isDiscrete() and v2.solve() > 0xff:
-            #v2 = v2 & 0xff
+        # No effect (not even flags) if shift is 0
+        if v2.isDiscrete():
+            bit = v2.solve()
+            if bit == 0:
+                return
+            elif bit == 1:
+                tsize = v1.getWidth()
+                power = o_pow(Const(2, tsize), tsize - 1, self._psize)
+                msb = o_div((v1 & power), power, v1.getWidth())
+                self.effSetVariable('eflags_of', msb)
 
-        self.setOperObj(op, 0, v1 >> v2)
-
-        u = UNK(v1, v2) # COP OUT FOR NOW...
-        self.effSetVariable('eflags_gt', u)
-        self.effSetVariable('eflags_lt', u)
-        self.effSetVariable('eflags_sf', u)
-        self.effSetVariable('eflags_eq', u)
+        res = v1 >> v2
+        self.setOperObj(op, 0, res)
+        self.effSetVariable('eflags_gt', gt(res, Const(0, self._psize)))
+        self.effSetVariable('eflags_lt', lt(res, Const(0, self._psize)))
+        self.effSetVariable('eflags_sf', lt(res, Const(0, self._psize)))
+        self.effSetVariable('eflags_eq', eq(res, Const(0, self._psize)))
 
     def i_std(self, op):
         self.effSetVariable('eflags_df', Const(1, self._psize))
@@ -868,10 +889,10 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
         v1 = self.getOperObj(op, 0)
         v2 = self.getOperObj(op, 1)
         obj = o_sub(v1, v2, v1.getWidth())
-        self.effSetVariable('eflags_gt', gt(v1, v2)) # v1 - v2 > 0 :: v1 > v2
-        self.effSetVariable('eflags_lt', lt(v1, v2)) # v1 - v2 < 0 :: v1 < v2
-        self.effSetVariable('eflags_sf', lt(v1, v2)) # v1 - v2 < 0 :: v1 < v2
-        self.effSetVariable('eflags_eq', eq(v1, v2)) # v1 - v2 == 0 :: v1 == v2
+        self.effSetVariable('eflags_gt', gt(v1, v2))  # v1 - v2 > 0 :: v1 > v2
+        self.effSetVariable('eflags_lt', lt(v1, v2))  # v1 - v2 < 0 :: v1 < v2
+        self.effSetVariable('eflags_sf', lt(v1, v2))  # v1 - v2 < 0 :: v1 < v2
+        self.effSetVariable('eflags_eq', eq(v1, v2))  # v1 - v2 == 0 :: v1 == v2
         self.setOperObj(op, 0, obj)
 
     def i_subsd(self, op):
@@ -887,12 +908,17 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
         v1 = self.getOperObj(op, 0)
         v2 = self.getOperObj(op, 1)
         obj = o_and(v1, v2, v1.getWidth())
-        u = UNK(v1, v2)
 
-        self.effSetVariable('eflags_gt', u)
+        self.effSetVariable('eflags_gt', gt(v1, v2))
         self.effSetVariable('eflags_lt', lt(obj, Const(0, self._psize)))  # ( SF != OF ) ( OF is cleared )
         self.effSetVariable('eflags_sf', lt(obj, Const(0, self._psize)))  # v1 & v2 < 0
         self.effSetVariable('eflags_eq', eq(obj, Const(0, self._psize)))  # v1 & v2 == 0
+
+        self.effSetVariable('eflags_of', Const(0, self._psize))
+        self.effSetVariable('eflags_cf', Const(0, self._psize))
+
+        pf = o_xor(o_xor(v1, v2, v1.getWidth()), Const(-1, self._psize), self._psize)
+        self.effSetVariable('eflags_pf', pf)
 
     def i_xadd(self, op):
         v1 = self.getOperObj(op, 0)
@@ -909,10 +935,9 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
         v1 = self.getOperObj(op, 0)
         v2 = self.getOperObj(op, 1)
         obj = o_xor(v1, v2, v1.getWidth())
-        u = UNK(v1, v2)
-        self.effSetVariable('eflags_gt', u)
-        self.effSetVariable('eflags_lt', u)
-        self.effSetVariable('eflags_sf', lt(obj, Const(0, self._psize))) # v1 & v2 < 0
+        self.effSetVariable('eflags_gt', gt(v1, v2))
+        self.effSetVariable('eflags_lt', lt(v1, v2))
+        self.effSetVariable('eflags_sf', lt(obj, Const(0, self._psize))) # v1 ^ v2 < 0
         self.effSetVariable('eflags_eq', eq(obj, Const(0, self._psize))) # v1 & v2 == 0
         self.setOperObj(op, 0, obj)
 

--- a/vivisect/symboliks/archs/i386.py
+++ b/vivisect/symboliks/archs/i386.py
@@ -871,7 +871,7 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
                 return
             elif bit == 1:
                 tsize = v1.getWidth()
-                power = o_pow(Const(2, tsize), tsize - 1, self._psize)
+                power = o_pow(Const(2, tsize), Const(tsize - 1, self._psize), self._psize)
                 msb = o_div((v1 & power), power, v1.getWidth())
                 self.effSetVariable('eflags_of', msb)
 

--- a/vivisect/symboliks/archs/i386.py
+++ b/vivisect/symboliks/archs/i386.py
@@ -483,7 +483,7 @@ class IntelSymbolikTranslator(vsym_trans.SymbolikTranslator):
         self.effSetVariable('eflags_gt', gt(v1, obj))
         self.effSetVariable('eflags_lt', lt(v1, obj))
         self.effSetVariable('eflags_sf', gt(v1, obj))
-        self.effSetVariable('eflags_eq', eq(onj, Const(0, self._psize)))
+        self.effSetVariable('eflags_eq', eq(obj, Const(0, self._psize)))
         self.setOperObj(op, 0, obj)
 
     def i_int3(self, op):

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -303,7 +303,7 @@ class SymbolikBase:
             if idx < len(cur.kids):
                 # sys.stdout.write('+')
                 kid = cur.kids[idx]
-                if once and kid in done:
+                if once and kid._sym_id in done:
                     idx += 1
                     continue
 
@@ -325,7 +325,7 @@ class SymbolikBase:
             path.pop()          # clean up, since our algorithm doesn't expect cur on the top...
             #sys.stdout.write(' << ')
 
-            done.append(cur)
+            done.append(cur._sym_id)
 
             if not len(path):
                 #sys.stdout.write('=')

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -994,11 +994,15 @@ class ge(Constraint):
 class UNK(Constraint):
     operstr = 'UNK'
     symtype = SYMT_CON_UNK
+    def oper(self, v1, v2):
+        raise Exception('Attempted reduce/solve on UNK, which has no oper')
 
 
 class NOTUNK(Constraint):
     operstr = '!UNK'
     symtype = SYMT_CON_NOTUNK
+    def oper(self, v1, v2):
+        raise Exception('Attempted reduce/solve on NOUNK, which has no oper')
 
 # Create our oposing constraints
 oppose(ne, eq)

--- a/vivisect/symboliks/tests/test_analysis.py
+++ b/vivisect/symboliks/tests/test_analysis.py
@@ -1,6 +1,7 @@
 import sys
 import unittest
 
+import vivisect.symboliks.common as vsc
 import vivisect.symboliks.analysis as vsym_analysis
 
 from vivisect.tests.helpers import MockVw
@@ -63,6 +64,54 @@ class WalkTreeTest(unittest.TestCase):
             walkTreeDoer(vw)
         except Exception:
             sys.excepthook(*sys.exc_info())
+
+    def test_coverage(self):
+        '''
+        ((mem[piva_global(0xbfbfee08):1] | (mem[(arg0 + 72):4] & 0xffffff00)) + piva_global())
+        '''
+        ids = []
+        piva1 = vsc.Var('piva_global', 4)
+        ids.append(piva1._sym_id)
+        arg = vsc.Const(0xbfbfee08, 4)
+        ids.append(arg._sym_id)
+        call = vsc.Call(piva1, 4, argsyms=[arg])
+        ids.append(call._sym_id)
+        con = vsc.Const(1, 4)
+        ids.append(con._sym_id)
+        mem1 = vsc.Mem(call, con)
+        ids.append(mem1._sym_id)
+
+        arg = vsc.Arg(0, 4)
+        ids.append(arg._sym_id)
+        addop = vsc.Const(72, 4)
+        ids.append(addop._sym_id)
+        add = vsc.o_add(arg, addop, 4)
+        ids.append(add._sym_id)
+        con = vsc.Const(4, 4)
+        ids.append(con._sym_id)
+        memac = vsc.Mem(add, con)
+        ids.append(memac._sym_id)
+        andop = vsc.Const(0xffffff00, 4)
+        ids.append(andop._sym_id)
+        mem2 = vsc.o_and(memac, andop, 4)
+        ids.append(mem2._sym_id)
+        memor = vsc.o_or(mem1, mem2, 4)
+        ids.append(memor._sym_id)
+
+        piva2 = vsc.Var('piva_global', 4)
+        ids.append(piva2._sym_id)
+        call2 = vsc.Call(piva2, 4, argsyms=[])
+        ids.append(call2._sym_id)
+        add = vsc.o_add(memor, call2, 4)
+        ids.append(add._sym_id)
+
+        traveled_ids = []
+        def walkerTest(path, symobj, ctx):
+            traveled_ids.append(symobj._sym_id)
+
+        add.walkTree(walkerTest)
+        self.assertEqual(traveled_ids, ids)
+        self.assertEqual('((mem[piva_global(0xbfbfee08):1] | (mem[(arg0 + 72):4] & 0xffffff00)) + piva_global())', str(add))
 
 
 def walkTreeDoer(vw):

--- a/vivisect/symboliks/tests/test_archind.py
+++ b/vivisect/symboliks/tests/test_archind.py
@@ -29,7 +29,7 @@ class TestArchind(unittest.TestCase):
         self.assertEquals(1, len(wiped))
         self.assertEquals('((mem[(arg0 + 1indreg()):4] + 0indreg) * 0indreg)', str(wiped[0]))
 
-    def test_wipAstArch_wipeva(self):
+    def test_wipeAstArch_wipeva(self):
         vw = viv.VivWorkspace()
         vw.addMemoryMap(0x410000, e_mem.MM_RWX, 'code', [0 for x in range(0xFFFF)])
         vw.addLocation(0x41b2ac, 47, viv_const.LOC_POINTER)

--- a/vivisect/symboliks/tests/test_archind.py
+++ b/vivisect/symboliks/tests/test_archind.py
@@ -1,0 +1,30 @@
+import unittest
+
+import envi.memory as e_mem
+
+import vivisect as viv
+import vivisect.const as viv_const
+import vivisect.symboliks.common as vsc
+import vivisect.symboliks.archind as vsym_archind
+import vivisect.symboliks.analysis as vsym_analysis
+
+
+class TestArchind(unittest.TestCase):
+
+    def test_wipeAstArch(self):
+        vw = viv.VivWorkspace()
+        vw.addMemoryMap(0x00, e_mem.MM_RWX, 'code', [0 for x in range(256)])
+        vw.addLocation(0x40, 47, viv_const.LOC_POINTER)
+        vw.setMeta('Architecture', 'i386')
+        symctx = vsym_analysis.SymbolikAnalysisContext(vw)
+
+        func = vsc.Var('eax', 4)
+        call = vsc.Call(func, 4)
+        addr = vsc.Var('arg0', 4) + call
+        mem = vsc.Mem(addr, vsc.Const(4, 4))
+
+        op = mem + vsc.Var('edx', 4)
+        final = op * vsc.Var('edx', 4)
+        wiped = vsym_archind.wipeAstArch(symctx, [final])
+        self.assertEquals(1, len(wiped))
+        self.assertEquals('((mem[(arg0 + 1indreg()):4] + 0indreg) * 0indreg)', str(wiped[0]))

--- a/vivisect/symboliks/tests/test_archind.py
+++ b/vivisect/symboliks/tests/test_archind.py
@@ -28,3 +28,21 @@ class TestArchind(unittest.TestCase):
         wiped = vsym_archind.wipeAstArch(symctx, [final])
         self.assertEquals(1, len(wiped))
         self.assertEquals('((mem[(arg0 + 1indreg()):4] + 0indreg) * 0indreg)', str(wiped[0]))
+
+    def test_wipAstArch_wipeva(self):
+        vw = viv.VivWorkspace()
+        vw.addMemoryMap(0x410000, e_mem.MM_RWX, 'code', [0 for x in range(0xFFFF)])
+        vw.addLocation(0x41b2ac, 47, viv_const.LOC_POINTER)
+        vw.addLocation(0x4149b3, 28, viv_const.LOC_POINTER)
+        vw.addLocation(0x41ac93, 83, viv_const.LOC_POINTER)
+        vw.setMeta('Architecture', 'i386')
+        symctx = vsym_analysis.SymbolikAnalysisContext(vw)
+
+        cons = vsc.Const(0x41b2ac, 4)
+        func1 = vsc.Call(cons, 4, argsyms=[vsc.Var('edx', 4)])
+        func2 = vsc.Call(vsc.Const(0x4149b3, 4), 4, argsyms=[vsc.Const(0, 4), vsc.Const(1, 4), vsc.Const(0x41b2ac, 4)])
+        func3 = vsc.Call(vsc.Const(0x41ac93, 4), 4, argsyms=[vsc.Const(0, 4), vsc.Var('edx', 4)])
+        wiped = vsym_archind.wipeAstArch(symctx, [func1 + func2, func3], wipeva=True)
+        self.assertEquals(2, len(wiped))
+        self.assertEquals('(2archindva(0indreg) + 1archindva(0,1,2archindva))', str(wiped[0]))
+        self.assertEquals('0archindva(0,0indreg)', str(wiped[1]))


### PR DESCRIPTION
Addresses #243 
Also addresses an issue in walkTree (that affected wipeAstArch) where we would skip certain elements of the tree that were similar (like two piva_global items), but that represented different symbolik elements