### PR TITLE
Fix: syntax error discovered by pytocs

### DIFF
--- a/vdb/testmods/hookbptest.py
+++ b/vdb/testmods/hookbptest.py
@@ -222,4 +222,4 @@ class HookBpTest6(v_testmods.VtracePythonTest):
 # TODO: I don't think these are run....
 if __name__ == '__main__':
     import sys
-    sys.exit(31) TODO: tests for something NOT in impapi
+    sys.exit(31) # TODO: tests for something NOT in impapi

--- a/visgraph/renderers/svgrend.py
+++ b/visgraph/renderers/svgrend.py
@@ -38,7 +38,7 @@ class SvgGraphRenderer(vg_render.GraphRenderer):
 
     def endRender(self):
         # Actually write out the file.
-        with open(self.svgfile, 'wb) as f:
+        with open(self.svgfile, 'wb') as f:
             f.write('<?xml version="1.0" standalone="no"?>\n')
             #f.write('<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >\n')
             xsize = self._vg_canvas_width

--- a/vivisect/parsers/macho.py
+++ b/vivisect/parsers/macho.py
@@ -33,7 +33,7 @@ def _loadMacho(vw, filebytes, filename=None, baseaddr=None):
 
     # grab md5 and sha256 hashes before we modify the bytes
     fhash = viv_parsers.md5Bytes(filebytes)
-    sha256 = v_parsers.sha256Bytes(filebytes))
+    sha256 = v_parsers.sha256Bytes(filebytes)
 
     # Check for the FAT binary magic...
     if binascii.hexlify(filebytes[:4]) in ('cafebabe', 'bebafeca'):


### PR DESCRIPTION
I'm finding various syntax errors running pytocs (https://github.com/uxmal/pytocs) on your codebase.