### PR TITLE
bugfix: ELF parsing Static bins sometimes calls getDynSymbol() when it shouldn't

### DIFF
--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -620,7 +620,6 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
 
     def _doDynRelocs(self, rva, relsz, cls=None):
         syms = self.getDynSyms()
-        symslen = len(syms)
 
         if cls is None:
             cls = self._cls_reloc

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -1022,7 +1022,6 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
         symidx indexed symbol.
         '''
         symtabrva, symsz, symtabsz = self.getDynSymTabInfo()
-        strtabva = self.dyns.get(DT_STRTAB)
 
         symrva = symtabrva + (symidx * symsz)
         # DON'T trust symtabsz.  it's often smaller than the '.dynsym' section
@@ -1051,6 +1050,7 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
         in self.dynsymtabct.  Perhaps this is horrible and should be stricken
         from the code.
         '''
+        #FIXME: make this use both SECTION and PT_DYNAMICS versions...
         symtabva = self.dyns.get(DT_SYMTAB)
         if symtabva is None:
             return None, None, None

--- a/Elf/elf_lookup.py
+++ b/Elf/elf_lookup.py
@@ -504,6 +504,8 @@ SHT_HIPROC = 0x7fffffff
 SHT_LOUSER = 0x80000000
 SHT_HIUSER = 0x8fffffff
 
+sht_lookup ={y: x for x, y in globals().items() if x.startswith("SHT_")}
+
 sh_type = {
     SHT_NULL:"Section header table entry unused",
     SHT_PROGBITS:"Program data",
@@ -573,6 +575,8 @@ STB_HIOS = 12
 STB_LOPROC = 13
 STB_HIPROC = 15
 
+stb_lookup ={y: x for x, y in globals().items() if x.startswith("STB_")}
+
 st_info_bind = {
     STB_LOCAL:"Local symbol",
     STB_GLOBAL:"Global symbol",
@@ -599,6 +603,8 @@ STT_HIPROC = 15
 
 STT_GNU_IFUNC = 10
 
+stt_lookup ={y: x for x, y in globals().items() if x.startswith("STT_")}
+
 st_info_type = {
     STT_NOTYPE:"Symbol type is unspecified",
     STT_OBJECT:"Symbol is a data object",
@@ -613,6 +619,20 @@ st_info_type = {
     STT_LOPROC:"Start of processor-specific",
     STT_MDPROC:"Middle of processor-specific",
     STT_HIPROC:"End of processor-specific",
+}
+
+STV_DEFAULT     = 0
+STV_INTERNAL    = 1
+STV_HIDDEN      = 2
+STV_PROTECTED   = 3
+
+stv_lookup ={y: x for x, y in globals().items() if x.startswith("STV_")}
+
+st_other_visibility = {
+    STV_DEFAULT:"Symbol visibility specified by binding type",
+    STV_INTERNAL:"Symbol visibility is reserved",
+    STV_HIDDEN:"Symbol is not visible to other objects",
+    STV_PROTECTED:"Symbol is visibl by other objects, but cannot be preempted"
 }
 
 DT_NULL     = 0
@@ -687,6 +707,7 @@ DT_HIOS             = 0x6ffff000
 DT_LOPROC           = 0x70000000
 DT_HIPROC           = 0x7fffffff
 #DT_PROCNUM  = DT_MIPS_NUM
+
 dt_names = { v:k for k,v in globals().items() if k.startswith('DT_')}
 
 dt_types = {

--- a/Elf/elf_lookup.py
+++ b/Elf/elf_lookup.py
@@ -632,7 +632,7 @@ st_other_visibility = {
     STV_DEFAULT:"Symbol visibility specified by binding type",
     STV_INTERNAL:"Symbol visibility is reserved",
     STV_HIDDEN:"Symbol is not visible to other objects",
-    STV_PROTECTED:"Symbol is visibl by other objects, but cannot be preempted"
+    STV_PROTECTED:"Symbol is visible by other objects, but cannot be preempted"
 }
 
 DT_NULL     = 0

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -610,7 +610,7 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
 
             if arch in ('arm', 'thumb', 'thumb16'):
                 if rtype == Elf.R_ARM_JUMP_SLOT:
-                    symidx = r.getRelocSymTabIndex()
+                    symidx = r.getSymTabIndex()
                     if symidx == 0:
                         continue
 
@@ -639,7 +639,7 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                         vw.setComment(rlva, name)
                     
                 elif rtype == Elf.R_ARM_GLOB_DAT:
-                    symidx = r.getRelocSymTabIndex()
+                    symidx = r.getSymTabIndex()
                     if symidx == 0:
                         continue
 
@@ -665,7 +665,7 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                         vw.setComment(rlva, name)
 
                 elif rtype == Elf.R_ARM_ABS32:
-                    symidx = r.getRelocSymTabIndex()
+                    symidx = r.getSymTabIndex()
                     if symidx == 0:
                         continue
 

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -545,6 +545,7 @@ def loadElfIntoWorkspace(vw, elf, filename=None, baseaddr=None):
 
     return fname
 
+
 def applyRelocs(elf, vw, addbase=False, baseaddr=0):
     # process relocations / strings (relocs use Dynamic Symbols)
     arch = arch_names.get(elf.e_machine)
@@ -556,8 +557,8 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
         if addbase:
             rlva += baseaddr
         try:
-            # If it has a name, it's an externally
-            # resolved "import" entry, otherwise, just a regular reloc
+            # If it has a name, it's an externally resolved "import" entry, 
+            # otherwise, just a regular reloc
             name = r.getName()
             dmglname = demangle(name)
             logger.debug('relocs: 0x%x: %r  (%r)', rlva, dmglname, name)
@@ -582,10 +583,6 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                         logger.info(r.tree())
                        
                 else:
-                    symidx = Elf.getRelocSymTabIndex(r.r_info)
-                    sym = elf.getDynSymbol(symidx)
-                    ptr = sym.st_value
-
                     if rtype == Elf.R_386_RELATIVE: # R_X86_64_RELATIVE is the same number
                         ptr = vw.readMemoryPtr(rlva)
                         logger.info('R_386_RELATIVE: adding Relocation 0x%x -> 0x%x (name: %s) ', rlva, ptr, dmglname)
@@ -613,7 +610,10 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
 
             if arch in ('arm', 'thumb', 'thumb16'):
                 if rtype == Elf.R_ARM_JUMP_SLOT:
-                    symidx = Elf.getRelocSymTabIndex(r.r_info)
+                    symidx = r.getRelocSymTabIndex()
+                    if symidx == 0:
+                        continue
+
                     sym = elf.getDynSymbol(symidx)
                     ptr = sym.st_value
 
@@ -639,7 +639,10 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                         vw.setComment(rlva, name)
                     
                 elif rtype == Elf.R_ARM_GLOB_DAT:
-                    symidx = Elf.getRelocSymTabIndex(r.r_info)
+                    symidx = r.getRelocSymTabIndex()
+                    if symidx == 0:
+                        continue
+
                     sym = elf.getDynSymbol(symidx)
                     ptr = sym.st_value
 
@@ -662,7 +665,10 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                         vw.setComment(rlva, name)
 
                 elif rtype == Elf.R_ARM_ABS32:
-                    symidx = Elf.getRelocSymTabIndex(r.r_info)
+                    symidx = r.getRelocSymTabIndex()
+                    if symidx == 0:
+                        continue
+
                     sym = elf.getDynSymbol(symidx)
                     ptr = sym.st_value
 

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -611,9 +611,6 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
             if arch in ('arm', 'thumb', 'thumb16'):
                 if rtype == Elf.R_ARM_JUMP_SLOT:
                     symidx = r.getSymTabIndex()
-                    if symidx == 0:
-                        continue
-
                     sym = elf.getDynSymbol(symidx)
                     ptr = sym.st_value
 
@@ -640,9 +637,6 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                     
                 elif rtype == Elf.R_ARM_GLOB_DAT:
                     symidx = r.getSymTabIndex()
-                    if symidx == 0:
-                        continue
-
                     sym = elf.getDynSymbol(symidx)
                     ptr = sym.st_value
 
@@ -666,9 +660,6 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
 
                 elif rtype == Elf.R_ARM_ABS32:
                     symidx = r.getSymTabIndex()
-                    if symidx == 0:
-                        continue
-
                     sym = elf.getDynSymbol(symidx)
                     ptr = sym.st_value
 

--- a/vivisect/tests/testelf.py
+++ b/vivisect/tests/testelf.py
@@ -15,8 +15,10 @@ from vivisect.tests import linux_amd64_ls_data
 from vivisect.tests import linux_amd64_chown_data
 from vivisect.tests import linux_amd64_libc_2_27_data
 from vivisect.tests import linux_amd64_libstdc_data
+from vivisect.tests import linux_amd64_static_data
 from vivisect.tests import linux_i386_libc_2_13_data
 from vivisect.tests import linux_i386_libstdc_data
+from vivisect.tests import linux_i386_static_data
 from vivisect.tests import linux_arm_sh_data
 from vivisect.tests import qnx_arm_ksh_data
 from vivisect.tests import openbsd_amd64_ls_data
@@ -26,8 +28,10 @@ data = (
         ("linux_amd64_chown", linux_amd64_chown_data.chown_data, ('linux', 'amd64', 'chown'),),
         ("linux_amd64_libc", linux_amd64_libc_2_27_data.libc_data, ('linux', 'amd64', 'libc-2.27.so'),),
         ("linux_amd64_libstdc", linux_amd64_libstdc_data.libstdc_data, ('linux', 'amd64', 'libstdc++.so.6.0.25'),),
+        #("linux_amd64_static", linux_amd64_static_data.static64_data, ('linux', 'amd64', 'static64.llvm.elf'),),
         ("linux_i386_libc", linux_i386_libc_2_13_data.libc_data, ('linux', 'i386', 'libc-2.13.so'),),
         ("linux_i386_libstdc", linux_i386_libstdc_data.libstdc_data, ('linux', 'i386', 'libstdc++.so.6.0.25'),),
+        #("linux_i386_static", linux_i386_static_data.static32_data, ('linux', 'i386', 'static32.llvm.elf'),),
         ("linux_arm_sh", linux_arm_sh_data.sh_data, ('linux', 'arm', 'sh'),),
         ("qnx_arm_ksh", qnx_arm_ksh_data.ksh_data, ('qnx', 'arm', 'ksh'),),
         ("openbsd_amd64_ls", openbsd_amd64_ls_data.ls_amd64_data, ('openbsd', 'ls.amd64'),),
@@ -138,4 +142,11 @@ class ELFTests(unittest.TestCase):
         # while they are seldom in hard targets, this is a weakness we should correct.
         pass
 
+    def test_minimal(self):
+        for path in ('linux/amd64/static64.llvm.elf', 'linux/i386/static32.llvm.elf'):
+            logger.warn("======== %r ========", name)
+            fn = helpers.getTestPath(*path)
+            e = Elf.Elf(file(fn))
+            vw = viv_cli.VivCli()
+            vw.loadFromFile(fn)
 

--- a/vivisect/tests/testelf.py
+++ b/vivisect/tests/testelf.py
@@ -142,7 +142,7 @@ class ELFTests(unittest.TestCase):
 
     def test_minimal(self):
         for path in ('linux/amd64/static64.llvm.elf', 'linux/i386/static32.llvm.elf'):
-            logger.warn("======== %r ========", name)
+            logger.warn("======== %r ========", path)
             fn = helpers.getTestPath(*path)
             e = Elf.Elf(file(fn))
             vw = viv_cli.VivCli()

--- a/vivisect/tests/testelf.py
+++ b/vivisect/tests/testelf.py
@@ -141,7 +141,7 @@ class ELFTests(unittest.TestCase):
         pass
 
     def test_minimal(self):
-        for path in ('linux/amd64/static64.llvm.elf', 'linux/i386/static32.llvm.elf'):
+        for path in (('linux','amd64','static64.llvm.elf'), ('linux','i386','static32.llvm.elf')):
             logger.warn("======== %r ========", path)
             fn = helpers.getTestPath(*path)
             e = Elf.Elf(file(fn))

--- a/vivisect/tests/testelf.py
+++ b/vivisect/tests/testelf.py
@@ -15,10 +15,8 @@ from vivisect.tests import linux_amd64_ls_data
 from vivisect.tests import linux_amd64_chown_data
 from vivisect.tests import linux_amd64_libc_2_27_data
 from vivisect.tests import linux_amd64_libstdc_data
-from vivisect.tests import linux_amd64_static_data
 from vivisect.tests import linux_i386_libc_2_13_data
 from vivisect.tests import linux_i386_libstdc_data
-from vivisect.tests import linux_i386_static_data
 from vivisect.tests import linux_arm_sh_data
 from vivisect.tests import qnx_arm_ksh_data
 from vivisect.tests import openbsd_amd64_ls_data


### PR DESCRIPTION
bugfix: getDynSymbol() called when unnecessary (and sometimes don't exist)
minor cleanup