### PR TITLE
Backport emu fixes

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -2623,6 +2623,8 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             fmtname = viv_parsers.guessFormatFilename(filename)
 
         if fmtname in ('viv', 'mpviv'):
+            if fmtname == 'mpviv':
+                self.setMeta('StorageModule', 'vivisect.storage.mpfile')
             self.loadWorkspace(filename)
             return self.normFileName(filename)
 

--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -205,7 +205,7 @@ class WorkspaceEmulator:
                 # pops, which leads us to say that code path isn't a function since we miss the ret instruction.
                 # So we have here a fix for that. Added some rails so we don'y always just punch it in
                 if self._safe_mem:
-                    if not self.vw.isValidPointer(newaddr) and self.isValidPointer(retn):
+                    if not self.vw.isValidPointer(newaddr) and self.vw.isValidPointer(retn):
                         self.setProgramCounter(retn)
             # no else since we'll emulate into the function
 

--- a/vivisect/storage/tools/convert.py
+++ b/vivisect/storage/tools/convert.py
@@ -1,0 +1,20 @@
+import argparse
+
+import vivisect.storage as v_storage
+
+def setup():
+    ap = argparse.ArgumentParser('')
+
+    ap.add_argument('')
+    ap.add_argument('')
+    ap.add_argument('')
+
+    return ap
+
+
+def main(argv):
+    opts = setup().parse_args(argv)
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/vivisect/storage/tools/convert.py
+++ b/vivisect/storage/tools/convert.py
@@ -1,19 +1,57 @@
+import os
+import sys
 import argparse
 
+import vivisect
+import vivisect.parsers as v_parsers
 import vivisect.storage as v_storage
 
-def setup():
-    ap = argparse.ArgumentParser('')
+storemap = {
+    'viv': 'vivisect.storage.basicfile',
+    'mpviv': 'vivisect.storage.mpfile',
+}
 
-    ap.add_argument('')
-    ap.add_argument('')
-    ap.add_argument('')
+
+def setup():
+    ap = argparse.ArgumentParser('Convert from one workspace format to another')
+
+    ap.add_argument('old', help='Path to older workspace')
+    ap.add_argument('--name', '-n', help='Name for the new workspace')
 
     return ap
 
 
+def convert(old, newname):
+    oldfmt = v_parsers.guessFormatFilename(old)
+    vw = vivisect.VivWorkspace()
+    if oldfmt not in storemap:
+        print('Refusing to handle format %s, this is for workspace files only!')
+        return -1
+
+    newfmt = 'mpviv'
+    if oldfmt == 'mpviv':
+        newfmt = 'viv'
+
+    if not newname:
+        newname = '%s.%s' % (old, newfmt)
+
+    oldstor = storemap[oldfmt]
+    newstor = storemap[newfmt]
+
+    vw.setMeta('StorageModule', oldstor)
+    vw.loadWorkspace(old)
+
+    vw.setMeta('StorageModule', newstor)
+    vw.setMeta('StorageName', newname)
+    vw.saveWorkspace()
+
+
 def main(argv):
     opts = setup().parse_args(argv)
+
+    old = os.path.abspath(opts.old)
+
+    convert(old, opts.name)
 
 
 if __name__ == '__main__':

--- a/vivisect/tests/testvivisect.py
+++ b/vivisect/tests/testvivisect.py
@@ -88,12 +88,12 @@ class VivisectTest(unittest.TestCase):
         self.assertTrue(len(vw.getLocations()) > 1000)
 
         # tuples are Name, Number of Locations, Size in bytes, Percentage of space
-        ans = {0: ('Undefined', 0, 509878, 48),
+        ans = {0: ('Undefined', 0, 509293, 48),
                1: ('Num/Int', 271, 1724, 0),
                2: ('String', 4066, 153678, 14),
                3: ('Unicode', 0, 0, 0),
                4: ('Pointer', 5376, 43008, 4),
-               5: ('Opcode', 81348, 331076, 31),
+               5: ('Opcode', 81474, 331661, 31),
                6: ('Structure', 496, 11544, 1),
                7: ('Clsid', 0, 0, 0),
                8: ('VFTable', 0, 0, 0),


### PR DESCRIPTION
Back the emu fixes that came up, also add conversion tool for going from basicfile to msgpack (or vice versa), since msgpack is py3 compatible (at least from a quick glance) while basicfile is not (cuz pickle).

Readme updates for some of this will go onto master. But this should be one of the last few py2 branches.

Should address #348 and help side step (but not fix) #363, as it provides a possible upgrade path 