### PR TITLE
i386: emu: rep(n)z repmax handling

### DIFF
--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -311,7 +311,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         while ecx and repmax and not emu.getFlag(EFLAGS_ZF):
             ret = meth(op)
             ecx -= 1
-            ecx -= 1
+            repmax -= 1
             emu.setRegister(REG_ECX, ecx)
         return ret
 

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -283,7 +283,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
             repmax = min(ecx, repmax)
 
         ret = None
-        while ecx and repmap and emu.getFlag(EFLAGS_ZF):
+        while ecx and repmax and emu.getFlag(EFLAGS_ZF):
             ret = meth(op)
             ecx -= 1
             repmax -= 1

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -279,9 +279,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         ecx = emu.getRegister(REG_ECX)
         emu.setFlag(EFLAGS_ZF, 1)
 
-        repmax = emu.getEmuOpt('i386:repmax') or sys.maxsize
-        if repmax:
-            repmax = min(ecx, repmax)
+        repmax = emu.getEmuOpt('i386:repmax') or ecx
 
         ret = None
         while ecx and repmax and emu.getFlag(EFLAGS_ZF):
@@ -304,9 +302,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         ecx = emu.getRegister(REG_ECX)
         emu.setFlag(EFLAGS_ZF, 0)
 
-        repmax = emu.getEmuOpt('i386:repmax') or sys.maxsize
-        if repmax:
-            repmax = min(ecx, repmax)
+        repmax = emu.getEmuOpt('i386:repmax') or ecx
 
         ret = None
         while ecx and repmax and not emu.getFlag(EFLAGS_ZF):

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -272,18 +272,21 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         ZF starts off being set. 
         Then the instruction is repeated and ECX decremented until either
         ECX reaches 0 or the ZF is cleared.
+        
+        Respects emu option "i386:repmax" limiting the number of repetitions.
         '''
         ecx = emu.getRegister(REG_ECX)
         emu.setFlag(EFLAGS_ZF, 1)
 
         repmax = emu.getEmuOpt('i386:repmax')
         if repmax:
-            ecx = min(ecx, repmax)
+            repmax = min(ecx, repmax)
 
         ret = None
-        while ecx and emu.getFlag(EFLAGS_ZF):
+        while ecx and repmap and emu.getFlag(EFLAGS_ZF):
             ret = meth(op)
             ecx -= 1
+            repmax -= 1
             emu.setRegister(REG_ECX, ecx)
         return ret
 
@@ -294,17 +297,20 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         ZF starts off being cleared. 
         Then the instruction is repeated and ECX decremented until either
         ECX reaches 0 or the ZF is set.
+        
+        Respects emu option "i386:repmax" limiting the number of repetitions.
         '''
         ecx = emu.getRegister(REG_ECX)
         emu.setFlag(EFLAGS_ZF, 0)
 
         repmax = emu.getEmuOpt('i386:repmax')
         if repmax:
-            ecx = min(ecx, repmax)
+            repmax = min(ecx, repmax)
 
         ret = None
-        while ecx and not emu.getFlag(EFLAGS_ZF):
+        while ecx and repmax and not emu.getFlag(EFLAGS_ZF):
             ret = meth(op)
+            ecx -= 1
             ecx -= 1
             emu.setRegister(REG_ECX, ecx)
         return ret

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -1,6 +1,7 @@
 """
 Home for the i386 emulation code.
 """
+import sys
 import struct
 import operator
 
@@ -278,7 +279,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         ecx = emu.getRegister(REG_ECX)
         emu.setFlag(EFLAGS_ZF, 1)
 
-        repmax = emu.getEmuOpt('i386:repmax')
+        repmax = emu.getEmuOpt('i386:repmax') or sys.maxsize
         if repmax:
             repmax = min(ecx, repmax)
 
@@ -303,7 +304,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         ecx = emu.getRegister(REG_ECX)
         emu.setFlag(EFLAGS_ZF, 0)
 
-        repmax = emu.getEmuOpt('i386:repmax')
+        repmax = emu.getEmuOpt('i386:repmax') or sys.maxsize
         if repmax:
             repmax = min(ecx, repmax)
 

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -1,7 +1,6 @@
 """
 Home for the i386 emulation code.
 """
-import sys
 import struct
 import operator
 

--- a/envi/tests/test_arch_i386_emu.py
+++ b/envi/tests/test_arch_i386_emu.py
@@ -220,12 +220,11 @@ class i386EmulatorTests(unittest.TestCase, IntelEmulatorTests):
         emu32.setRegisterByName('ecx', -1)
         emu32.setRegisterByName('edi', 0x40000000)
         emu32.executeOpcode(op_scasb)
-        self.assertEqual(emu32.getRegisterByName('ecx'), 0xfffffff1)
+        self.assertEqual(emu32.getRegisterByName('ecx'), 0xffffffff - len("foobarbazbane\x00"))
 
         # repz Byte scan string
         emu32.setRegisterByName('eax', 0)
         emu32.setRegisterByName('ecx', -1)
         emu32.setRegisterByName('edi', 0x4000000d)
         emu32.executeOpcode(op_zscasb)
-        self.assertEqual(emu32.getRegisterByName('ecx'), 0xfffffffb)
-
+        self.assertEqual(emu32.getRegisterByName('ecx'), 0xffffffff - len("\x00\x00\x00f"))

--- a/envi/tests/test_arch_i386_emu.py
+++ b/envi/tests/test_arch_i386_emu.py
@@ -228,3 +228,29 @@ class i386EmulatorTests(unittest.TestCase, IntelEmulatorTests):
         emu32.setRegisterByName('edi', 0x4000000d)
         emu32.executeOpcode(op_zscasb)
         self.assertEqual(emu32.getRegisterByName('ecx'), 0xffffffff - len("\x00\x00\x00f"))
+
+        # repnz Byte scan string with repmax
+        TEST_REPMAX = 2
+        orig_repmax = emu32.getEmuOpt("i386:repmax")
+        emu32.setEmuOpt("i386:repmax", TEST_REPMAX)
+
+        emu32.setRegisterByName('eax', 0)
+        emu32.setRegisterByName('ecx', -1)
+        emu32.setRegisterByName('edi', 0x40000000)
+        emu32.executeOpcode(op_scasb)
+        self.assertEqual(emu32.getRegisterByName('ecx'), 0xffffffff - min(TEST_REPMAX, len("foobarbazbane\x00")))
+
+        emu32.setEmuOpt("i386:repmax", orig_repmax)
+
+        # repz Byte scan string with repmax
+        TEST_REPMAX = 2
+        orig_repmax = emu32.getEmuOpt("i386:repmax")
+        emu32.setEmuOpt("i386:repmax", TEST_REPMAX)
+
+        emu32.setRegisterByName('eax', 0)
+        emu32.setRegisterByName('ecx', -1)
+        emu32.setRegisterByName('edi', 0x4000000d)
+        emu32.executeOpcode(op_zscasb)
+        self.assertEqual(emu32.getRegisterByName('ecx'), 0xffffffff - min(TEST_REPMAX, len("\x00\x00\x00f")))
+
+        emu32.setEmuOpt("i386:repmax", orig_repmax)


### PR DESCRIPTION
fix handling of REP prefix with `i386:repmax` configuration for sequences like:

```
.text:100010E9 BF 20 60 02 10          mov     edi, offset aHello ; "hello"
.text:100010EE 83 C9 FF                or      ecx, 0FFFFFFFFh
.text:100010F1 33 C0                   xor     eax, eax
.text:100010F3 6A 00                   push    0
.text:100010F5 F2 AE                   repne scasb
.text:100010F7 F7 D1                   not     ecx
.text:100010F9 49                      dec     ecx
.text:100010FA 51                      push    ecx
```

this `strlen()` implementation does not work today because `ecx` is clobbered by the repmax implementation. pull the repmax counter into its own variable.