### PR TITLE
Fix vstruct number issue

### DIFF
--- a/vivisect/tests/teststruct.py
+++ b/vivisect/tests/teststruct.py
@@ -28,4 +28,7 @@ class StructTest(unittest.TestCase):
         self.assertEqual(vs.foo, 0x03020100)
         self.assertEqual(vs.bar, 0x07060504)
         self.assertEqual(vs.baz, 0x0b0a0908)
-        self.assertEqual(vs.biz, 0xfffefdfc)
+        self.assertEqual(vs.biz, -0x010204)
+
+        fd.seek(0)
+        self.assertEqual(vs.vsEmit(), fd.read())

--- a/vstruct/primitives.py
+++ b/vstruct/primitives.py
@@ -123,14 +123,31 @@ class v_prim(v_base):
 
 
 num_fmts = {
+    # big endian unsigned
     (True, 1): '>B',
     (True, 2): '>H',
     (True, 4): '>I',
     (True, 8): '>Q',
+
+    # little endian unsigned
     (False, 1): '<B',
     (False, 2): '<H',
     (False, 4): '<I',
     (False, 8): '<Q',
+}
+
+signed_fmts = {
+    # big endian signed
+    (True, 1): '>b',
+    (True, 2): '>h',
+    (True, 4): '>i',
+    (True, 8): '>q',
+
+    # little endian signed
+    (False, 1): '<b',
+    (False, 2): '<h',
+    (False, 4): '<i',
+    (False, 8): '<q',
 }
 
 
@@ -140,13 +157,13 @@ class v_number(v_prim):
     def __init__(self, value=0, bigend=False, enum=None):
         v_prim.__init__(self)
         self._vs_bigend = bigend
-        self._vs_value = value
         self._vs_enum = enum
         self._vs_length = self.__class__._vs_length
         self._vs_fmt = num_fmts.get((bigend, self._vs_length))
 
         # TODO: could use envi.bits, but do we really want to dep on envi?
         self.maxval = (2 ** (8 * self._vs_length)) - 1
+        self.vsSetValue(value)
 
     def vsGetValue(self):
         return self._vs_value
@@ -171,7 +188,7 @@ class v_number(v_prim):
         else:
             r = []
             for i in range(self._vs_length):
-                r.append(ord(fbytes[offset + i]))
+                r.append(fbytes[offset + i])
 
             if not self._vs_bigend:
                 r.reverse()
@@ -328,12 +345,12 @@ class v_number(v_prim):
 class v_snumber(v_number):
     _vs_length = 1
 
-    def __init__(self, value=0, bigend=False):
-        v_number.__init__(self, value=value, bigend=bigend)
-
-        # TODO: could use envi.bits, but do we really want to dep on envi?
+    def __init__(self, value=0, bigend=False, enum=None):
         smaxval = (2**((8 * self._vs_length)-1)) - 1
         self.smask = smaxval + 1
+
+        v_number.__init__(self, value=value, bigend=bigend, enum=enum)
+        self._vs_fmt = signed_fmts.get((bigend, self._vs_length))
 
     def vsSetValue(self, value):
         value = value & self.maxval

--- a/vstruct/tests/testbasic.py
+++ b/vstruct/tests/testbasic.py
@@ -299,3 +299,44 @@ class VStructTest(unittest.TestCase):
         s.vsParse(bytez)
         self.assertEqual(s.vsGetValue(), "accelerator.dll")
         self.assertEqual(s.vsEmit(), b'a\x00c\x00c\x00e\x00l\x00e\x00r\x00a\x00t\x00o\x00r\x00.\x00d\x00l\x00l\x00\x00\x00')
+
+    def test_unsigned(self):
+        s = v_uint16(value=17)
+        byts = s.vsEmit()
+        self.assertEqual(b'\x11\x00', byts)
+
+        new = v_uint16()
+        new.vsParse(byts)
+        self.assertEqual(new.vsEmit(), s.vsEmit())
+
+        # test class that skips by having a real format
+        class v_silly(v_number):
+            _vs_builder = True
+            _vs_length = 5
+
+        num = v_silly(value=1947824, bigend=True)
+        byts = num.vsEmit()
+        self.assertEqual(b'\x00\x00\x1d\xb8\xb0', byts)
+
+        othr = v_silly(bigend=True)
+        othr.vsParse(byts)
+        self.assertEqual(othr, num)
+
+    def test_signed(self):
+        s = v_int16(value=-1)
+        self.assertEqual(b'\xff\xff', s.vsEmit())
+
+        s.vsSetValue(1)
+        self.assertEqual(b'\x01\x00', s.vsEmit())
+
+        s = v_int16(value=-1, bigend=True)
+        self.assertEqual(b'\xff\xff', s.vsEmit())
+
+        s.vsSetValue(1)
+        self.assertEqual(b'\x00\x01', s.vsEmit())
+
+        s = v_int32(value=32)
+        self.assertEqual(b'\x20\x00\x00\x00', s.vsEmit())
+
+        s = v_int32(value=-32)
+        self.assertEqual(b'\xe0\xff\xff\xff', s.vsEmit())


### PR DESCRIPTION
Hey look, an actually somewhat targeted PR for once!

But seriously, @atlas0fd00m found a bug in vstruct emitting for signed numbers. Took the delta he submitted and carried it over the finish line with some tests, and wrapped in a couple other fixes. One for when we don't have a vs_fmt for numbers (old ord call that didn't get removed) and add enums to the v_snumber constructor to make it match the base v_number constructor.