### PR TITLE
fix PE carving

### DIFF
--- a/PE/carve.py
+++ b/PE/carve.py
@@ -8,7 +8,7 @@ from itertools import cycle
 import PE
 
 
-MAX_OFFSET_PE_AFTER_MZ = 0x100
+MAX_OFFSET_PE_AFTER_MZ = 0x200
 
 
 def xorbytes(data, key):

--- a/PE/carve.py
+++ b/PE/carve.py
@@ -8,6 +8,9 @@ from itertools import cycle
 import PE
 
 
+MAX_OFFSET_PE_AFTER_MZ = 0x100
+
+
 def xorbytes(data, key):
     return bytes([(x ^ y) for (x, y) in zip(data, cycle(key))])
 
@@ -44,6 +47,10 @@ def carve(pbytes, offset=0):
         if nextres != -1:
             todo.append((nextres, mzx, pex, i))
 
+        # PE header should occur soon after MZ
+        if newoff > MAX_OFFSET_PE_AFTER_MZ:
+            continue
+
         peoff = off + newoff
         if pblen < (peoff + 2):
             continue
@@ -58,6 +65,8 @@ class CarvedPE(PE.PE):
         self.fbytes = fbytes
         self.xorkey = xkey
         PE.PE.__init__(self, BytesIO())
+        # ensure sections can be parsed
+        self.getSections()
 
     def readAtOffset(self, offset, size):
         offset += self.carved_offset
@@ -65,7 +74,7 @@ class CarvedPE(PE.PE):
 
     def getFileSize(self):
         ret = 0
-        for sec in self.getSections():
+        for sec in self.sections:
             ret = max(ret, sec.PointerToRawData + sec.SizeOfRawData)
         return ret
 

--- a/vivisect/parsers/pe.py
+++ b/vivisect/parsers/pe.py
@@ -527,6 +527,7 @@ def loadPeIntoWorkspace(vw, pe, filename=None, baseaddr=None):
                 # ensure sub-pe can be parsed
                 subpe = pe_carve.CarvedPE(fbytes, offset, [i])
             except vivisect.exc.CorruptPeFile:
+                logger.warning("could not parse carved PE at offset 0x%x, XOR key: 0x%x", offset, i)
                 continue
 
             pebytes = subpe.readAtOffset(0, subpe.getFileSize())

--- a/vivisect/parsers/pe.py
+++ b/vivisect/parsers/pe.py
@@ -523,8 +523,12 @@ def loadPeIntoWorkspace(vw, pe, filename=None, baseaddr=None):
         pe.fd.seek(0)
         fbytes = pe.fd.read()
         for offset, i in pe_carve.carve(fbytes, 1):
-            # Found a sub-pe!
-            subpe = pe_carve.CarvedPE(fbytes, offset, [i])
+            try:
+                # ensure sub-pe can be parsed
+                subpe = pe_carve.CarvedPE(fbytes, offset, [i])
+            except vivisect.exc.CorruptPeFile:
+                continue
+
             pebytes = subpe.readAtOffset(0, subpe.getFileSize())
             rva = pe.offsetToRva(offset) + baseaddr
             vw.markDeadData(rva, rva+len(pebytes))


### PR DESCRIPTION
For the file with MD5 hash 0761142efbda6c4b1e801223de723578 the PE carver falsely finds an XOR encoded (key 8) PE starting at offset 0x4CE83B.

This PR adds code to ensure that
- the PE header occurs shortly after the MZ header
- the sections of a parse PE can be parsed