### PR TITLE
Added support for delay imports

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -796,7 +796,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
 
     def getImports(self):
         """
-        Return a list of imports in location tuple format.
+        Return a list of imports, including delay imports, in location tuple format.
         """
         return self.getLocations(LOC_IMPORT)
 

--- a/vivisect/parsers/pe.py
+++ b/vivisect/parsers/pe.py
@@ -337,6 +337,10 @@ def loadPeIntoWorkspace(vw, pe, filename=None, baseaddr=None):
         if vw.probeMemory(rva + baseaddr, 4, e_mem.MM_READ):
             vw.makeImport(rva + baseaddr, lname, iname)
 
+    for rva, lname, iname in pe.getDelayImports():
+        if vw.probeMemory(rva + baseaddr, 4, e_mem.MM_READ):
+            vw.makeImport(rva + baseaddr, lname, iname)
+
     # Tell vivisect about ntdll functions that don't exit...
     vw.addNoReturnApi("ntdll.RtlExitUserThread")
     vw.addNoReturnApi("kernel32.ExitProcess")

--- a/vstruct/defs/pe.py
+++ b/vstruct/defs/pe.py
@@ -97,6 +97,19 @@ class IMAGE_IMPORT_DIRECTORY(vstruct.VStruct):
         self.Name               = v_uint32()
         self.FirstThunk         = v_uint32()
 
+# https://docs.microsoft.com/en-us/cpp/build/reference/structure-and-constant-definitions?view=vs-2019
+class IMAGE_DELAY_IMPORT_DIRECTORY(vstruct.VStruct):
+    def __init__(self):
+        vstruct.VStruct.__init__(self)
+        self.grAttrs      = v_uint32()
+        self.rvaDLLName   = v_uint32()
+        self.rvaHmod      = v_uint32()
+        self.rvaIAT       = v_uint32()
+        self.rvaINT       = v_uint32()
+        self.rvaBoundIAT  = v_uint32()
+        self.rvaUnloadIAT = v_uint32()
+        self.dwTimeStamp  = v_uint32()
+
 class IMAGE_IMPORT_BY_NAME(vstruct.VStruct):
     def __init__(self, namelen=128):
         vstruct.VStruct.__init__(self)


### PR DESCRIPTION
Attempts to address #297. Ultimately no distinction is made between delay imports and standard imports.  