### PR TITLE
Change amd64 symboliks callconv class declaration

### DIFF
--- a/vivisect/symboliks/archs/amd64.py
+++ b/vivisect/symboliks/archs/amd64.py
@@ -212,10 +212,10 @@ class Amd64SymbolikTranslator(vsym_i386.IntelSymbolikTranslator):
 class Amd64ArgDefSymEmu(vsym_i386.ArgDefSymEmu):
     __xlator__ = Amd64SymbolikTranslator
 
-class MSx64CallSym(e_amd64.MSx64Call, vsym_callconv.SymbolikCallingConvention):
+class MSx64CallSym(vsym_callconv.SymbolikCallingConvention, e_amd64.MSx64Call):
     __argdefemu__ = Amd64ArgDefSymEmu
 
-class SysVAmd64CallSym(e_amd64.SysVAmd64Call, vsym_callconv.SymbolikCallingConvention):
+class SysVAmd64CallSym(vsym_callconv.SymbolikCallingConvention, e_amd64.SysVAmd64Call):
     __argdefemu__ = Amd64ArgDefSymEmu
 
 msx64callsym = MSx64CallSym()

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -66,16 +66,6 @@ def cb_astNodeCount(path,obj,ctx):
     if len(path) > ctx['depth']:
         ctx['depth'] = len(path)
 
-def intify(func):
-    def wrapper(*args, **kwargs):
-        obj = args[0]
-        other = args[1]
-        if type(other) is int:
-            other = Const(other, obj.getWidth())
-        return func(obj, other)
-
-    return wrapper
-
 class SymbolikBase:
     idgen = itertools.count()
 
@@ -89,91 +79,69 @@ class SymbolikBase:
         self.parents = []
         self.cache = {}
 
-    @intify
     def __add__(self, other):
         return o_add(self, other, self.getWidth())
 
-    @intify
     def __iadd__(self, other):
         return o_add(self, other, self.getWidth())
 
-    @intify
     def __sub__(self, other):
         return o_sub(self, other, self.getWidth())
 
-    @intify
     def __isub__(self, other):
         return o_sub(self, other, self.getWidth())
 
-    @intify
     def __xor__(self, other):
         return o_xor(self, other, self.getWidth())
 
-    @intify
     def __ixor__(self, other):
         return o_xor(self, other, self.getWidth())
 
-    @intify
     def __lshift__(self, count):
         return o_lshift(self, count, self.getWidth())
 
-    @intify
     def __ilshift__(self, count):
         return o_lshift(self, count, self.getWidth())
 
-    @intify
     def __rshift__(self, count):
         return o_rshift(self, count, self.getWidth())
 
-    @intify
     def __irshift__(self, count):
         return o_rshift(self, count, self.getWidth())
 
-    @intify
     def __or__(self, other):
         return o_or(self, other, self.getWidth())
 
-    @intify
     def __ior__(self, other):
         return o_or(self, other, self.getWidth())
 
-    @intify
     def __and__(self, other):
         return o_and(self, other, self.getWidth())
 
-    @intify
     def __iand__(self, other):
         return o_and(self, other, self.getWidth())
 
-    @intify
     def __mod__(self, other):
         return o_mod(self, other, self.getWidth())
 
-    @intify
     def __imod__(self, other):
         return o_mod(self, other, self.getWidth())
 
-    @intify
     def __mul__(self, other):
         return o_mul(self, other, self.getWidth())
 
-    @intify
     def __imul__(self, other):
         return o_mul(self, other, self.getWidth())
 
-    @intify
     def __truediv__(self, other):
         return o_div(self, other, self.getWidth())
 
-    @intify
     def __idiv__(self, other):
         return o_div(self, other, self.getWidth())
 
-    @intify
     def __floordiv__(self, other):
         return o_div(self, other, self.getWidth())
 
-    @intify
     def __pow__(self, other):
         return o_pow(self, other, self.getWidth())
 

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -71,7 +71,6 @@ def intify(func):
         obj = args[0]
         other = args[1]
         if type(other) is int:
-            breakpoint()
             other = Const(other, obj.getWidth())
         return func(obj, other)
 

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -2,7 +2,6 @@ import hashlib
 import operator
 import functools
 import itertools
-import collections
 
 import vstruct
 import envi.bits as e_bits
@@ -67,6 +66,17 @@ def cb_astNodeCount(path,obj,ctx):
     if len(path) > ctx['depth']:
         ctx['depth'] = len(path)
 
+def intify(func):
+    def wrapper(*args, **kwargs):
+        obj = args[0]
+        other = args[1]
+        if type(other) is int:
+            breakpoint()
+            other = Const(other, obj.getWidth())
+        return func(obj, other)
+
+    return wrapper
+
 class SymbolikBase:
     idgen = itertools.count()
 
@@ -80,69 +90,91 @@ class SymbolikBase:
         self.parents = []
         self.cache = {}
 
+    @intify
     def __add__(self, other):
         return o_add(self, other, self.getWidth())
 
+    @intify
     def __iadd__(self, other):
         return o_add(self, other, self.getWidth())
 
+    @intify
     def __sub__(self, other):
         return o_sub(self, other, self.getWidth())
 
+    @intify
     def __isub__(self, other):
         return o_sub(self, other, self.getWidth())
 
+    @intify
     def __xor__(self, other):
         return o_xor(self, other, self.getWidth())
 
+    @intify
     def __ixor__(self, other):
         return o_xor(self, other, self.getWidth())
 
+    @intify
     def __lshift__(self, count):
         return o_lshift(self, count, self.getWidth())
 
+    @intify
     def __ilshift__(self, count):
         return o_lshift(self, count, self.getWidth())
 
+    @intify
     def __rshift__(self, count):
         return o_rshift(self, count, self.getWidth())
 
+    @intify
     def __irshift__(self, count):
         return o_rshift(self, count, self.getWidth())
 
+    @intify
     def __or__(self, other):
         return o_or(self, other, self.getWidth())
 
+    @intify
     def __ior__(self, other):
         return o_or(self, other, self.getWidth())
 
+    @intify
     def __and__(self, other):
         return o_and(self, other, self.getWidth())
 
+    @intify
     def __iand__(self, other):
         return o_and(self, other, self.getWidth())
 
+    @intify
     def __mod__(self, other):
         return o_mod(self, other, self.getWidth())
 
+    @intify
     def __imod__(self, other):
         return o_mod(self, other, self.getWidth())
 
+    @intify
     def __mul__(self, other):
         return o_mul(self, other, self.getWidth())
 
+    @intify
     def __imul__(self, other):
         return o_mul(self, other, self.getWidth())
 
+    @intify
     def __truediv__(self, other):
         return o_div(self, other, self.getWidth())
 
+    @intify
     def __idiv__(self, other):
         return o_div(self, other, self.getWidth())
 
+    @intify
     def __floordiv__(self, other):
         return o_div(self, other, self.getWidth())
 
+    @intify
     def __pow__(self, other):
         return o_pow(self, other, self.getWidth())
 


### PR DESCRIPTION
So AMD64's old class declarations for the calling conventions meant that instead of the `_dealloc method in `vivisect/symboliks/callconv.py` being called, it would call the one in `envi/__init__.py`, which would occasionally explode in an "int has no property kids" exception. 

Python 3 MRO means we want `SymbolikCallingConvention` as the first parent so that we get the right `_dealloc` method and other overrides.