### PR TITLE
srec parser support

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1966,7 +1966,8 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         """
         loctup = self.getLocation(va)
         if loctup is not None:
-            logger.warn("0x%x: Attempting to make a Pointer where another location object exists (of type %r)", va, self.reprLocation(loctup))
+            if loctup[L_LTYPE] != LOC_POINTER or loctup[L_VA] != va:
+                logger.warn("0x%x: Attempting to make a Pointer where another location object exists (of type %r)", va, self.reprLocation(loctup))
             return None
 
         psize = self.psize

--- a/vivisect/analysis/__init__.py
+++ b/vivisect/analysis/__init__.py
@@ -182,7 +182,23 @@ def addAnalysisModules(vw):
         vw.addFuncAnalysisModule("vivisect.analysis.generic.impapi")
         vw.addFuncAnalysisModule("vivisect.analysis.generic.thunks")
 
-    elif fmt == 'ihex': # BLOB ######################################################
+    elif fmt == 'ihex': # Intel HEX ################################################
+
+        vw.addAnalysisModule("vivisect.analysis.generic.entrypoints")
+        vw.addAnalysisModule("vivisect.analysis.generic.funcentries")
+        vw.addAnalysisModule("vivisect.analysis.generic.relocations")
+        #vw.addAnalysisModule("vivisect.analysis.generic.pointertables")
+        vw.addAnalysisModule("vivisect.analysis.generic.emucode")
+
+        if arch in ARM_ARCHS:
+            vw.addFuncAnalysisModule("vivisect.analysis.arm.emulation")
+            vw.addFuncAnalysisModule('vivisect.analysis.arm.renaming')
+
+        vw.addFuncAnalysisModule("vivisect.analysis.generic.codeblocks")
+        vw.addFuncAnalysisModule("vivisect.analysis.generic.impapi")
+        vw.addFuncAnalysisModule("vivisect.analysis.generic.thunks")
+
+    elif fmt == 'srec': # SRECORD ###################################################
 
         vw.addAnalysisModule("vivisect.analysis.generic.entrypoints")
         vw.addAnalysisModule("vivisect.analysis.generic.funcentries")

--- a/vivisect/analysis/__init__.py
+++ b/vivisect/analysis/__init__.py
@@ -182,23 +182,7 @@ def addAnalysisModules(vw):
         vw.addFuncAnalysisModule("vivisect.analysis.generic.impapi")
         vw.addFuncAnalysisModule("vivisect.analysis.generic.thunks")
 
-    elif fmt == 'ihex': # Intel HEX ################################################
-
-        vw.addAnalysisModule("vivisect.analysis.generic.entrypoints")
-        vw.addAnalysisModule("vivisect.analysis.generic.funcentries")
-        vw.addAnalysisModule("vivisect.analysis.generic.relocations")
-        #vw.addAnalysisModule("vivisect.analysis.generic.pointertables")
-        vw.addAnalysisModule("vivisect.analysis.generic.emucode")
-
-        if arch in ARM_ARCHS:
-            vw.addFuncAnalysisModule("vivisect.analysis.arm.emulation")
-            vw.addFuncAnalysisModule('vivisect.analysis.arm.renaming')
-
-        vw.addFuncAnalysisModule("vivisect.analysis.generic.codeblocks")
-        vw.addFuncAnalysisModule("vivisect.analysis.generic.impapi")
-        vw.addFuncAnalysisModule("vivisect.analysis.generic.thunks")
-
-    elif fmt == 'srec': # SRECORD ###################################################
+    elif fmt in ('ihex', 'srec'): # Intel HEX  or SRECORD (similar) #################
 
         vw.addAnalysisModule("vivisect.analysis.generic.entrypoints")
         vw.addAnalysisModule("vivisect.analysis.generic.funcentries")

--- a/vivisect/defconfig.py
+++ b/vivisect/defconfig.py
@@ -24,6 +24,7 @@ defconfig = {
             },
             'ihex':{
                 'arch':'',
+                'offset':0,
             },
             'srec':{
                 'arch':'',

--- a/vivisect/defconfig.py
+++ b/vivisect/defconfig.py
@@ -25,6 +25,10 @@ defconfig = {
             'ihex':{
                 'arch':'',
             },
+            'srec':{
+                'arch':'',
+                'offset':0,
+            },
         },
         'analysis':{
             'pointertables':{
@@ -63,6 +67,10 @@ docconfig = {
             },
             'ihex':{
                 'arch':'What architecture is the ihex dump?',
+            },
+            'srec':{
+                'arch':'What architecture is the srec dump?',
+                'offset':'Skip over initial bytes in the file',
             },
         },
 

--- a/vivisect/parsers/__init__.py
+++ b/vivisect/parsers/__init__.py
@@ -67,6 +67,9 @@ def guessFormat(bytes):
     if bytemagic in macho_magics:
         return 'macho'
 
+    if bytes[0] == 'S':
+        return 'srec'
+
     if bytes[0] == ':':
         return 'ihex'
 

--- a/vivisect/parsers/ihex.py
+++ b/vivisect/parsers/ihex.py
@@ -1,6 +1,7 @@
 import envi
 import vstruct.defs.ihex as v_ihex
 import vivisect.parsers as v_parsers
+from vivisect.const import *
 
 import logging
 logger = logging.getLogger(__name__)

--- a/vivisect/parsers/ihex.py
+++ b/vivisect/parsers/ihex.py
@@ -46,13 +46,13 @@ def parseFile(vw, filename, baseaddr=None):
 
         ihex.vsParse(sbytes)
 
-        eva = srec.getEntryPoint()
+        eva = ihex.getEntryPoint()
         if eva is not None:
             vw.addExport(eva, EXP_FUNCTION, '__entry', fname)
             logger.info('adding function from IHEX metadata: 0x%x (_entry)', eva)
             vw.addEntryPoint(eva)
 
-        sseg = srec.getStartSeg()
+        sseg = ihex.getStartSeg()
         if sseg is not None:
             ecs, eva = sseg
             vw.addExport(eva, EXP_FUNCTION, '__entry', fname)

--- a/vivisect/parsers/ihex.py
+++ b/vivisect/parsers/ihex.py
@@ -40,25 +40,23 @@ def parseFile(vw, filename, baseaddr=None):
     with open(filename, 'rb') as f:
         shdr = f.read(offset)
         sbytes = f.read()
-        logger.debug('skipping %d bytes: %r', offset, repr(shdr)[:300])
+        if offset:
+            logger.debug('skipping %d bytes: %r', offset, repr(shdr)[:300])
 
-        fname = vw.addFile(filename, 0, v_parsers.md5Bytes(sbytes))
-        vw.setFileMeta(fname, 'sha256', v_parsers.sha256Bytes(sbytes))
+        fname = vw.addFile(filename, 0, v_parsers.md5Bytes(shdr + sbytes))
+        vw.setFileMeta(fname, 'sha256', v_parsers.sha256Bytes(shdr + sbytes))
 
         ihex.vsParse(sbytes)
 
-        eva = ihex.getEntryPoint()
-        if eva is not None:
-            vw.addExport(eva, EXP_FUNCTION, '__entry', fname)
-            logger.info('adding function from IHEX metadata: 0x%x (_entry)', eva)
-            vw.addEntryPoint(eva)
+        # calculate IHEX-specific hash - only the fields copied into memory
+        ihdata = ihex.vsEmit()
+        vw.setFileMeta(fname, 'sha256_ihex', v_parsers.sha256Bytes(ihdata))
 
-        sseg = ihex.getStartSeg()
-        if sseg is not None:
-            ecs, eva = sseg
-            vw.addExport(eva, EXP_FUNCTION, '__entry', fname)
-            logger.info('adding function from IHEX metadata: 0x%x (_entry)', eva)
-            vw.addEntryPoint(eva)
+        for eva in ihex.getEntryPoints():
+            if eva is not None:
+                vw.addExport(eva, EXP_FUNCTION, '__entry', fname, makeuniq=True)
+                logger.info('adding function from IHEX metadata: 0x%x (_entry)', eva)
+                vw.addEntryPoint(eva)
 
         for addr, perms, notused, bytes in ihex.getMemoryMaps():
             vw.addMemoryMap(addr, perms, fname, bytes)

--- a/vivisect/parsers/srec.py
+++ b/vivisect/parsers/srec.py
@@ -44,11 +44,11 @@ def parseFile(vw, filename, baseaddr=None):
         fname = vw.addFile(filename, 0, v_parsers.md5Bytes(sbytes))
         vw.setFileMeta(fname, 'sha256', v_parsers.sha256Bytes(sbytes))
 
-        srec.vsParse(f.read())
+        srec.vsParse(fbytes)
 
         eva = srec.getEntryPoint()
         if eva is not None:
-            vw.addExport(eentry, EXP_FUNCTION, '__entry', fname)
+            vw.addExport(eva, EXP_FUNCTION, '__entry', fname)
             logger.info('adding function from SREC metadata: 0x%x (_entry)', eva)
             vw.addEntryPoint(eva)
 

--- a/vivisect/parsers/srec.py
+++ b/vivisect/parsers/srec.py
@@ -37,14 +37,14 @@ def parseFile(vw, filename, baseaddr=None):
 
     srec = v_srec.SRecFile()
     with open(filename, 'rb') as f:
-        fbytes = f.read()[offset:]
-        shdr = fbytes[:offset]
-        sbytes = fbytes[offset:]
+        shdr = f.read(offset)
+        sbytes = f.read()
+        logger.debug('skipping %d bytes: %r', offset, repr(shdr)[:300])
 
         fname = vw.addFile(filename, 0, v_parsers.md5Bytes(sbytes))
         vw.setFileMeta(fname, 'sha256', v_parsers.sha256Bytes(sbytes))
 
-        srec.vsParse(fbytes)
+        srec.vsParse(sbytes)
 
         eva = srec.getEntryPoint()
         if eva is not None:

--- a/vivisect/parsers/srec.py
+++ b/vivisect/parsers/srec.py
@@ -39,18 +39,23 @@ def parseFile(vw, filename, baseaddr=None):
     with open(filename, 'rb') as f:
         shdr = f.read(offset)
         sbytes = f.read()
-        logger.debug('skipping %d bytes: %r', offset, repr(shdr)[:300])
+        if offset:
+            logger.debug('skipping %d bytes: %r', offset, repr(shdr)[:300])
 
-        fname = vw.addFile(filename, 0, v_parsers.md5Bytes(sbytes))
-        vw.setFileMeta(fname, 'sha256', v_parsers.sha256Bytes(sbytes))
+        fname = vw.addFile(filename, 0, v_parsers.md5Bytes(shdr + sbytes))
+        vw.setFileMeta(fname, 'sha256', v_parsers.sha256Bytes(shdr + sbytes))
 
         srec.vsParse(sbytes)
 
-        eva = srec.getEntryPoint()
-        if eva is not None:
-            vw.addExport(eva, EXP_FUNCTION, '__entry', fname)
-            logger.info('adding function from SREC metadata: 0x%x (_entry)', eva)
-            vw.addEntryPoint(eva)
+        # calculate SREC-specific hash - only the fields copied into memory
+        srdata = srec.vsEmit()
+        vw.setFileMeta(fname, 'sha256_srec', v_parsers.sha256Bytes(srdata))
+
+        for eva in srec.getEntryPoints():
+            if eva is not None:
+                vw.addExport(eva, EXP_FUNCTION, '__entry', fname, makeuniq=True)
+                logger.info('adding function from SREC metadata: 0x%x (_entry)', eva)
+                vw.addEntryPoint(eva)
 
         for addr, perms, notused, bytes in srec.getMemoryMaps():
             vw.addMemoryMap(addr, perms, fname, bytes)

--- a/vivisect/parsers/srec.py
+++ b/vivisect/parsers/srec.py
@@ -1,0 +1,61 @@
+import envi
+import vstruct.defs.srec as v_srec
+import vivisect.parsers as v_parsers
+from vivisect.const import *
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+archcalls = {
+    'i386': 'cdecl',
+    'amd64': 'sysvamd64call',
+    'arm': 'armcall',
+    'thumb': 'armcall',
+    'thumb16': 'armcall',
+}
+
+
+def parseFile(vw, filename, baseaddr=None):
+
+    arch = vw.config.viv.parsers.srec.arch
+    if not arch:
+        raise Exception('SRec loader *requires* arch option (-O viv.parsers.srec.arch=\\"<archname>\\")')
+
+    envi.getArchModule(arch)
+
+    vw.setMeta('Architecture', arch)
+    vw.setMeta('Platform', 'Unknown')
+    vw.setMeta('Format', 'srec')
+
+    vw.setMeta('DefaultCall', archcalls.get(arch, 'unknown'))
+
+    offset = vw.config.viv.parsers.srec.offset
+    if not offset:
+        offset = 0
+    vw.config.viv.parsers.srec.offset = 0
+
+    srec = v_srec.SRecFile()
+    with open(filename, 'rb') as f:
+        fbytes = f.read()[offset:]
+        shdr = fbytes[:offset]
+        sbytes = fbytes[offset:]
+
+        fname = vw.addFile(filename, 0, v_parsers.md5Bytes(sbytes))
+        vw.setFileMeta(fname, 'sha256', v_parsers.sha256Bytes(sbytes))
+
+        srec.vsParse(f.read())
+
+        eva = srec.getEntryPoint()
+        if eva is not None:
+            vw.addExport(eentry, EXP_FUNCTION, '__entry', fname)
+            logger.info('adding function from SREC metadata: 0x%x (_entry)', eva)
+            vw.addEntryPoint(eva)
+
+        for addr, perms, notused, bytes in srec.getMemoryMaps():
+            vw.addMemoryMap(addr, perms, fname, bytes)
+            vw.addSegment(addr, len(bytes), '%.8x' % addr, fname)
+
+
+def parseMemory(vw, memobj, baseaddr):
+    raise Exception('srec loader cannot parse memory!')

--- a/vivisect/tests/testihex.py
+++ b/vivisect/tests/testihex.py
@@ -5,7 +5,6 @@ import Elf
 import envi
 import vivisect.cli as viv_cli
 import vivisect.tests.helpers as helpers
-from vivisect.const import *
 
 logger = logging.getLogger(__name__)
 

--- a/vivisect/tests/testsrec.py
+++ b/vivisect/tests/testsrec.py
@@ -5,11 +5,10 @@ import Elf
 import envi
 import vivisect.cli as viv_cli
 import vivisect.tests.helpers as helpers
-from vivisect.const import *
 
 logger = logging.getLogger(__name__)
 
-path = ('raw', 'msp430', 'blink.hex')
+path = ('raw', 'msp430', 'blink.srec')
 
 
 class IHexTests(unittest.TestCase):
@@ -17,7 +16,7 @@ class IHexTests(unittest.TestCase):
     def test_ihex(self):
         fn = helpers.getTestPath(*path)
         vw = viv_cli.VivCli()
-        vw.config.viv.parsers.ihex.arch = 'msp430'
+        vw.config.viv.parsers.srec.arch = 'msp430'
         vw.loadFromFile(fn)
 
         vw.makeFunction(0x4000)

--- a/vivisect/vivbin.py
+++ b/vivisect/vivbin.py
@@ -36,7 +36,7 @@ def main():
                         help='Do *not* start the gui, just load, analyze and save')
     parser.add_argument('-C', '--cprofile', dest='cprof', default=False, action='store_true',
                         help='Output vivisect performace profiling (cProfile) info')
-    parser.add_argument('-E', '--entrypoint', dest='addEntryPoints', default=[], action='append',
+    parser.add_argument('-E', '--entrypoint', dest='entrypoints', default=[], action='append',
                         help='Add Entry Point for bulk analysis (can have multiple "-E <addr>" args')
     parser.add_argument('-O', '--option', dest='option', default=None, action='append',
                         help='<secname>.<optname>=<optval> (optval must be json syntax)')
@@ -106,12 +106,12 @@ def main():
             logger.info('Loaded (%.4f sec) %s', (end - start), fname)
 
     if args.bulk:
-        for entryva in args.addEntryPoints:
+        for entryva in args.entrypoints:
             try:
                 vw.vprint("Adding Entry Point: %s: " % entryva)
                 eva = int(entryva, 0)
                 vw.setVaSetRow('EntryPoints', (eva,))
-            except Exception, e:
+            except Exception as e:
                 vw.vprint("Failure: %r" % e)
 
         if args.doanalyze:

--- a/vstruct/defs/srec.py
+++ b/vstruct/defs/srec.py
@@ -43,7 +43,7 @@ class SRecChunk(vstruct.VStruct):
 
     def pcb_bytecount(self):
         dsize = int(self.bytecount, 16) 
-        dsize -= int(len(self.vsGetField('address')) // 2)
+        dsize -= len(self.vsGetField('address')) // 2
         dsize -= 1  # csum
         self.vsGetField('data').vsSetLength( 2 * dsize )
 

--- a/vstruct/defs/srec.py
+++ b/vstruct/defs/srec.py
@@ -1,10 +1,15 @@
 '''
 Parser objects for the SRECORD file format.
 '''
+import logging
 import binascii
 
 import vstruct
 from vstruct.primitives import *
+
+
+logger = logging.getLogger(__name__)
+
 
 S0_HEADER = 0
 S1_DATA = 1
@@ -104,7 +109,7 @@ class SRecFile(vstruct.VArray):
         for fname, chunk in self:
 
             ctype = int( chunk.recordtype, 16 )
-            print fname, chunk.tree(), ctype
+            #print fname, chunk.tree(), ctype
 
             if ctype in (S1_DATA, S2_DATA, S3_DATA):
                 addr = chunk.getAddress()
@@ -118,7 +123,7 @@ class SRecFile(vstruct.VArray):
                 continue
 
             elif ctype == S0_HEADER:
-                print("HEADER: %r" % chunk.data)
+                logger.warning("HEADER: %r", chunk.data)
                 continue
 
             raise Exception('Unhandled SREC chunk: %s' % chunk.recordtype)

--- a/vstruct/defs/srec.py
+++ b/vstruct/defs/srec.py
@@ -78,9 +78,6 @@ class SRecFile(vstruct.VArray):
 
             self.vsAddElement( c )
 
-            #if int(c.recordtype, 16) in (S7_STARTADDR, S8_STARTADDR, S9_STARTADDR):
-            #    break
-
         return offset
 
     def getEntryPoint(self):


### PR DESCRIPTION
much like IHEX, but slightly different.

* added SREC vstruct def
* added SREC viv parser
* modified vivbin to accept multiple -O options
* modified IHEX parser/def to use v_str instead of v_bytes, because v_bytes displays hex... which in this case turns into "hex of hex", eg.  3330 for the hex byte "30" that SREC and IHEX use.
* modified vivbin to allow the setting of "EntryPoints" from the commandline.