### PR TITLE
fix erroneous XREFs added by makeOpcode() when PC is an operand.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ dist: bionic
 language: python
 
 python:
-    - "2.7_with_system_site_packages"
+    - "2.7"
 
 install:
     - "travis_retry sudo apt-get update"

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -554,10 +554,12 @@ class Opcode:
         return ()
 
     def genRefOpers(self, emu=None):
-        """
-        Search through operands and yield potential references for further
-        analysis.
-        """
+        '''
+        Operand generator, yielding an (oper-index, operand) tuple from this 
+        Opcode... but only for operands which make sense for XREF analysis.  
+        Override when architecture makes use of odd operands like the program 
+        counter, which returns a real value even without an emulator.
+        '''
         for oidx, o in enumerate(self.opers):
             yield (oidx, o)
 

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -553,6 +553,14 @@ class Opcode:
         """
         return ()
 
+    def genRefOpers(self, emu=None):
+        """
+        Search through operands and yield potential references for further
+        analysis.
+        """
+        for oidx, o in enumerate(self.opers):
+            yield (oidx, o)
+
     def render(self, mcanv):
         """
         Render this opcode to the memory canvas passed in.  This is used for both

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -347,7 +347,7 @@ class Operand:
     pwn on purpose to cut down on memory use and constructor CPU cost.
     """
 
-    def getOperValue(self, op, emu=None, codeflow=False):
+    def getOperValue(self, op, emu=None):
         """
         Get the current value for the operand.  If needed, use
         the given emulator/workspace/trace to resolve things like
@@ -571,7 +571,7 @@ class Opcode:
                 ret.append(name)
         return " ".join(ret)
 
-    def getOperValue(self, idx, emu=None, codeflow=False):
+    def getOperValue(self, idx, emu=None):
         oper = self.opers[idx]
         return oper.getOperValue(self, emu=emu)
 

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -347,7 +347,7 @@ class Operand:
     pwn on purpose to cut down on memory use and constructor CPU cost.
     """
 
-    def getOperValue(self, op, emu=None):
+    def getOperValue(self, op, emu=None, codeflow=False):
         """
         Get the current value for the operand.  If needed, use
         the given emulator/workspace/trace to resolve things like
@@ -571,7 +571,7 @@ class Opcode:
                 ret.append(name)
         return " ".join(ret)
 
-    def getOperValue(self, idx, emu=None):
+    def getOperValue(self, idx, emu=None, codeflow=False):
         oper = self.opers[idx]
         return oper.getOperValue(self, emu=emu)
 

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -1486,9 +1486,9 @@ class ArmRegOper(ArmOperand):
     def isDeref(self):
         return False
 
-    def getOperValue(self, op, emu=None):
-        if self.reg == REG_PC:
-            return self.va  # FIXME: is this modified?  or do we need to att # to this?
+    def getOperValue(self, op, emu=None, codeflow=False):
+        if self.reg == REG_PC and not codeflow:
+            return self.va
 
         if emu == None:
             return None

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -1486,16 +1486,16 @@ class ArmRegOper(ArmOperand):
     def isDeref(self):
         return False
 
-    def getOperValue(self, op, emu=None, codeflow=False):
-        if self.reg == REG_PC and not codeflow:
+    def getOperValue(self, op, emu=None):
+        if self.reg == REG_PC:
             return self.va
 
-        if emu == None:
+        if emu is None:
             return None
         return emu.getRegister(self.reg)
 
     def setOperValue(self, op, emu=None, val=None):
-        if emu == None:
+        if emu is None:
             return None
         emu.setRegister(self.reg, val)
 
@@ -1503,8 +1503,7 @@ class ArmRegOper(ArmOperand):
         rname = arm_regs[self.reg][0]
         mcanv.addNameText(rname, typename='registers')
         if self.oflags & OF_W:
-            mcanv.addText( "!" )
-
+            mcanv.addText("!")
 
     def repr(self, op):
         rname = arm_regs[self.reg][0]

--- a/envi/archs/arm/disasm.py
+++ b/envi/archs/arm/disasm.py
@@ -1335,6 +1335,18 @@ class ArmOpcode(envi.Opcode):
     def __len__(self):
         return int(self.size)
 
+    def genRefOpers(self, emu=None):
+        '''
+        Operand generator, yielding an (oper-index, operand) tuple from this 
+        Opcode... but only for operands which make sense for XREF analysis.  
+        Override when architecture makes use of odd operands like the program 
+        counter, which returns a real value even without an emulator.
+        '''
+        for oidx, o in enumerate(self.opers):
+            if o.isReg() and o.reg == REG_PC:
+                continue
+            yield (oidx, o)
+
     def getBranches(self, emu=None):
         """
         Return a list of tuples.  Each tuple contains the target VA of the

--- a/envi/codeflow.py
+++ b/envi/codeflow.py
@@ -2,9 +2,12 @@
 A module to contain code flow analysis for envi opcode objects...
 '''
 import copy
+import logging
 import traceback
 import envi
 import envi.memory as e_mem
+
+logger = logging.getLogger(__name__)
 
 class CodeFlowContext(object):
 
@@ -154,10 +157,10 @@ class CodeFlowContext(object):
             try:
                 op = self._mem.parseOpcode(va, arch=arch)
             except envi.InvalidInstruction as e:
-                print 'parseOpcode error at 0x%.8x: %s' % (va,e)
+                logger.warn('parseOpcode error at 0x%.8x (addCodeFlow(0x%x)): %s',va, startva, e)
                 continue
             except Exception as e:
-                print 'parseOpcode error at 0x%.8x: %s' % (va,e)
+                logger.warn('parseOpcode error at 0x%.8x (addCodeFlow(0x%x)): %s', va, startva, e)
                 continue
 
             branches = op.getBranches()

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1165,10 +1165,13 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                 self.addXref(va, tova, REF_CODE, bflags)
 
         # Check the instruction for static d-refs
-        for o in op.opers:
+        for oidx, o in op.genRefOpers(emu=None):
             # FIXME it would be nice if we could just do this one time
             # in the emulation pass (or hint emulation that some have already
             # been done.
+            # unfortunately, emulation pass only occurs for code identified
+            # within a marked function.
+            # future fix: move this all into VivCodeFlowContext.
 
             # Does the operand touch memory ?
             if o.isDeref():

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1165,7 +1165,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                 self.addXref(va, tova, REF_CODE, bflags)
 
         # Check the instruction for static d-refs
-        for o in op.opers:
+        for oidx, o in enumerate(op.opers):
             # FIXME it would be nice if we could just do this one time
             # in the emulation pass (or hint emulation that some have already
             # been done.
@@ -1201,10 +1201,10 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                             self.makeNumber(ref, o.tsize)
 
             else:
-                ref = o.getOperValue(op)
+                ref = op.getOperValue(oidx, codeflow=True)
                 if brdone.get(ref, False):
                     continue
-                if ref is not None and self.isValidPointer(ref):
+                if ref is not None and type(ref) in (int, long) and self.isValidPointer(ref):
                     self.addXref(va, ref, REF_PTR)
 
         return loc

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1165,7 +1165,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                 self.addXref(va, tova, REF_CODE, bflags)
 
         # Check the instruction for static d-refs
-        for oidx, o in enumerate(op.opers):
+        for o in op.opers:
             # FIXME it would be nice if we could just do this one time
             # in the emulation pass (or hint emulation that some have already
             # been done.
@@ -1201,7 +1201,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                             self.makeNumber(ref, o.tsize)
 
             else:
-                ref = op.getOperValue(oidx, codeflow=True)
+                ref = o.getOperValue(op)
                 if brdone.get(ref, False):
                     continue
                 if ref is not None and type(ref) in (int, long) and self.isValidPointer(ref):

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -716,6 +716,7 @@ class VivCodeFlowContext(e_codeflow.CodeFlowContext):
             branches = [br for br in branches if not self._mem.isLocType(br[0],LOC_IMPORT)]
 
             self._mem.makeOpcode(op.va, op=op)
+            # FIXME: future home of makeOpcode branch/xref analysis
             return branches
 
         return ()


### PR DESCRIPTION
one option for fixing...  open to suggestions

add "codeflow" argument to getOperValue() for both Opcode and Operand.  VivWorkspace.makeOpcode() uses this option to avoid getting PC (or whatever PC's value is) when PC is referenced by opcodes such as ARM's "mov pc, lr".  this delta is intended to fix erroneous XREFs which are getting put in whenever PC is used as an operand.  due to ARM's pipelining, PC at the time of execution is +8, causing "mov pc, lr" to cause an XREF two instructions after the opcode, even though this instruction is IF_NOFALL.