### PR TITLE
Speed ups

### DIFF
--- a/visgraph/exc.py
+++ b/visgraph/exc.py
@@ -11,7 +11,7 @@ class NodeNonExistant(VisGraphException):
     def __init__(self, nodeid):
         self.nodeid = nodeid
         Exception.__init__(self, 'Node %d does not exist!' % nodeid)
-        
+
 class EdgeNonExistant(VisGraphException):
     def __init__(self, edgeid):
         self.edgeid = edgeid

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -3003,9 +3003,6 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         '''
         Add a prefix to the given name paying attention to the filename prefix, and
         any VA suffix which may exist.
-
-        This is used by multiple analysis modules.
-        Uses _getNameParts.
         '''
         fpart, npart, vapart = self._getNameParts(name, va)
         if fpart is None and vapart is None:

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1130,7 +1130,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             if loctup is not None and loctup[L_TINFO] and loctup[L_LTYPE] == LOC_OP:
                 arch = loctup[L_TINFO]
         key = (va, arch, b[:16])
-        valu = self._op_cache.get(key)
+        valu = self._op_cache.get(key, None)
         if valu and not skip:
             return valu
         valu = self.imem_archs[(arch & envi.ARCH_MASK) >> 16].archParseOpcode(b, off, va)

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1116,9 +1116,9 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         '''
         Parse an opcode from the specified virtual address.
 
-        Example: op = m.parseOpcode(0x7c773803, skip=True)
+        Example: op = m.parseOpcode(0x7c773803, skipcache=True)
 
-        Set skip=True in order to bypass the opcode cache and force a reparsing of bytes
+        Set skipcache=True in order to bypass the opcode cache and force a reparsing of bytes
         '''
         off, b = self.getByteDef(va)
         if arch == envi.ARCH_DEFAULT:

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1112,7 +1112,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
     #
     # Opcode API
     #
-    def parseOpcode(self, va, arch=envi.ARCH_DEFAULT, skip=False):
+    def parseOpcode(self, va, arch=envi.ARCH_DEFAULT, skipcache=False):
         '''
         Parse an opcode from the specified virtual address.
 

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -13,6 +13,7 @@ import string
 import hashlib
 import logging
 import binascii
+import functools
 import itertools
 import traceback
 import threading
@@ -1111,6 +1112,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
     #
     # Opcode API
     #
+    @functools.cache
     def parseOpcode(self, va, arch=envi.ARCH_DEFAULT):
         '''
         Parse an opcode from the specified virtual address.

--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1128,7 +1128,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             # so that at least parse opcode wont fail
             if loctup is not None and loctup[L_TINFO] and loctup[L_LTYPE] == LOC_OP:
                 arch = loctup[L_TINFO]
-        if not skip:
+        if not skipcache:
             key = (va, arch, b[:16])
             valu = self._op_cache.get(key, None)
             if not valu:

--- a/vivisect/analysis/generic/pointers.py
+++ b/vivisect/analysis/generic/pointers.py
@@ -4,9 +4,8 @@ country looking for pointers to interesting things.
 
 in a previous life, this analysis code lived inside VivWorkspace.analyze()
 """
-import sys
 import logging
-from vivisect.const import RTYPE_BASEPTR, LOC_POINTER, L_LTYPE
+from vivisect.const import RTYPE_BASEPTR, LOC_POINTER
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +13,7 @@ def analyze(vw):
 
     logger.info('...analyzing pointers.')
 
-    done = []
+    done = {}
 
     # Let's analyze Relocations we know are pointers
     for rva, rtype in vw.reloc_by_va.items():
@@ -24,7 +23,8 @@ def analyze(vw):
         for xfr, xto, xtype, xinfo in vw.getXrefsFrom(rva):
             logger.debug('pointer(1): 0x%x -> 0x%x', xfr, xto)
             vw.analyzePointer(xto)
-            done.append((xfr, xto))
+            if vw.isLocType(xfr, LOC_POINTER):
+                done[xfr] = xto
 
     # Now, we'll analyze the pointers placed by the file wrapper (ELF, PE, MACHO, etc...)
     for pva, tva, fname, pname in vw.getVaSetRows('PointersFromFile'):
@@ -34,7 +34,7 @@ def analyze(vw):
             else:
                 logger.debug('making pointer(2) 0x%x -> 0x%x (%r)', pva, tva, pname)
             vw.makePointer(pva, tva, follow=True)
-            done.append((pva, tva))
+            done[pva] = tva
 
     for lva, lsz, lt, li in vw.getLocations(LOC_POINTER):
         tva = vw.readMemoryPtr(lva)
@@ -44,14 +44,14 @@ def analyze(vw):
         if vw.getLocation(tva) is not None:
             # event if it's a pointer, we may not have made a name for it
             if vw.getName(lva) is None:
-                done.append((lva, tva))
+                done[lva] = tva
             continue
 
         logger.debug('following previously discovered pointer 0x%x -> 0x%x', lva, tva)
         try:
             logger.debug('pointer(3): 0x%x -> 0x%x', lva, tva)
             vw.followPointer(tva)
-            done.append((lva, tva))
+            done[lva] = tva
         except Exception as e:
             logger.error('followPointer() failed for 0x%.8x (pval: 0x%.8x) (err: %s)', lva, tva, e)
 
@@ -62,30 +62,26 @@ def analyze(vw):
         try:
             logger.debug('pointer(4): 0x%x -> 0x%x', addr, pval)
             vw.makePointer(addr, follow=True)
-            done.append((addr, pval))
+            done[addr] = pval
         except Exception as e:
             logger.error('makePointer() failed for 0x%.8x (pval: 0x%.8x) (err: %s)', addr, pval, e)
 
-    # Now let's see what these guys should be named (if anything)
-    for _, _ in done:
-        for ptr, tgt in done:
-            try:
-                pname = vw.getName(ptr)
-                if pname is not None:
-                    logger.debug('skipping renaming of ptr 0x%x (currently: %r)', ptr, pname)
-                    continue
+    refs = {v: k for k, v in done.items()}
+    while refs:
+        tgt, ptr = refs.popitem()
+        while ptr:
+            pname = vw.getName(ptr)
+            if pname:
+                break
+            if not vw.isLocType(ptr, LOC_POINTER):
+                break
 
-                loc = vw.getLocation(ptr)
-                if loc is not None and loc[L_LTYPE] != LOC_POINTER:
-                    logger.debug('skipping naming of 0x%x (no longer a pointer: %s)', ptr, vw.reprLocation(loc))
-                    continue
-                tgtname = vw.getName(tgt)
-                if tgtname is not None:
-                    name = vw._addNamePrefix(tgtname, tgt, 'ptr', '_') + '_%.8x' % ptr
-                    logger.debug('0x%x: adding name prefix: %r  (%r)', tgt, tgtname, name)
-                    vw.makeName(ptr, name)
-                else:
-                    logger.debug('0x%x: Skipping naming due to no target name' % tgt)
-            except Exception as e:
-                logger.error('naming failed (0x%x -> 0x%x), (err: %s)', ptr, tgt, e)
-                sys.excepthook(*sys.exc_info())
+            tgtname = vw.getName(tgt)
+            if tgtname:
+                name = vw._addNamePrefix(tgtname, tgt, 'ptr', '_') + '_%.8x' % ptr
+                logger.debug('0x%x: adding name prefix: %r  (%r)', tgt, tgtname, name)
+                vw.makeName(ptr, name)
+                tgt = ptr
+                ptr = refs.pop(tgt, None)
+            else:
+                ptr = None

--- a/vivisect/analysis/generic/pointers.py
+++ b/vivisect/analysis/generic/pointers.py
@@ -26,8 +26,7 @@ def analyze(vw):
         for xfr, xto, xtype, xinfo in vw.getXrefsFrom(rva):
             logger.debug('pointer(1): 0x%x -> 0x%x', xfr, xto)
             vw.analyzePointer(xto)
-            if vw.isLocType(xfr, LOC_POINTER):
-                done[xfr] = xto
+            done[xfr] = xto
 
     # Now, we'll analyze the pointers placed by the file wrapper (ELF, PE, MACHO, etc...)
     for pva, tva, fname, pname in vw.getVaSetRows('PointersFromFile'):

--- a/vivisect/impemu/emulator.py
+++ b/vivisect/impemu/emulator.py
@@ -129,7 +129,6 @@ class WorkspaceEmulator:
         self.path = self.newCodePathNode()
         self.curpath = self.path
         self.op = None
-        self.opcache = {}
         self.emumon = None
         self.psize = self.getPointerSize()
 
@@ -238,13 +237,7 @@ class WorkspaceEmulator:
         self.emumon = emumon
 
     def parseOpcode(self, va, arch=envi.ARCH_DEFAULT):
-        # We can make an opcode *faster* with the workspace because of
-        # getByteDef etc... use it.
-        op = self.opcache.get(va)
-        if op is None:
-            op = envi.Emulator.parseOpcode(self, va, arch=arch)
-            self.opcache[va] = op
-        return op
+        return self.vw.parseOpcode(va, arch=arch)
 
     def checkCall(self, starteip, endeip, op):
         """
@@ -335,7 +328,6 @@ class WorkspaceEmulator:
         # if we've already hunted this location down, know it's a table, and we've resolved it
         # step carefully so we don't conflate tables together
         xrefs = vw.getXrefsFrom(op.va, rtype=REF_CODE)
-        branches = []
         for bva, bflags in op.getBranches(emu=None):
             if bflags & envi.BR_TABLE and vw.getLocation(op.va) and len(xrefs):
                 for xrfrom, xrto, xrtype, xrflags in xrefs:

--- a/vivisect/impemu/platarch/arm.py
+++ b/vivisect/impemu/platarch/arm.py
@@ -1,7 +1,6 @@
 import logging
 
 import envi
-import envi.common as e_common
 import envi.archs.arm as e_arm
 from envi.archs.arm.regs import *
 
@@ -45,7 +44,7 @@ class ArmWorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_arm.ArmEmulator):
             tmode = self.getFlag(PSR_T_bit)
             arch = (envi.ARCH_ARMV7, envi.ARCH_THUMB)[tmode]
 
-        return self.vw.parseOpcode(self, va, arch=arch)
+        return self.vw.parseOpcode(va, arch=arch)
 
     def stepi(self):
         # NOTE: when we step, we *always* want to be stepping over calls

--- a/vivisect/impemu/platarch/arm.py
+++ b/vivisect/impemu/platarch/arm.py
@@ -27,11 +27,9 @@ class ArmWorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_arm.ArmEmulator):
         self.setMemArchitecture(envi.ARCH_ARMV7)
 
     def setThumbMode(self, thumb=1):
-        self.opcache = {}
         e_arm.ArmEmulator.setThumbMode(self, thumb)
 
     def setArmMode(self, arm=1):
-        self.opcache = {}
         e_arm.ArmEmulator.setArmMode(self, arm)
 
     def parseOpcode(self, va, arch=envi.ARCH_DEFAULT):
@@ -43,16 +41,11 @@ class ArmWorkspaceEmulator(v_i_emulator.WorkspaceEmulator, e_arm.ArmEmulator):
 
         Made for ARM, because envi.Emulator doesn't understand the Thumb flag
         '''
-        op = self.opcache.get(va)
-
-        if op is None:
+        if arch == envi.ARCH_DEFAULT:
             tmode = self.getFlag(PSR_T_bit)
-            if arch == envi.ARCH_DEFAULT:
-                arch = (envi.ARCH_ARMV7, envi.ARCH_THUMB)[tmode]
+            arch = (envi.ARCH_ARMV7, envi.ARCH_THUMB)[tmode]
 
-            op = envi.archs.arm.emu.ArmEmulator.parseOpcode(self, va, arch=arch)
-            self.opcache[va] = op
-        return op
+        return self.vw.parseOpcode(self, va, arch=arch)
 
     def stepi(self):
         # NOTE: when we step, we *always* want to be stepping over calls

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -237,7 +237,7 @@ class SymbolikBase:
         '''
         raise Exception('%s *must* implement solve(emu=emu)!' % self.__class__.__name__)
 
-    def reduce(self, emu=None, foo=False):
+    def reduce(self, emu=None, foo=True):
         '''
         Algebraic reduction and operator folding where possible.
 

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -511,7 +511,7 @@ class Call(SymbolikBase):
         args = []
         for symkid in self.kids[1:]:
             args.append(symkid._reduce(emu=emu))
-        return Call(self.kids[0]._reduce(emu=emu), self.width._reduce(emu=emu), args)
+        return Call(self.kids[0]._reduce(emu=emu), self.width, args)
 
     def _solve(self, emu=None, vals=None):
         ret = 0

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -247,14 +247,15 @@ class SymbolikBase:
         def doreduce(path, oldkid, ctx):
             return oldkid._reduce(emu=emu)
 
-        sym = self
-        symstr = str(self)
-        while True:
-            sym = sym.walkTree(doreduce)
-            s1str = str(sym)
-            if s1str == symstr:
-                break
-            symstr = s1str
+        sym = self.walkTree(doreduce, once=True)
+        if foo:
+            symstr = str(sym)
+            while True:
+                sym = sym.walkTree(doreduce)
+                s1str = str(sym)
+                if s1str == symstr:
+                    break
+                symstr = s1str
 
         return sym
 

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -247,15 +247,14 @@ class SymbolikBase:
         def doreduce(path, oldkid, ctx):
             return oldkid._reduce(emu=emu)
 
-        sym = self.walkTree(doreduce, once=True)
-        if foo:
-            symstr = str(sym)
-            while True:
-                sym = sym.walkTree(doreduce)
-                s1str = str(sym)
-                if s1str == symstr:
-                    break
-                symstr = s1str
+        sym = self
+        symstr = str(self)
+        while True:
+            sym = sym.walkTree(doreduce)
+            s1str = str(sym)
+            if s1str == symstr:
+                break
+            symstr = s1str
 
         return sym
 
@@ -263,7 +262,7 @@ class SymbolikBase:
         '''
         Algebraic reduction and operator folding where possible.
         '''
-        return None
+        return self
 
     def update(self, emu):
         '''
@@ -511,8 +510,8 @@ class Call(SymbolikBase):
     def _reduce(self, emu=None):
         args = []
         for symkid in self.kids[1:]:
-            args.append(symkid.reduce(emu=emu))
-        return Call(self.kids[0].reduce(emu=emu), self.width, args)
+            args.append(symkid._reduce(emu=emu))
+        return Call(self.kids[0]._reduce(emu=emu), self.width._reduce(emu=emu), args)
 
     def _solve(self, emu=None, vals=None):
         ret = 0
@@ -582,7 +581,7 @@ class Mem(SymbolikBase):
         return self.kids[1].solve()
 
     def _reduce(self, emu):
-        return Mem(self.kids[0].reduce(), self.kids[1].reduce())
+        return Mem(self.kids[0]._reduce(emu=emu), self.kids[1]._reduce(emu=emu))
 
 class Var(SymbolikBase):
 
@@ -835,7 +834,7 @@ class Operator(SymbolikBase):
 
     def _op_reduce(self, v1, v1val, v2, v2val, emu):
         # Override this to do per operator special reduction
-        return None
+        return self
 
     def update(self, emu):
         v1 = self.kids[0].update(emu)

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -306,7 +306,7 @@ class SymbolikBase:
         for obj in root_symobjs:
             obj.clearCache()
         '''
-        if idx > len(self.kids)-1:
+        if idx > len(self.kids) - 1:
             self.kids.append(kid)
             self.kids[idx].parents.append(self)
         else:
@@ -373,7 +373,6 @@ class SymbolikBase:
         while True:
             # follow kids if there are any left...
             if idx < len(cur.kids):
-                # sys.stdout.write('+')
                 kid = cur.kids[idx]
                 if once and kid._sym_id in done:
                     idx += 1
@@ -393,12 +392,12 @@ class SymbolikBase:
             newb = cb(path, cur, ctx)
             path.pop()          # clean up, since our algorithm doesn't expect cur on the top...
 
-            done.add(cur._sym_id)
-
-            if not len(path):
+            if not path:
                 if newb:
                     return newb
                 return cur
+
+            done.add(cur._sym_id)
 
             # pop back up a level
             cur = path.pop()

--- a/vivisect/symboliks/tests/test_reduce.py
+++ b/vivisect/symboliks/tests/test_reduce.py
@@ -131,7 +131,7 @@ class TestReduceCase(unittest.TestCase):
         expr = Call(Const(0x400, 8), Const(8, 8), argsyms=[arg,])
 
         expr = expr.reduce()
-        self.assertEqual(str(expr), '1024((mem[0x00014000:8] ^ 0))')
+        self.assertEqual(str(expr), '1024(mem[0x00014000:8])')
 
         op = (Const(0x1000, 8) - Const(0xb90, 8)) - Const(0x60, 8)
         arg = (Mem(Const(0x14000, 8), Const(8, 8)) ^ op) ^ op

--- a/vivisect/tests/testvivisect.py
+++ b/vivisect/tests/testvivisect.py
@@ -842,7 +842,7 @@ class VivisectTest(unittest.TestCase):
         vw.clearOpcache()
         self.assertEqual(len(vw._op_cache), 0)
 
-        op = vw.parseOpcode(0x140010ef2, skip=True)
+        op = vw.parseOpcode(0x140010ef2, skipcache=True)
         self.assertEqual(str(op), 'mov rax,qword [rsi + 56]')
         self.assertEqual(len(vw._op_cache), 0)
 

--- a/vivisect/tests/testvivisect.py
+++ b/vivisect/tests/testvivisect.py
@@ -835,3 +835,17 @@ class VivisectTest(unittest.TestCase):
             self.assertEqual(msize, ssize)
             self.assertEqual(flags, ans[sname][2])
             self.assertEqual(mfname, sfname)
+
+    def test_opcache(self):
+        vw = self.firefox_vw
+        self.assertGreater(len(vw._op_cache), 0)
+        vw.clearOpcache()
+        self.assertEqual(len(vw._op_cache), 0)
+
+        op = vw.parseOpcode(0x140010ef2, skip=True)
+        self.assertEqual(str(op), 'mov rax,qword [rsi + 56]')
+        self.assertEqual(len(vw._op_cache), 0)
+
+        op = vw.parseOpcode(0x140010ef2)
+        self.assertEqual(str(op), 'mov rax,qword [rsi + 56]')
+        self.assertEqual(len(vw._op_cache), 1)


### PR DESCRIPTION
3 main things in this PR:
* I wanted to bring up caching opcodes again since we do that all over the place and it would be good to try and make that as fast as possible without inducing a bunch of cache thrashing.
* There are some experimental changes to symboliks that I wanted to discuss that hopefully speed things up.
* Main speedup though is in vivisect/analysis/generic/pointers.py. The creation of pointers was O(n^2), which was causing all sorts of performance problems. So instead, I treat the pointers like a somewhat connected graph, since I realized pointers essentially form a bunch of trees. Didn't have to change any of the tests, worked fine, and from looking at the Elf tests in testelf.py, reduces analysis time anywhere from 20% to 80%, with an average of ~40%.

The first two I can rip out as need be. They're helpful but I'm no beholden to them. The pointers one though I feel is fairly important since it has a huge effect on performance.