### PR TITLE
analysis: remove reference to impapi.windows.arm

### DIFF
--- a/vivisect/analysis/__init__.py
+++ b/vivisect/analysis/__init__.py
@@ -39,7 +39,6 @@ def addAnalysisModules(vw):
             vw.addStructureModule('ntdll', 'vstruct.defs.windows.win_6_1_amd64.ntdll')
 
         elif arch in ARM_ARCHS:
-            vw.addImpApi('windows','arm')
             vw.addFuncAnalysisModule('vivisect.analysis.arm.renaming')
 
         vw.addConstModule('vstruct.constants.ntstatus')


### PR DESCRIPTION
closes #423

a better fix is to actually implement this file; however, i don't have the logic handy and i wonder if it sitting on @atlas0fd00m computer not yet checked in?