### PR TITLE
Strings-As-Code fix

### DIFF
--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -178,24 +178,18 @@ class CodeFlowContext(object):
                 try:
                     # Handle a table branch by adding more branches...
                     ptrfmt = ('<P', '>P')[self._mem.getEndian()]
+                    # most if not all of the work to construct jump tables is done in makeOpcode
                     if bflags & envi.BR_TABLE:
                         if self._cf_exptable:
                             ptrbase = bva
-                            bdest = self._mem.readMemoryFormat(ptrbase, ptrfmt)[0]
-                            tabdone = {}
-                            while self._mem.isValidPointer(bdest):
-
-                                if self._cb_branchtable(bva, ptrbase, bdest) == False:
+                            tabdone = set()
+                            for bdest in self._mem.iterJumpTable(ptrbase):
+                                if not self._cb_branchtable(bva, ptrbase, bdest):
                                     break
-
-                                if not tabdone.get(bdest):
-                                    tabdone[bdest] = True
+                                if bdest not in tabdone:
+                                    tabdone.add(bdest)
                                     branches.append((bdest, envi.BR_COND))
-
                                 ptrbase += self._mem.psize
-                                if not self._mem.isValidPointer(ptrbase):
-                                    break
-                                bdest = self._mem.readMemoryFormat(ptrbase, ptrfmt)[0]
                         continue
 
                     if bflags & envi.BR_DEREF:

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -964,7 +964,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
 
             yield rdest
             ptrbase += self.psize
-            if len(self.getXrefsTo(ptrbase)):
+            if len(self.getXrefsTo(ptrbase)) or self.analyzePointer(ptrbase) in (LOC_STRING, LOC_UNI):
                 break
             rdest = self.castPointer(ptrbase)
 

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -958,14 +958,16 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
     def iterJumpTable(self, startva):
         ptrbase = startva
         rdest = self.castPointer(ptrbase)
-        while self.isValidPointer(rdest):
-            if self.analyzePointer(rdest) in (LOC_STRING, LOC_UNI):
+        while self.isValidPointer(rdest) and self.analyzePointer(rdest) not in (LOC_STRING, LOC_UNI):
+            if self.analyzePointer(ptrbase) in (LOC_STRING, LOC_UNI):
                 break
 
             yield rdest
+
             ptrbase += self.psize
-            if len(self.getXrefsTo(ptrbase)) or self.analyzePointer(ptrbase) in (LOC_STRING, LOC_UNI):
+            if len(self.getXrefsTo(ptrbase)):
                 break
+
             rdest = self.castPointer(ptrbase)
 
     def moveCodeBlock(self, cbva, newfva):

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -50,8 +50,12 @@ from vivisect.defconfig import *
 
 import vivisect.analysis.generic.emucode as v_emucode
 
+STOP_LOCS = (LOC_STRING, LOC_UNI, LOC_STRUCT, LOC_CLSID, LOC_VFTABLE, LOC_IMPORT, LOC_PAD, LOC_NUMBER)
+
+
 def guid(size=16):
     return hexlify(os.urandom(size))
+
 
 class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
 
@@ -961,7 +965,6 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         iters = 0
         ptrbase = startva
         rdest = self.castPointer(ptrbase)
-        STOP_LOCS = (LOC_STRING, LOC_UNI, LOC_STRUCT, LOC_CLSID, LOC_VFTABLE, LOC_IMPORT, LOC_PAD, LOC_NUMBER)
         while self.isValidPointer(rdest) and self.analyzePointer(rdest) in (None, LOC_OP):
             if self.analyzePointer(ptrbase) in STOP_LOCS:
                 break

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -961,6 +961,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         while self.isValidPointer(rdest):
             if self.analyzePointer(rdest) in (LOC_STRING, LOC_UNI):
                 break
+
             yield rdest
             ptrbase += self.psize
             if len(self.getXrefsTo(ptrbase)):
@@ -1078,7 +1079,8 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                     refva, refsize, reftype, refinfo = self.getLocation(xrfrom)
                     if reftype != vivisect.LOC_OP:
                         continue
-
+                    if refva == op.va:
+                        continue
                     refop = self.parseOpcode(refva)
                     for refbase, refbflags in refop.getBranches():
                         if refbflags & envi.BR_TABLE:

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -961,8 +961,9 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         iters = 0
         ptrbase = startva
         rdest = self.castPointer(ptrbase)
+        STOP_LOCS = (LOC_STRING, LOC_UNI, LOC_STRUCT, LOC_CLSID, LOC_VFTABLE, LOC_IMPORT, LOC_PAD, LOC_NUMBER)
         while self.isValidPointer(rdest) and self.analyzePointer(rdest) in (None, LOC_OP):
-            if self.analyzePointer(ptrbase) in (LOC_STRING, LOC_UNI):
+            if self.analyzePointer(ptrbase) in STOP_LOCS:
                 break
 
             yield rdest
@@ -1088,8 +1089,9 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                     refva, refsize, reftype, refinfo = self.getLocation(xrfrom)
                     if reftype != vivisect.LOC_OP:
                         continue
-                    # If we've already seen this jump table from somewhere else, there's no need to split
-                    # the codeblock, so just move on
+                    # If we've already constructed this opcode location and made the xref to the new codeblock,
+                    # that should mean we've already made the jump table, so there should be no need to split this
+                    # jump table.
                     if refva == op.va:
                         continue
                     refop = self.parseOpcode(refva)

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -959,6 +959,8 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         ptrbase = startva
         rdest = self.castPointer(ptrbase)
         while self.isValidPointer(rdest):
+            if self.analyzePointer(rdest) in (LOC_STRING, LOC_UNI):
+                break
             yield rdest
             ptrbase += self.psize
             if len(self.getXrefsTo(ptrbase)):
@@ -1087,8 +1089,6 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                     if not tabdone.get(rdest):
                         tabdone[rdest] = True
                         self.addXref(va, rdest, REF_CODE, envi.BR_COND)
-                        # Honestly we should be more specific, because some cases can fall through
-                        # or to others and effectively overlap
                         if self.getName(rdest) is None:
                             self.makeName(rdest, "case%d_%.8x" % (i, rdest))
                     else:

--- a/vivisect/analysis/generic/strconst.py
+++ b/vivisect/analysis/generic/strconst.py
@@ -30,13 +30,14 @@ def analyze(vw):
                     if not vw.getSegment(ref):
                         continue
 
-                    sz = vw.detectString(ref)
+                    # Look for Unicode before ASCII to catch UTF-16 LE.
+                    sz = vw.detectUnicode(ref)
                     if sz > 0:
-                        vw.addLocation(ref, sz, LOC_STRING)
+                        vw.addLocation(ref, sz, LOC_UNI)
                     else:
-                        sz = vw.detectUnicode(ref)
+                        sz = vw.detectString(ref)
                         if sz > 0:
-                            vw.addLocation(ref, sz, LOC_UNI)
+                            vw.addLocation(ref, sz, LOC_STRING)
 
                 va += len(op)
     return

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -761,7 +761,10 @@ class VivCodeFlowContext(e_codeflow.CodeFlowContext):
             return False
 
         if self._mem.getLocation(tableva) == None:
+            # Deal with string tables
+            if self._mem.analyzePointer(destva) in (LOC_STRING, LOC_UNI):
+                return False
             self._mem.makePointer(tableva, tova=destva, follow=False)
-    
+
         return True
 

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -761,9 +761,6 @@ class VivCodeFlowContext(e_codeflow.CodeFlowContext):
             return False
 
         if self._mem.getLocation(tableva) == None:
-            # Deal with string tables
-            if self._mem.analyzePointer(destva) in (LOC_STRING, LOC_UNI):
-                return False
             self._mem.makePointer(tableva, tova=destva, follow=False)
 
         return True

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -106,6 +106,7 @@ def loadElfIntoWorkspace(vw, elf, filename=None, baseaddr=None):
     vw.setMeta('DefaultCall', archcalls.get(arch,'unknown'))
 
     vw.addNoReturnApi("*.exit")
+    vw.addNoReturnApi("*.abort")
 
     # Base addr is earliest section address rounded to pagesize
     # NOTE: This is only for prelink'd so's and exe's.  Make something for old style so.

--- a/vivisect/tests/testvivisect.py
+++ b/vivisect/tests/testvivisect.py
@@ -7,31 +7,82 @@ import vivisect.tests.helpers as helpers
 
 
 class VivisectTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.chgrp_vw = helpers.getTestWorkspace('linux', 'i386', 'chgrp.llvm')
+        cls.vdir_vw = helpers.getTestWorkspace('linux', 'i386', 'vdir.llvm')
 
     def test_consecutive_jump_table(self):
-        vw = helpers.getTestWorkspace('linux', 'i386', 'chgrp.llvm')
-
         primaryJumpOpVa = 0x804c9b6
         secondJumpOpVa = 0x804ca2b
 
-        pfva = vw.getFunction(primaryJumpOpVa)
-        sfva = vw.getFunction(secondJumpOpVa)
+        pfva = self.chgrp_vw.getFunction(primaryJumpOpVa)
+        sfva = self.chgrp_vw.getFunction(secondJumpOpVa)
         self.assertEqual(pfva, sfva)
         self.assertTrue(pfva is not None)
 
         # 2 actual codeblocks and 1 xref to the jumptable itself
-        prefs = vw.getXrefsFrom(primaryJumpOpVa)
+        prefs = self.chgrp_vw.getXrefsFrom(primaryJumpOpVa)
         self.assertEqual(len(prefs), 3)
-        cmnt = vw.getComment(0x804c9bd)
+        cmnt = self.chgrp_vw.getComment(0x804c9bd)
         self.assertEqual(cmnt, 'Other Case(s): 2, 6, 8, 11, 15, 20, 21, 34, 38, 40, 47')
         # 13 actual codeblocks and 1 xref to the jumptable itself
-        srefs = vw.getXrefsFrom(secondJumpOpVa)
+        srefs = self.chgrp_vw.getXrefsFrom(secondJumpOpVa)
         self.assertEqual(len(srefs), 14)
-        cmnt = vw.getComment(0x804ca4a)
+        cmnt = self.chgrp_vw.getComment(0x804ca4a)
         self.assertEqual(cmnt, 'Other Case(s): 41')
 
+    def test_jumptable_adjacent_strings(self):
+        jmpop = 0x804abc7
+        cases = list(map(lambda k: k[1], self.chgrp_vw.getXrefsFrom(jmpop)))
+        self.assertEqual(len(cases), 11)
+
+        casevas = [
+            0x804ac76,
+            0x804ac88,
+            0x804ac98,
+            0x804ac86,
+            0x804ac8a,
+            0x804b671,
+            0x804ac56,
+            0x804acd6,
+            0x804abce,
+            0x804abf4,
+            0x805162c
+        ]
+        self.assertEqual(casevas, cases)
+
+        strlocs = [
+            (0x8051930, 8, 2, 'literal\x00'),
+            (0x8051938, 6, 2, 'shell\x00'),
+            (0x805193e, 13, 2, 'shell-always\x00'),
+            (0x805194b, 13, 2, 'shell-escape\x00'),
+            (0x8051958, 20, 2, 'shell-escape-always\x00'),
+            (0x805196c, 8, 2, 'c-maybe\x00'),
+            (0x8051974, 8, 2, 'clocale\x00'),
+        ]
+        for lva, lsize, ltype, lstr in strlocs:
+            loctup = self.chgrp_vw.getLocation(lva)
+            self.assertEqual(loctup[0], lva)
+            self.assertEqual(lsize, loctup[1])
+            self.assertEqual(ltype, loctup[2])
+            self.assertEqual(lstr, self.chgrp_vw.readMemory(lva, lsize))
+
+    def test_non_codeblock(self):
+        '''
+        So these VAs used to be recognized as codeblocks, which is not correct.
+        <va> should be actually be a VA in the middle of a string
+        <strtbl> should be a table of *string* pointers, not code block pointers
+        '''
+        va = 0x0805b6f2
+        loctup = self.vdir_vw.getLocation(va)
+        self.assertEqual((134592163, 86, 2, None), loctup)
+
+        strtbl = 0x805e75c
+        loctup = self.vdir_vw.getLocation(strtbl)
+        self.assertEqual(loctup, (strtbl, 4, 4, None))
+
     def test_consecutive_jump_table_diff_func(self):
-        vw = helpers.getTestWorkspace('linux', 'i386', 'vdir.llvm')
         jumptabl = [
             0x8059718,
             0x8059b68,
@@ -58,11 +109,11 @@ class VivisectTest(unittest.TestCase):
         ]
 
         for i, tablva in enumerate(jumptabl):
-            refva = vw.getXrefsTo(tablva)
+            refva = self.vdir_vw.getXrefsTo(tablva)
             self.assertEqual(len(refva), 1)
             refva = refva[0]
-            func = vw.getFunction(refva[0])
-            refs = vw.getXrefsFrom(refva[0])
+            func = self.vdir_vw.getFunction(refva[0])
+            refs = self.vdir_vw.getXrefsFrom(refva[0])
             test = ans[i]
             self.assertEqual(refva[0], test[0])
             self.assertEqual(func, test[1])

--- a/vivisect/tests/testvivisect.py
+++ b/vivisect/tests/testvivisect.py
@@ -68,14 +68,41 @@ class VivisectTest(unittest.TestCase):
             self.assertEqual(ltype, loctup[2])
             self.assertEqual(lstr, self.chgrp_vw.readMemory(lva, lsize))
 
+    def test_libfunc_meta_equality(self):
+        '''
+        both vdir and chgrp have a bunch of library ufunctions in common, and while the addresses
+        may be off, other information like # of blocks, # of xrefs from each block, etc.
+        '''
+        vdir_fva = 0x8055bb0
+        chgp_fva = 0x804ab30
+
+        vmeta = self.vdir_vw.getFunctionMetaDict(vdir_fva)
+        cmeta = self.chgrp_vw.getFunctionMetaDict(chgp_fva)
+
+        self.assertEqual(vmeta['InstructionCount'], cmeta['InstructionCount'])
+        self.assertEqual(vmeta['InstructionCount'], 868)
+
+        self.assertEqual(vmeta['BlockCount'], cmeta['BlockCount'])
+        self.assertEqual(vmeta['BlockCount'], 261)
+
+        self.assertEqual(vmeta['Size'], cmeta['Size'])
+        self.assertEqual(vmeta['Size'], 3154)  # or 877?
+
+        self.assertEqual(vmeta['MnemDist'], cmeta['MnemDist'])
+
+        self.assertEqual(vmeta['Recursive'], cmeta['Recursive'])
+        self.assertTrue(vmeta['Recursive'])
+
+
     def test_non_codeblock(self):
         '''
         So these VAs used to be recognized as codeblocks, which is not correct.
         <va> should be actually be a VA in the middle of a string
         <strtbl> should be a table of *string* pointers, not code block pointers
         '''
-        va = 0x0805b6f2
-        loctup = self.vdir_vw.getLocation(va)
+        opva = 0x805633c
+        badva = 0x0805b6f2
+        loctup = self.vdir_vw.getLocation(badva)
         self.assertEqual((134592163, 86, 2, None), loctup)
 
         strtbl = 0x805e75c

--- a/vivisect/tests/testvivisect.py
+++ b/vivisect/tests/testvivisect.py
@@ -93,14 +93,12 @@ class VivisectTest(unittest.TestCase):
         self.assertEqual(vmeta['Recursive'], cmeta['Recursive'])
         self.assertTrue(vmeta['Recursive'])
 
-
     def test_non_codeblock(self):
         '''
         So these VAs used to be recognized as codeblocks, which is not correct.
         <va> should be actually be a VA in the middle of a string
         <strtbl> should be a table of *string* pointers, not code block pointers
         '''
-        opva = 0x805633c
         badva = 0x0805b6f2
         loctup = self.vdir_vw.getLocation(badva)
         self.assertEqual((134592163, 86, 2, None), loctup)


### PR DESCRIPTION
So with how certain compilers (llvm) lay things out, you can get a jumptable laid out right next to a table of strings or a table of string pointers, which leads to fun kinds of bugs where we jump into things like the gnu copyright and disassembly that as code, which has a ton of implications on symboliks, graph layout, etc.

Also adds abort as a no return api since we were disassembling past that and conflating functions together.