### PR TITLE
Drop readthedocs python version to the next highest one we support.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,5 @@
 python:
-  version: 3.9
+  version: 3.8
   pip_install: true
   extra_requirements:
     - docs


### PR DESCRIPTION
readthedocs didn't like that I specified version 3.9.