### PR TITLE
fix opcache key creation

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1167,7 +1167,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             if loctup is not None and loctup[L_TINFO] and loctup[L_LTYPE] == LOC_OP:
                 arch = loctup[L_TINFO]
         if not skipcache:
-            key = (va, arch, b[:16])
+            key = (va, arch, b[off:off+16])
             valu = self._op_cache.get(key, None)
             if not valu:
                 valu = self.imem_archs[(arch & envi.ARCH_MASK) >> 16].archParseOpcode(b, off, va)


### PR DESCRIPTION
the existing implementation uses the exact same 16 bytes for comparison, so if the bytes ever actually *do* change, the key never changes so Viv keeps returning the same opcodes.