### PR TITLE
bugs in imports in i386, amd64 and thumb.

### DIFF
--- a/envi/archs/amd64/disasm.py
+++ b/envi/archs/amd64/disasm.py
@@ -4,7 +4,7 @@ import envi
 import envi.bits as e_bits
 import envi.archs.i386 as e_i386
 import envi.archs.i386.opconst as e_i386_const
-import envi.archs.amd64.opcode64 as opcode86
+from . import opcode64 as opcode86
 
 from envi.const import RMETA_NMASK
 
@@ -13,7 +13,7 @@ from envi.archs.i386.disasm import iflag_lookup, operand_range, priv_lookup, \
         i386SibOper, PREFIX_REPNZ, PREFIX_REP, PREFIX_OP_SIZE, PREFIX_ADDR_SIZE, \
         MANDATORY_PREFIXES, PREFIX_REP_MASK, RMETA_LOW8, RMETA_LOW16
 
-from envi.archs.amd64.regs import *
+from .regs import *
 from envi.archs.i386.opconst import OP_EXTRA_MEMSIZES, OP_MEM_B, OP_MEM_W, OP_MEM_D, \
                                     OP_MEM_Q, OP_MEM_DQ, OP_MEM_QQ, OP_MEMMASK, \
                                     INS_VEXREQ, OP_NOVEXL

--- a/envi/archs/amd64/opcode64.py
+++ b/envi/archs/amd64/opcode64.py
@@ -1,5 +1,5 @@
 from envi.archs.i386.opconst import *
-import envi.archs.amd64.regs as e_amd64_regs
+from . import regs as e_amd64_regs
 
 # in order to be included, table name must be listed here.
 tablenames = [  None,           # nexttable index 0 means NO TABLE!

--- a/envi/archs/i386/disasm.py
+++ b/envi/archs/i386/disasm.py
@@ -10,10 +10,10 @@ import envi.bits as e_bits
 
 # Grab our register enums etc...
 from envi.const import *
-from envi.archs.i386.regs import *
+from .regs import *
 
-import envi.archs.i386.opconst as opconst
-import envi.archs.i386.opcode86 as opcode86
+from . import opconst
+from . import opcode86
 all_tables = opcode86.tables86
 
 # Our instruction prefix masks

--- a/envi/archs/i386/opcode86.py
+++ b/envi/archs/i386/opcode86.py
@@ -1,5 +1,5 @@
 from envi.archs.i386.opconst import *
-import envi.archs.i386.regs as e_i386_regs
+from . import regs as e_i386_regs
 """
 (optable, optype, operand 0, operand 1, operand 2, CPU required, "opcodename", op0Register, op1Register, op2Register)
 """

--- a/envi/archs/thumb16/__init__.py
+++ b/envi/archs/thumb16/__init__.py
@@ -1,6 +1,6 @@
 from envi.archs.arm import *
 
-import envi.archs.thumb16.disasm as th_disasm
+from . import disasm as th_disasm
 
 
 class Thumb16Module(ThumbModule):

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
         'Programming Language :: Python :: 2',
         'License :: OSI Approved :: Apache Software License',
     ],
-    python_requires='<3',
+    python_requires='>=3',
 )

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
         'Programming Language :: Python :: 2',
         'License :: OSI Approved :: Apache Software License',
     ],
-    python_requires='>=3',
+    python_requires='<3',
 )


### PR DESCRIPTION
bugs in imports in i386, amd64 and thumb.
setup.py set to require Python 3+