### PR TITLE
FIX issue #391, added check to prevent divide by zero error.

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -815,7 +815,8 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
          numPointers,
          numVtables) = self.getDiscoveredInfo()
 
-        self.vprint("Percentage of discovered executable surface area: %.1f%% (%s / %s)" % (disc*100.0/(disc+undisc), disc, disc+undisc))
+        percentage = disc*100.0/(disc+undisc) if disc or undisc else 0
+        self.vprint("Percentage of discovered executable surface area: %.1f%% (%s / %s)" % (percentage, disc, disc+undisc))
         self.vprint("   Xrefs/Blocks/Funcs:                             (%s / %s / %s)" % (numXrefs, numBlocks, numFuncs))
         self.vprint("   Locs,  Ops/Strings/Unicode/Nums/Ptrs/Vtables:   (%s:  %s / %s / %s / %s / %s / %s)" % (numLocs, numOps, numStrings, numUnis, numNumbers, numPointers, numVtables))
 


### PR DESCRIPTION
Fixing issue [#391](https://github.com/vivisect/vivisect/issues/391).
Added check to prevent divide by zero error in [printDiscoveredStats](https://github.com/vivisect/vivisect/blob/e0592b15dcaeef4fe6c6c2f2df1f56b74ceb088e/vivisect/__init__.py#L804).
