### PR TITLE
WIP: Reloc elf

### DIFF
--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -671,10 +671,6 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
 
             relocs = reloc * count
             vstruct.VArray(elems=relocs).vsParse(secbytes, fast=True)
-            print(sec)
-            print(sec.name, self.dynamic_symbols)
-            print(relocs)
-            print()
 
             for reloc in relocs:
                 index = reloc.getSymTabIndex()
@@ -684,12 +680,9 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
 
                 # Appears kernel modules only have a strtab if they're not stripped?
                 # Check to see if a name was recovered
-                print("Reloc old name!", reloc.getName())
                 if reloc.getName() == "":
-                    print("SymTabIndex", reloc.getSymTabIndex())
                     sym = self.symbols[index]
                     reloc.setName( sym.getName() )
-                    print("Reloc new name!", reloc.getName())
 
                 if reloc.r_offset in self.relocvas:
                     # FIXME: This line is hit sever tens of thousands of times during parsing

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -673,6 +673,7 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
             vstruct.VArray(elems=relocs).vsParse(secbytes, fast=True)
 
             for reloc in relocs:
+                print("_parseSectionReloc", reloc.vsGetField("r_info") & 0xff, hex(sec.sh_offset))
                 index = reloc.getSymTabIndex()
                 if index < len(self.dynamic_symbols):
                     sym = self.dynamic_symbols[index]
@@ -684,8 +685,11 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
                     sym = self.symbols[index]
                     reloc.setName( sym.getName() )
 
+
                 if reloc.r_offset in self.relocvas:
                     # FIXME: This line is hit sever tens of thousands of times during parsing
+                    # Possible solution -- Make self.relocvas a set. Ensures each entry
+                    # is unique
                     logger.debug('duplicate relocation (section): %s', reloc)
                     continue
 
@@ -746,15 +750,9 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
         return self.readAtOffset(self.rvaToOffset(rva), size)
 
     def rvaToOffset(self, rva):
-        if self.e_type == ET_REL:
-            self.relRvaToOffset(rva)
-        else:
-            self.execRvaToOffset(rva)
+        self.execRvaToOffset(rva)
 
-    def relRvaToOffset(self, rva):
-        print("relRvaToOffset", rva)
-
-    def execRvaToOffset(self, rva):
+    def RvaToOffset(self, rva):
         '''
         Convert an RVA for this ELF binary to a file offset.
         '''

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -750,9 +750,6 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
         return self.readAtOffset(self.rvaToOffset(rva), size)
 
     def rvaToOffset(self, rva):
-        self.execRvaToOffset(rva)
-
-    def rvaToOffset(self, rva):
         '''
         Convert an RVA for this ELF binary to a file offset.
         '''

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -753,6 +753,15 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
         return self.readAtOffset(self.rvaToOffset(rva), size)
 
     def rvaToOffset(self, rva):
+        if self.e_type == ET_REL:
+            self.relRvaToOffset(rva)
+        else:
+            self.execRvaToOffset(rva)
+
+    def relRvaToOffset(self, rva):
+        print("relRvaToOffset", rva)
+
+    def execRvaToOffset(self, rva):
         '''
         Convert an RVA for this ELF binary to a file offset.
         '''
@@ -1045,10 +1054,6 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
         symidx indexed symbol.
         '''
         symtabrva, symsz, symtabsz = self.getDynSymTabInfo()
-
-        if symsz is None:
-            # Sometimes there isn't a DynSym, zero everything out
-            symtabrva, symsz, symtabsz = 0,0,0
 
         symrva = symtabrva + (symidx * symsz)
         # DON'T trust symtabsz.  it's often smaller than the '.dynsym' section

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -752,7 +752,7 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
     def rvaToOffset(self, rva):
         self.execRvaToOffset(rva)
 
-    def RvaToOffset(self, rva):
+    def rvaToOffset(self, rva):
         '''
         Convert an RVA for this ELF binary to a file offset.
         '''

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -1046,6 +1046,10 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
         '''
         symtabrva, symsz, symtabsz = self.getDynSymTabInfo()
 
+        if symsz is None:
+            # Sometimes there isn't a DynSym, zero everything out
+            symtabrva, symsz, symtabsz = 0,0,0
+
         symrva = symtabrva + (symidx * symsz)
         # DON'T trust symtabsz.  it's often smaller than the '.dynsym' section
         # but, if we attempt to parse outside the binary, we'll throw an error.

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -531,6 +531,7 @@ def loadElfIntoWorkspace(vw, elf, filename=None, baseaddr=None):
                 logger.warning("%s" % str(e))
 
         if s.st_info == Elf.STT_FUNC:
+            print("LOADSTUFFINTOWORKSPACE", sva, s.getName())
             new_functions.append(("STT_FUNC", sva))
 
     if addbase:
@@ -648,8 +649,9 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                             print("RELOCABLE_RELOCS", rsecname, rr)
                             # Try to recover the section name, they seem to have the same convention
                             # .rel.xxx --> .xxx
-                            print("RNAME", rsecname.split('.'), ".".join(rsecname.split('.')[2:]))
-                            rname = "." + '.'.join(rsecname.split('.')[2:])
+                            # Except when it doesn't
+                            rname = '.'.join(rsecname.split('rel')[1:])
+                            print("RNAME", rsecname.split('rel'), rname)
 
                             # Now read from the approriate section
                             rlva = 0

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -642,18 +642,15 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                             # relocable_reloc indexes should be in sync with relocs
                             ridx = relocs.index(r)
                             rsecname, rr = elf.relocable_relocs[ridx]
-                            rlva = rr.r_offset
                             # Try to recover the section name, they seem to have the same convention
                             # .rel.xxx --> .xxx
-                            rname = '.'.join([rsecname.split('.')[-1]])
-                            
-                            if addbase:
-                                rlva += baseaddr
+                            rname = f".{rsecname.split('.')[-1]}"
 
                             # Now read from the approriate section
                             for sva, ssz, sname, fname in vw.segments:
                                 if sname == rname:
-                                    temp = vw.readMemoryPtr(rlva + sva)
+                                    rlva = rr.r_offset + sva
+                                    temp = vw.readMemoryPtr(rlva)
                                     break
                         else:
                             temp = vw.readMemoryPtr(rlva)

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -646,7 +646,12 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                             ridx = relocs.index(r)
                             print("RIDX", ridx)
                             rsecname, rr = elf.relocable_relocs[ridx]
-                            print("RELOCABLE_RELOCS", rsecname, rr)
+                            print("RELOCABLE_RELOCS", rsecname, rr, "r.r_info >> 8", r.r_info >> 8)
+                            print(
+                                "SYMBOL", 
+                                elf.symbols[r.r_info >> 8], 
+                                elf.symbols[r.r_info >> 8].st_info & 0xf,
+                            )
                             # Try to recover the section name, they seem to have the same convention
                             # .rel.xxx --> .xxx
                             # Except when it doesn't
@@ -693,6 +698,12 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
 
                 logger.debug('addend: 0x%x', addend)
 
+                if rtype in (0,1):
+                    print("foundone")
+                    print(r)
+                    raise Exception("ExasdsaD")
+
+
                 if rtype == Elf.R_ARM_JUMP_SLOT:
                     symidx = r.getSymTabIndex()
                     sym = elf.getDynSymbol(symidx)
@@ -721,7 +732,7 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
 
                     else:
                         logger.info('R_ARM_JUMP_SLOT: adding Import 0x%x (%s) ', rlva, dmglname)
-                        vw.makeImport(rlva, "*", dmglname)
+                        vw.makeImport(rlva, "a*", dmglname)
                         vw.setComment(rlva, name)
 
                 elif rtype == Elf.R_ARM_GLOB_DAT:
@@ -747,7 +758,7 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
 
                     else:
                         logger.info('R_ARM_GLOB_DAT: adding Import 0x%x (%s) ', rlva, dmglname)
-                        vw.makeImport(rlva, "*", dmglname)
+                        vw.makeImport(rlva, "b*", dmglname)
                         vw.setComment(rlva, name)
 
                 elif rtype == Elf.R_ARM_ABS32:
@@ -767,7 +778,8 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
 
                     else:
                         logger.info('R_ARM_ABS32: adding Import 0x%x (%s) ', rlva, dmglname)
-                        vw.makeImport(rlva, "*", dmglname)
+                        vw.makeImport(rlva, "*", name)
+                        #vw.makeImport(rlva, "*", dmglname)
                         vw.setComment(rlva, name)
 
                     vw.setComment(rlva, dmglname)
@@ -797,6 +809,13 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
                     vw.addRelocation(rlva, vivisect.RTYPE_BASEOFF, ptr)
                     vw.makeName(rlva, name, makeuniq=True)
                     vw.setComment(rlva, name)
+
+                elif rtype == Elf.R_ARM_NONE:
+                    symidx = r.getSymTabIndex()
+                    sym = elf.getSymbols()[symidx]
+
+                    print("NO_TYPE")
+                    print(sym.getName())
                     
 
                 else:

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -741,7 +741,10 @@ def applyRelocs(elf, vw, addbase=False, baseaddr=0):
 
                 elif rtype == Elf.R_ARM_ABS32:
                     symidx = r.getSymTabIndex()
-                    sym = elf.getDynSymbol(symidx)
+                    if elf.e_type == Elf.ET_REL:
+                        sym = elf.getSymbols()[symidx]
+                    else:
+                        sym = elf.getDynSymbol(symidx)
                     ptr = sym.st_value
 
                     if ptr:


### PR DESCRIPTION
When trying to load ARM kernel objects into the vivisect workspace, things begin to break down.  Since they are Relocatable files, the relocs are all relative to the section they represent which caused issues when trying to read memory for analysis. I think I have that fixed, so far.  

The next issue I am trying to run down is that there are multiple functions in Elf that really bank on that fact that there is a dynsym section. From what I can tell, that is not the case for ARM kernel objects, looks like they are using the symtab. It was at this point I realized I might need some help trying to run down this issue. 

In da0a0d4, I was playing with what return values I could feed to **rvaToOffset** to make it not bomb out. But I realized it was all for not because **rvaToOffset** wants program headers, which aren't in kernel objects.

So I am looking for advice for how to best move forward. Thanks. 