### PR TITLE
import emulator to handle dynamic branches (switchcases) using only xrefs

### DIFF
--- a/vivisect/impapi/posix/i386.py
+++ b/vivisect/impapi/posix/i386.py
@@ -938,5 +938,6 @@ api = {
     'plt_wctomb':( 'int', None, 'cdecl', '*.wctomb', (('void *', 'ptr'), ('int', None)) ),
     'plt_wprintf':( 'int', None, 'cdecl', '*.wprintf', (('int', None),) ),
     'plt_wscanf':( 'int', None, 'cdecl', '*.wscanf', (('int', None),) ),
+    'plt___ctype_b_loc':( 'int', None, 'cdecl', '*.__ctype_b_loc', () ),
 
 } # END

--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -272,6 +272,18 @@ class WorkspaceEmulator:
                 ret.append((bva, bpath))
                 paths.add(bva)
 
+        if op.iflags & envi.IF_BRANCH \
+                and not op.iflags & envi.IF_COND \
+                and len(xrefs):
+                    # we've hit a branch that doesn't go anywhere.  probably a switchcase we don't handle here.
+                    for xrfr, xrto, xrt, xrflag in xrefs:
+                        if xrto in paths:
+                            continue
+
+                        bpath = self.getBranchNode(self.curpath, xrto)
+                        ret.append((xrto, bpath))
+                        paths.add(xrto)
+
         # let's also take into account some of the dynamic branches we may have found
         # like our table pointers
 

--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -277,7 +277,8 @@ class WorkspaceEmulator:
                 and len(xrefs):
                     # we've hit a branch that doesn't go anywhere.  probably a switchcase we don't handle here.
                     for xrfr, xrto, xrt, xrflag in xrefs:
-                        if xrto in paths:
+                        # skip existing, skip DEREFS
+                        if xrto in paths or xrflag & envi.BR_DEREF:
                             continue
 
                         bpath = self.getBranchNode(self.curpath, xrto)


### PR DESCRIPTION
this is helpful for manual xref additions as well as switchcases where the instruction doesn't flag as BR_TABLE.