### PR TITLE
extension improvements

### DIFF
--- a/vivisect/extensions/__init__.py
+++ b/vivisect/extensions/__init__.py
@@ -20,9 +20,10 @@ def loadExtensions(vw, vwgui):
     extdir = os.getenv('VIV_EXT_PATH')
 
     if extdir is None:
-        return
+        # if user hasn't overridden the Extension Path, use the built-in default
+        extdir = os.sep.join([vw.vivhome, 'plugins'])
 
-    for dirname in extdir.split(';'):
+    for dirname in extdir.split(os.pathsep):
 
         if not os.path.isdir(dirname):
             vw.vprint('Invalid VIV_EXT_PATH dir: %s' % dirname)
@@ -32,23 +33,26 @@ def loadExtensions(vw, vwgui):
             modpath = os.path.join(dirname, fname)
             # dig into first level of directories and exec the __init__.py
             if os.path.isdir(modpath):
+                modname = fname
                 modpath = os.path.join(modpath, '__init__.py')
                 if not os.path.exists(modpath):
                     continue
 
             # otherwise, run all the .py files in the VIV_EXT_PATH dir
-            if not modpath.endswith('.py'):
+            elif not modpath.endswith('.py'):
                 continue
 
-            # Build code objects from the module files
-            spec = importlib.util.spec_from_file_location('viv_ext', modpath)
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+            else:
+                # it's a .py file
+                modname = fname[:-3]
 
             try:
-                with open(modpath, 'r') as fd:
-                    filebytes = fd.read()
-                exec(filebytes, module.__dict__)
+                # Build code objects from the module files
+                spec = importlib.util.spec_from_file_location(fname, modpath)
+                module = importlib.util.module_from_spec(spec)
+                module.vw = vw
+                spec.loader.exec_module(module)
+
                 module.vivExtension(vw, vwgui)
                 vw.addExtension(fname, module)
             except Exception:


### PR DESCRIPTION
* Bugfix: remove duplicate loading of each module
* Default VIV_EXT_PATH of ~/.viv/plugins
* Fix module name (no longer "viv_ext") so "from ." works correctly
* Add vw to namespace (some indication of running as an extension)