### PR TITLE
Python3 fixes

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -1,4 +1,5 @@
 import io
+import logging
 import os
 import struct
 
@@ -178,6 +179,8 @@ RT_ANICURSOR        = 21
 RT_ANIICON          = 22
 RT_HTML             = 23
 RT_MANIFEST         = 24
+
+logger = logging.getLogger('vivisect')
 
 class VS_VERSIONINFO:
     '''
@@ -1019,7 +1022,10 @@ class PE(object):
                     fwdname = self.readAtRva(funcoff, 260, shortok=True).split(b'\x00', 1)[0]
                     self.forwarders.append((funclist[ordl], name.decode('utf-8'), fwdname))
                 else:
-                    self.exports.append((funclist[ordl], ordl, name.decode('utf-8')))
+                    try:
+                        self.exports.append((funclist[ordl], ordl, name.decode('utf-8')))
+                    except UnicodeDecodeError:
+                        logger.warning('Invalid name for export ordinal %i: %s', ordl, name[:16].hex())
 
         # unnamed function exports
         else:

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -229,6 +229,8 @@ class IMemory:
         Return a tuple of mapva,size,perms,filename for the memory
         map which contains the specified address (or None).
         '''
+        if va is None:
+            return None
         for mapva, size, perms, mname in self.getMemoryMaps():
             if mapva <= va < (mapva + size):
                 return (mapva, size, perms, mname)
@@ -449,6 +451,8 @@ class MemoryObject(IMemory):
         """
         Get the va,size,perms,fname tuple for this memory map
         """
+        if va is None:
+            return None
         for mva, mmaxva, mmap, mbytes in self._map_defs:
             if mva <= va < mmaxva:
                 return mmap

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
         'Programming Language :: Python :: 2',
         'License :: OSI Approved :: Apache Software License',
     ],
-    python_requires='<3',
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
I have tried the current master (Python3) in capa: https://github.com/fireeye/capa/pull/421 This PR includes the fixes I needed in vivisect to get it working:

-  **Update Python version in setup.py**
-  **Keep Python2's behaviour of IMemory#getMemoryMap()**
   When using Python3, `getMemoryMap(None)` raises an exception, while with Python2 it returns `None`. This is caused by the following breaking change in Python3:
   > The ordering comparison operators (<, <=, >=, >) raise a TypeError exception when the operands don’t have a meaningful natural ordering.

   This causes `isValidPointer(None)` to also raise an exception in Python3, while it returns `False` in Python2.

   This can be a breaking change for applications relaying on being able to call these methods with `None` as argument. For example (from [capa](fireeye/capa@master/capa/features/extractors/viv/insn.py#L193)):
   ```python
   while True:
       if not vw.isValidPointer(p):
           return
       yield p

       try:
           next = vw.readMemoryPtr(p)
   ```
-  **Fix parsing dll name of packed binary**

   When parsing invalid exports, decoding to `utf-8` fails with an Exception. This causes `VivWorkspace#loadFromFile(file)` to fail for the following packed `.exe`: [https://github.com/fireeye/capa-testfiles/blob/master/971e599e6e707349eccea2fd4c8e5f67.exe_](https://github.com/fireeye/capa-testfiles/blob/master/971e599e6e707349eccea2fd4c8e5f67.exe_)

With these small changes it seems like vivisect is working pretty well with Python3. Only 8 files out of 175 in our test suite seems to have issues (check https://github.com/fireeye/capa/pull/421 for details). I'll check them in the next days and report it if it is vivisect related.


