### PR TITLE
add getFormat() to envi.bits for consistency and ease-of-use.

### DIFF
--- a/envi/bits.py
+++ b/envi/bits.py
@@ -150,9 +150,16 @@ master_fmts = (fmt_chars, fmt_schars)
 
 fmt_sizes =  (None,1,2,4,4,8,8,8,8)
 
+def getFormat(size, big_endian=False, signed=False):
+    '''
+    Returns the proper struct format for numbers up to 8 bytes in length
+    Endianness and Signedness aware.
 
-fmt_schars = (le_fmt_schars, be_fmt_schars)
-
+    Only useful for *full individual* numbers... ie. 1, 2, 4, 8.  Numbers
+    of 24-bits (3), 40-bit (5), 48-bits (6) or 56-bits (7) are not accounted 
+    for here and will return None.
+    '''
+    return master_fmts[signed][big_endian][size]
 
 def parsebytes(bytes, offset, size, sign=False, bigend=False):
     """


### PR DESCRIPTION
simple PR.  just add a function for easily and consistently getting a format string based on size, endianness, and signedness.