### PR TITLE
handle PE delay import tables with VA pointers instead of RVA pointers

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -496,6 +496,13 @@ class PE(object):
     def getSections(self):
         return self.sections
 
+    def vaToOffset(self, va):
+        if self.inmem:
+            return va
+
+        rva = va - self.IMAGE_NT_HEADERS.OptionalHeader.ImageBase
+        return self.rvaToOffset(rva)
+ 
     def rvaToOffset(self, rva):
         if self.inmem:
             return rva
@@ -760,6 +767,10 @@ class PE(object):
         if self.psize == 8:
             fmt = "<Q"
         return struct.unpack(fmt, self.readAtOffset(off, self.psize))[0]
+
+    def readPointerAtVa(self, va):
+        off = self.vaToOffset(va)
+        return self.readPointerAtOffset(off)
 
     def readPointerAtRva(self, rva):
         off = self.rvaToOffset(rva)

--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -389,6 +389,7 @@ class PE(object):
         object.__init__(self)
         self.inmem = inmem
         self.filesize = None
+        self.min_rva = None
         self.max_rva = None
 
         if not inmem:
@@ -763,6 +764,14 @@ class PE(object):
     def readPointerAtRva(self, rva):
         off = self.rvaToOffset(rva)
         return self.readPointerAtOffset(off)
+
+    def getMinRva(self):
+        '''
+        Minimum RVA is the smallest virtual address that might be observed.
+        '''
+        if not self.min_rva:
+            self.min_rva = min(map(lambda sec: sec.VirtualAddress, self.getSections()))
+        return self.min_rva
 
     def getMaxRva(self):
         '''


### PR DESCRIPTION
closes #438 

I'm sorry there's so much new code, but I've commented thoroughly so its clear what I'm doing and why. In theory, this code is only relevant for VS6 binaries (uncommon).