### PR TITLE
Safeguard codeblocks.py as it counts mnemonics

### DIFF
--- a/vivisect/analysis/generic/codeblocks.py
+++ b/vivisect/analysis/generic/codeblocks.py
@@ -75,8 +75,11 @@ def analyzeFunction(vw, funcva):
                 brefs.append((va, False))
                 break
 
-            op = vw.parseOpcode(va)     # parseOpcode() pulls arch from the location db, if exists
-            mnem[op.mnem] += 1
+            try:
+                op = vw.parseOpcode(va)     # parseOpcode() pulls arch from the location db, if exists
+                mnem[op.mnem] += 1
+            except Exception:
+                pass
             size += lsize
             opcount += 1
             nextva = va + lsize

--- a/vivisect/analysis/generic/codeblocks.py
+++ b/vivisect/analysis/generic/codeblocks.py
@@ -80,7 +80,7 @@ def analyzeFunction(vw, funcva):
                 mnem[op.mnem] += 1
             except Exception:
                 logger.warning('Codeblock bad opcode at 0x%x, ignoring error %s', va, e)
-                pass
+                break
             size += lsize
             opcount += 1
             nextva = va + lsize

--- a/vivisect/analysis/generic/codeblocks.py
+++ b/vivisect/analysis/generic/codeblocks.py
@@ -79,6 +79,7 @@ def analyzeFunction(vw, funcva):
                 op = vw.parseOpcode(va)     # parseOpcode() pulls arch from the location db, if exists
                 mnem[op.mnem] += 1
             except Exception:
+                logger.warning('Codeblock bad opcode at 0x%x, ignoring error %s', va, e)
                 pass
             size += lsize
             opcount += 1


### PR DESCRIPTION
Counting the mnemonics can raise an exception, causing premature termination of analyzeFunction() in codeblocks.py.  The mnemonics count is used in instrhook.py and does nothing constructive for codeblocks.py.  Usually the exception is InvalidInstruction but I have seen others; therefore, recommending to handle the general Exception.

Example in VirusTotal:  0030688c20e9b36d8e619d04c23ebf78.  Exceptions cause code blocks at 0x808cfa0, 0x8070480, 0x8062f30, and other places to be missed during vw.analyze().