### PR TITLE
Archind fix

### DIFF
--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -2,6 +2,7 @@ import hashlib
 import operator
 import functools
 import itertools
+import collections
 
 import vstruct
 import envi.bits as e_bits
@@ -244,19 +245,19 @@ class SymbolikBase:
             if oldkid._sym_id == kid._sym_id:
                 return
 
-            # invalidate the cache
-            todo = list(set(oldkid.parents))
+            # invalidate the cache, but be careful not to repopulate it
+            todo = collections.OrderedDict({p._sym_id: p for p in oldkid.parents})
             done = set()
             while todo:
-                parent = todo.pop()
-                if parent._sym_id in done:
+                pid, parent = todo.popitem()
+                if pid in done:
                     continue
 
                 # track the objects whose cache has been cleared
-                done.add(parent._sym_id)
+                done.add(pid)
                 parent.cache.clear()
                 # grow our todo list
-                todo += list(set(parent.parents))
+                todo.update({p._sym_id: p for p in parent.parents})
 
             # remove ourselves as the parent
             if oldkid.parents:

--- a/vivisect/symboliks/tests/test_analysis.py
+++ b/vivisect/symboliks/tests/test_analysis.py
@@ -98,3 +98,18 @@ class WalkTreeTest(unittest.TestCase):
         add.walkTree(walkerTest)
         self.assertEqual(traveled_ids, ids)
         self.assertEqual('((mem[piva_global(0xbfbfee08):1] | (mem[(arg0 + 72):4] & 0xffffff00)) + piva_global())', str(add))
+
+    def test_cleanwalk(self):
+        '''
+        test that we don't accidentally populate the solver cache while walking the tree
+        '''
+        symstr = "o_add(o_xor(o_sub(Var('eax', 4), Const(98, 4), 4), Const(127, 4), 4), Const(4, 4), 4)"
+        symobj = vsc.evalSymbolik(symstr)
+        objs = []
+        def walker(path, symobj, ctx):
+            objs.append(symobj)
+        symobj.walkTree(walker)
+
+        self.assertEquals(len(objs), 7)
+        for obj in objs:
+            self.assertEquals(obj.cache, {})

--- a/vivisect/symboliks/tests/test_archind.py
+++ b/vivisect/symboliks/tests/test_archind.py
@@ -44,5 +44,5 @@ class TestArchind(unittest.TestCase):
         func3 = vsc.Call(vsc.Const(0x41ac93, 4), 4, argsyms=[vsc.Const(0, 4), vsc.Var('ecx', 4)])
         wiped = vsym_archind.wipeAstArch(symctx, [func1 + func2, func3], wipeva=True)
         self.assertEquals(2, len(wiped))
-        self.assertEquals('(0archindva(0indreg) + 1archindva(0,1,0archindva))', str(wiped[0]))
-        self.assertEquals('2archindva(0,1indreg)', str(wiped[1]))
+        self.assertEquals('(2archindva(1indreg) + 1archindva(0,1,2archindva))', str(wiped[0]))
+        self.assertEquals('0archindva(0,0indreg)', str(wiped[1]))


### PR DESCRIPTION
Impetus behind this is that the architecture wiping was producing *just* different enough results to subtly induce madness into my world. Ultimately this is because `set()` calls `__hash__` on object insertion, which ends up populating things into the symbolic cache that influence what the `poshash` variable ends up becoming (in archind.py), so things like the VA end up screwing with what the position hashes become, which is no bueno. Walking the tree shouldn't produce side effects like that, so this PR fixes that.