### PR TITLE
Viv-location-va

### DIFF
--- a/vivisect/qt/funcgraph.py
+++ b/vivisect/qt/funcgraph.py
@@ -490,17 +490,6 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
         #self.parentWidget().delEventCore(self)
         #return e_mem_qt.VQMemoryWindow.closeEvent(self, event)
 
-    def _getLocVa(self, addr):
-        '''
-        since we have a location database, let's use that to make sure we get a
-        real location if it exists.  otherwise, we end up in no-man's land, 
-        since we rely on labels, which only exist for the base of a location.
-        '''
-        loc = self.vw.getLocation(addr)
-        if loc is None:
-            return addr
-
-        return loc[L_VA]
 
     @idlethread
     def _renderMemory(self):
@@ -516,9 +505,13 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
                 self.mem_canvas.addText('Invalid Address: %s (%s)' % (expr, e))
                 return
 
-            # get a location anchor if one exists
-            addr = self._getLocVa(addr)
+            # get a location anchor if one exists, otherwise, we may end up in no-man's land,
+            # since we rely on labels, which only exist for the base of a location.
+            loc = self.vw.getLocation(addr)
+            if loc is not None:
+                addr = loc[L_VA]
 
+            # check if we're already rendering this function. if so, just scroll to addr
             fva = self.vw.getFunction(addr)
             if fva == self.fva:
                 self.mem_canvas.page().mainFrame().scrollToAnchor('viv:0x%.8x' % addr)
@@ -529,6 +522,7 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
                 self.vw.vprint('0x%.8x is not in a function!' % addr)
                 return
 
+            # if we're rendering a different function, get to work!
             self.clearText()
             self.renderFunctionGraph(fva)
             self.mem_canvas.page().mainFrame().scrollToAnchor('viv:0x%.8x' % addr)

--- a/vivisect/qt/funcgraph.py
+++ b/vivisect/qt/funcgraph.py
@@ -342,6 +342,7 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
         after every change.  
         '''
         self._last_viewpt = self.mem_canvas.page().mainFrame().scrollPosition()
+        # FIXME: history should track this as well and return to the same place
         self.clearText()
         self.fva = None
         self._renderMemory()
@@ -489,6 +490,18 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
         #self.parentWidget().delEventCore(self)
         #return e_mem_qt.VQMemoryWindow.closeEvent(self, event)
 
+    def _getLocVa(self, addr):
+        '''
+        since we have a location database, let's use that to make sure we get a
+        real location if it exists.  otherwise, we end up in no-man's land, 
+        since we rely on labels, which only exist for the base of a location.
+        '''
+        loc = self.vw.getLocation(addr)
+        if loc is None:
+            return addr
+
+        return loc[L_VA]
+
     @idlethread
     def _renderMemory(self):
         try:
@@ -503,12 +516,10 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
                 self.mem_canvas.addText('Invalid Address: %s (%s)' % (expr, e))
                 return
 
-            fva = self.vw.getFunction(addr)
-            if fva == self.fva:
-                self.mem_canvas.page().mainFrame().scrollToAnchor('viv:0x%.8x' % addr)
-                self.updateWindowTitle()
-                return
+            # get a location anchor if one exists
+            addr = self._getLocVa(addr)
 
+            fva = self.vw.getFunction(addr)
             if fva == None:
                 self.vw.vprint('0x%.8x is not in a function!' % addr)
                 return
@@ -516,6 +527,11 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
             self.clearText()
             self.renderFunctionGraph(fva)
             self.updateWindowTitle()
+
+            if fva == self.fva:
+                self.mem_canvas.page().mainFrame().scrollToAnchor('viv:0x%.8x' % addr)
+                self.updateWindowTitle()
+                return
 
             self._renderDoneSignal.emit()
         except Exception, e:

--- a/vivisect/qt/funcgraph.py
+++ b/vivisect/qt/funcgraph.py
@@ -520,18 +520,19 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
             addr = self._getLocVa(addr)
 
             fva = self.vw.getFunction(addr)
+            if fva == self.fva:
+                self.mem_canvas.page().mainFrame().scrollToAnchor('viv:0x%.8x' % addr)
+                self.updateWindowTitle()
+                return
+
             if fva == None:
                 self.vw.vprint('0x%.8x is not in a function!' % addr)
                 return
 
             self.clearText()
             self.renderFunctionGraph(fva)
+            self.mem_canvas.page().mainFrame().scrollToAnchor('viv:0x%.8x' % addr)
             self.updateWindowTitle()
-
-            if fva == self.fva:
-                self.mem_canvas.page().mainFrame().scrollToAnchor('viv:0x%.8x' % addr)
-                self.updateWindowTitle()
-                return
 
             self._renderDoneSignal.emit()
         except Exception, e:

--- a/vivisect/qt/memory.py
+++ b/vivisect/qt/memory.py
@@ -407,6 +407,24 @@ class VQVivMemoryView(e_mem_qt.VQMemoryWindow, viv_base.VivEventCore):
 
         return title
 
+    def _getRenderVaSize(self):
+        '''
+        Vivisect steps in and attempts to map to locations when they exist.
+        
+        since we have a location database, let's use that to make sure we get a
+        real location if it exists.  otherwise, we end up in no-man's land, 
+        since we rely on labels, which only exist for the base of a location.
+        '''
+        addr, size = e_mem_qt.VQMemoryWindow._getRenderVaSize(self)
+        if addr is None:
+            return addr, size
+
+        loc = self.vw.getLocation(addr)
+        if loc is None:
+            return addr, size
+
+        return loc[L_VA], size
+
     def initMemoryCanvas(self, memobj, syms=None):
         return VQVivMemoryCanvas(memobj, syms=syms, parent=self)
 


### PR DESCRIPTION
Vivisect Memory and FuncGraph views attempt to map navigation to locations, not raw VA's.  this is particularly helpful for ARM/THUMB where addresses in the names often are odd when the actual address is even.
currently, when the address in the nav field is in the middle of a Viv location, the desired address is nearly never shown in the window.  this branch fixes that.