### PR TITLE
minor bugfix for handling deleted codeblocks

### DIFF
--- a/vivisect/analysis/generic/codeblocks.py
+++ b/vivisect/analysis/generic/codeblocks.py
@@ -130,7 +130,8 @@ def analyzeFunction(vw, funcva):
         # So we don't add a codeblock if we're re-analyzing a function
         # (like during dynamic branch analysis)
         bsize = blocks[bva]
-        if bva not in oldblocks:
+        tmpcb = vw.getCodeBlock(bva)
+        if bva not in oldblocks or tmpcb is None:   # sometimes codeblocks can be deleted if owned by multiple functions
             vw.addCodeBlock(bva, bsize, funcva)
         elif bsize != oldblocks[bva]:
             vw.delCodeBlock(bva)


### PR DESCRIPTION
occasionally, especially when belonging to multiple functions, a codeblock will be deleted.  this simply deals with that case while performing codeblock analysis.