### PR TITLE
Emulator/Jump Table Fixes

### DIFF
--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -155,8 +155,8 @@ class CodeFlowContext(object):
                 op = self._mem.parseOpcode(va, arch=arch)
             except envi.InvalidInstruction, e:
                 print 'parseOpcode error at 0x%.8x: %s' % (va,e)
-                continue 
-            except Exception, e:
+                continue
+            except Exception as e:
                 print 'parseOpcode error at 0x%.8x: %s' % (va,e)
                 continue
 
@@ -167,7 +167,7 @@ class CodeFlowContext(object):
             while len(branches):
 
                 bva, bflags = branches.pop()
-                                
+
                 # look for dynamic branches (ie. branches which don't have a known target).  assume at least one branch
                 if bva == None:
                     self._cb_dynamic_branch(va, op, bflags, branches)
@@ -193,6 +193,8 @@ class CodeFlowContext(object):
                                     branches.append((bdest, envi.BR_COND))
 
                                 ptrbase += self._mem.psize
+                                if not self._mem.isValidPointer(ptrbase):
+                                    break
                                 bdest = self._mem.readMemoryFormat(ptrbase, ptrfmt)[0]
                         continue
 

--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -153,7 +153,7 @@ class CodeFlowContext(object):
 
             try:
                 op = self._mem.parseOpcode(va, arch=arch)
-            except envi.InvalidInstruction, e:
+            except envi.InvalidInstruction as e:
                 print 'parseOpcode error at 0x%.8x: %s' % (va,e)
                 continue
             except Exception as e:

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1006,8 +1006,9 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                             self.makeName(rdest, "case%d_%.8x" % (i, rdest))
 
                     ptrbase += self.psize
-                    if len(self.getXrefsTo(ptrbase)):
-                        break  # Another xref means not our table anymore
+                    if len(self.getXrefsTo(ptrbase)) or not self.isValidPointer(ptrbase):
+                        # Another xref or an invalid pointer means we're done here
+                        break
                     i += 1
                     rdest = self.castPointer(ptrbase)
 

--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -487,8 +487,6 @@ class WorkspaceEmulator:
 
         taint = self.getVivTaint(val)
         if taint:
-            # NOTE we need to prevent infinite recursion due to args being
-            # tainted and then referencing the same api call
             va, ttype, tinfo = taint
             if ttype == 'apicall':
                 op, pc, api, argv = tinfo


### PR DESCRIPTION
Fixes issue where if a jump table is aligned to end of segment, vivisect will raise a segment violation on after the last entry in the jump table.

Also bypasses/fixes a longstanding TODO in reprVivTaint where we would sit and spin forever trying to repr certain recursive calls where the args to an apicall would be tainted and then passed again to the same apicall.