### PR TITLE
cobra: remove unused imports

### DIFF
--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -18,6 +18,7 @@ import struct
 import logging
 import urllib2
 import traceback
+import cPickle as pickle
 
 from threading import currentThread,Thread,RLock,Timer,Lock,Event
 from SocketServer import ThreadingTCPServer, BaseRequestHandler

--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -38,8 +38,6 @@ try:
 except ImportError:
     msgpack = None
 
-import envi.common as e_common
-
 logger = logging.getLogger(__name__)
 
 daemon = None

--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -9,10 +9,8 @@ and get/set attributes on objects that exist on a remote system.
 """
 # Copyright (C) 2011 Invisigoth - See LICENSE file for details
 import os
-import sys
 import json
 import time
-import errno
 import types
 import Queue
 import socket
@@ -20,7 +18,6 @@ import struct
 import logging
 import urllib2
 import traceback
-import cPickle as pickle
 
 from threading import currentThread,Thread,RLock,Timer,Lock,Event
 from SocketServer import ThreadingTCPServer, BaseRequestHandler


### PR DESCRIPTION
`envi.common` doesn't seem to be used, unless its used for the side-effects of import (which I think should probably also be removed, in that case).