### PR TITLE
S00perEASY-bugfix: RemoteWorkspaceAnalysisModules

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -630,6 +630,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
         self.server.vprint('%s connecting...' % uname)
         wsevents = self.server.exportWorkspace()
         self.importWorkspace(wsevents)
+        self._snapInAnalysisModules()
         self.server.vprint('%s connection complete!' % uname)
 
         thr = threading.Thread(target=self._clientThread)


### PR DESCRIPTION
we recreate the workspace through the proxy, but never snap in the appropriate analysis modules.  this likely dates back to the days when analysis modules were added to the eventlist.