### PR TITLE
Enabling POSIX Library Load notifications

### DIFF
--- a/envi/threads.py
+++ b/envi/threads.py
@@ -19,8 +19,7 @@ def firethread(func):
     and callers may not expect sync behavior!
     '''
     def dothread(*args, **kwargs):
-        thr = threading.Thread(target=func, args=args, kwargs=kwargs)
-        thr.setDaemon(True)
+        thr = threading.Thread(target=func, args=args, kwargs=kwargs, daemon=True)
         thr.start()
         return thr
     functools.update_wrapper(dothread, func)
@@ -44,8 +43,7 @@ def maintthread(stime):
                 time.sleep(stime)
 
         def dothread(*args, **kwargs):
-            thr = threading.Thread(target=maintloop, args=args, kwargs=kwargs)
-            thr.setDaemon(True)
+            thr = threading.Thread(target=maintloop, args=args, kwargs=kwargs, daemon=True)
             thr.start()
 
         functools.update_wrapper(dothread, func)

--- a/vdb/__init__.py
+++ b/vdb/__init__.py
@@ -492,8 +492,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
             trace.setMeta('PendingBreak', False)
             bp = trace.getCurrentBreakpoint()
             if bp:
-                if not bp.silent:
-                    self.vprint("Thread: %d Hit Break: %s" % (tid, repr(bp)))
+                self.vprint("Thread: %d Hit Break: %s" % (tid, repr(bp)))
                 cmdstr = self.bpcmds.get(bp.id, None)
                 if cmdstr is not None:
                     self.onecmd(cmdstr)
@@ -1722,7 +1721,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
 
         where options include:
            -F  toggles a breakpoint's FastBreak mode
-           -S  toggles a breakpoint's Silent mode (prints a consolem message on break)
+           -S  toggles a breakpoint's Stealth mode (doesn't fire Notifiers, still runs BP code)
            -V  prints more metadata about a given breakpoint (default is just the code)
 
         NOTE: Your code must be surrounded by "s and may not
@@ -1751,12 +1750,10 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
                 verbose = True
 
             elif opt == '-S':
-                bp.silent = not bp.silent
-                bp = self.trace.getBreakpoint(bpid)
+                bp.stealthbreak = not bp.stealthbreak
 
             elif opt == '-F':
                 bp.fastbreak = not bp.fastbreak
-                bp = self.trace.getBreakpoint(bpid)
 
         if len(args) == 2:
             self.trace.setBreakpointCode(bpid, args[1])
@@ -1770,7 +1767,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
             self.vprint("    resonce:       %r" % bp.resonce)
             self.vprint("    active:        %r" % bp.active)
             self.vprint("    enabled:       %r" % bp.enabled)
-            self.vprint("    silent:        %r" % bp.silent)
+            self.vprint("    stealth:       %r" % bp.stealthbreak)
             if bp.untouchable:
                 self.vprint("    untouchable:   %r" % bp.untouchable)
 

--- a/vdb/__init__.py
+++ b/vdb/__init__.py
@@ -1843,7 +1843,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
 
             elif opt == "-C":
                 for bp in self.trace.getBreakpoints():
-                    if bp.untouchable:
+                    if bp.stealthbreak:
                         continue
 
                     self.bpcmds.pop(bp.id, None)
@@ -1914,8 +1914,8 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
 
         self.vprint(" [ Breakpoints ]")
         for bp in self.trace.getBreakpoints():
-            if bp.untouchable and not showall:
-                # don't list untouchable bp's (unless forced)
+            if bp.stealthbreak and not showall:
+                # don't list stealthbreak bp's (unless forced)
                 continue
             self._print_bp(bp)
 

--- a/vdb/__init__.py
+++ b/vdb/__init__.py
@@ -492,7 +492,8 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
             trace.setMeta('PendingBreak', False)
             bp = trace.getCurrentBreakpoint()
             if bp:
-                self.vprint("Thread: %d Hit Break: %s" % (tid, repr(bp)))
+                if not bp.silent:
+                    self.vprint("Thread: %d Hit Break: %s" % (tid, repr(bp)))
                 cmdstr = self.bpcmds.get(bp.id, None)
                 if cmdstr is not None:
                     self.onecmd(cmdstr)
@@ -574,7 +575,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
         if dohex:
             memstr = binascii.unhexlify(memstr)
         if douni:
-            memstr = ("\x00".join(memstr)) + "\x00"
+            memstr = (b"\x00".join(memstr)) + b"\x00"
 
         addr = self.parseExpression(exprstr)
         self.memobj.writeMemory(addr, memstr)
@@ -1861,6 +1862,8 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
 
         self.vprint(" [ Breakpoints ]")
         for bp in self.trace.getBreakpoints():
+            if bp.untouchable:  # don't list untouchable bp's
+                continue
             self._print_bp(bp)
 
     def _print_bp(self, bp):

--- a/vdb/__init__.py
+++ b/vdb/__init__.py
@@ -492,7 +492,8 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
             trace.setMeta('PendingBreak', False)
             bp = trace.getCurrentBreakpoint()
             if bp:
-                self.vprint("Thread: %d Hit Break: %s" % (tid, repr(bp)))
+                if not self.silent:
+                    self.vprint("Thread: %d Hit Break: %s" % (tid, repr(bp)))
                 cmdstr = self.bpcmds.get(bp.id, None)
                 if cmdstr is not None:
                     self.onecmd(cmdstr)
@@ -1721,7 +1722,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
 
         where options include:
            -F  toggles a breakpoint's FastBreak mode
-           -S  toggles a breakpoint's Stealth mode (doesn't fire Notifiers, still runs BP code)
+           -S  toggles a breakpoint's Silent mode (doesn't print console msg, still runs BP code)
            -V  prints more metadata about a given breakpoint (default is just the code)
 
         NOTE: Your code must be surrounded by "s and may not
@@ -1750,7 +1751,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
                 verbose = True
 
             elif opt == '-S':
-                bp.stealthbreak = not bp.stealthbreak
+                bp.silent = not bp.silent
 
             elif opt == '-F':
                 bp.fastbreak = not bp.fastbreak
@@ -1764,12 +1765,12 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
             self.vprint("%r" % bp)
             self.vprint("    code: %s" % (pystr))
             self.vprint("    FastBreak:     %r" % bp.fastbreak)
-            self.vprint("    resonce:       %r" % bp.resonce)
-            self.vprint("    active:        %r" % bp.active)
             self.vprint("    enabled:       %r" % bp.enabled)
-            self.vprint("    stealth:       %r" % bp.stealthbreak)
-            if bp.untouchable:
-                self.vprint("    untouchable:   %r" % bp.untouchable)
+            self.vprint("    silent:        %r" % bp.silent)
+            self.vprint("    active:        %r" % bp.active)
+            self.vprint("    resonce:       %r" % bp.resonce)
+            if bp.stealthbreak:
+                self.vprint("    stealth:       %r" % bp.stealthbreak)
 
         else:
             self.vprint("[%d] Breakpoint code: %s" % (bpid,pystr))

--- a/vtrace/__init__.py
+++ b/vtrace/__init__.py
@@ -713,20 +713,6 @@ class Trace(e_mem.IMemory, e_reg.RegisterContext, e_resolv.SymbolResolver, objec
         # Remove cached breakpoint code
         Breakpoint.bpcodeobj.pop(id, None)
 
-    def _updateBreakAddresses(self):
-        """
-        Update breakpoint address resolution (in unresolved breakpoints).
-        Intended to be run after events which change the namespace, such as
-        NOTIFY_LOAD_LIBRARY events
-        """
-        for bp in self.deferred:
-            bp.resolveAddress(self)
-            if bp.address is not None:
-                self.breakpoints[bp.address] = bp
-                self.deferred.remove(bp)
-                bp.activate(self)
-                logger.warning("Resolved bp address: %r", bp)
-
     def getCurrentBreakpoint(self):
         """
         Return the current breakpoint otherwise None

--- a/vtrace/__init__.py
+++ b/vtrace/__init__.py
@@ -699,7 +699,7 @@ class Trace(e_mem.IMemory, e_reg.RegisterContext, e_resolv.SymbolResolver, objec
         """
         self.requireAttached()
         bp = self.bpbyid.pop(id, None)
-        if bp is not None and not bp.untouchable:
+        if bp is not None and not bp.stealthbreak:
             bp.deactivate(self)
             if bp in self.deferred:
                 self.deferred.remove(bp)
@@ -760,7 +760,7 @@ class Trace(e_mem.IMemory, e_reg.RegisterContext, e_resolv.SymbolResolver, objec
         NOTE: code which wants to be remote-safe should use this
         """
         bp = self.getBreakpoint(bpid)
-        if bp is None or bp.untouchable:
+        if bp is None or bp.stealthbreak:
             raise Exception("Breakpoint %d Not Found" % bpid)
         if not enabled: # To catch the "disable" of fastbreaks...
             bp.deactivate(self)

--- a/vtrace/__init__.py
+++ b/vtrace/__init__.py
@@ -156,6 +156,11 @@ class Trace(e_mem.IMemory, e_reg.RegisterContext, e_resolv.SymbolResolver, objec
         # Add event numbers to here for auto-continue
         self.auto_continue = [NOTIFY_LOAD_LIBRARY, NOTIFY_CREATE_THREAD, NOTIFY_UNLOAD_LIBRARY, NOTIFY_EXIT_THREAD, NOTIFY_DEBUG_PRINT]
 
+        # Create a LoadLibrary hook to enable simple and consistent 
+        # Break-On-Load/Init functionality. This is also necessary for
+        # resolving symbols on new library loads.
+        self.registerNotifier(NOTIFY_LOAD_LIBRARY, LibraryNotifier())
+
     def execute(self, cmdline):
         """
         Start a new process and debug it
@@ -694,7 +699,7 @@ class Trace(e_mem.IMemory, e_reg.RegisterContext, e_resolv.SymbolResolver, objec
         """
         self.requireAttached()
         bp = self.bpbyid.pop(id, None)
-        if bp is not None:
+        if bp is not None and not bp.untouchable:
             bp.deactivate(self)
             if bp in self.deferred:
                 self.deferred.remove(bp)
@@ -707,6 +712,20 @@ class Trace(e_mem.IMemory, e_reg.RegisterContext, e_resolv.SymbolResolver, objec
 
         # Remove cached breakpoint code
         Breakpoint.bpcodeobj.pop(id, None)
+
+    def _updateBreakAddresses(self):
+        """
+        Update breakpoint address resolution (in unresolved breakpoints).
+        Intended to be run after events which change the namespace, such as
+        NOTIFY_LOAD_LIBRARY events
+        """
+        for bp in self.deferred:
+            bp.resolveAddress(self)
+            if bp.address is not None:
+                self.breakpoints[bp.address] = bp
+                self.deferred.remove(bp)
+                bp.activate(self)
+                logger.warning("Resolved bp address: %r", bp)
 
     def getCurrentBreakpoint(self):
         """
@@ -755,7 +774,7 @@ class Trace(e_mem.IMemory, e_reg.RegisterContext, e_resolv.SymbolResolver, objec
         NOTE: code which wants to be remote-safe should use this
         """
         bp = self.getBreakpoint(bpid)
-        if bp is None:
+        if bp is None or bp.untouchable:
             raise Exception("Breakpoint %d Not Found" % bpid)
         if not enabled: # To catch the "disable" of fastbreaks...
             bp.deactivate(self)

--- a/vtrace/breakpoints.py
+++ b/vtrace/breakpoints.py
@@ -424,4 +424,4 @@ class PosixLibLoadHookBreakpoint(Breakpoint):
     def notify(self, event, trace):
         logger.debug("PosixLibLoadHookBreakpoint: reanalyze maps and resolve symbols")
         trace._findLibraryMaps(b'\x7fELF', always=True)
-        # handle unresolved expression bp's 
+        trace.runAgain()

--- a/vtrace/breakpoints.py
+++ b/vtrace/breakpoints.py
@@ -31,7 +31,6 @@ class Breakpoint:
         self.active = False
         self.fastbreak = False      # no NOTIFY_BREAK, autocont, no NOTIFY_CONTINUE
         self.stealthbreak = False   # no NOTIFY_BREAK
-        self.silent = False
         self.untouchable = False    # system breakpoint.  can't remove it or see it.
         self._complained = False
 
@@ -419,7 +418,7 @@ class PosixLibLoadHookBreakpoint(Breakpoint):
     def __init__(self, expression):
         Breakpoint.__init__(self, None, expression=expression)
         self.untouchable = True
-        self.silent = True
+        self.stealthbreak = True
 
     def notify(self, event, trace):
         logger.debug("PosixLibLoadHookBreakpoint: reanalyze maps and resolve symbols")

--- a/vtrace/breakpoints.py
+++ b/vtrace/breakpoints.py
@@ -25,14 +25,14 @@ class Breakpoint:
     bpcodeobj = {} # Cache compiled code objects on the class def
 
     def __init__(self, address, expression=None):
-        self.resonce = False
+        self.resonce = False        # has this addr expression been resolved yet?
         self.address = address
-        self.enabled = True
-        self.active = False
+        self.enabled = True         # should this BP be used/ignored
+        self.active = False         # have we placed a BP in the code (eg. i386: \xCC)
+        self.silent = False         # don't print "Hit Break" messages, still runs code/notifiers
         self.fastbreak = False      # no NOTIFY_BREAK, autocont, no NOTIFY_CONTINUE
-        self.stealthbreak = False   # no NOTIFY_BREAK
-        self.untouchable = False    # system breakpoint.  can't remove it or see it.
-        self._complained = False
+        self.stealthbreak = False   # no NOTIFY_BREAK - used for hidden/system events
+        self._complained = False    # only complain about not resolving this *once*
 
         self.id = -1
         self.vte = None
@@ -417,10 +417,12 @@ class PosixLibLoadHookBreakpoint(Breakpoint):
     '''
     def __init__(self, expression):
         Breakpoint.__init__(self, None, expression=expression)
-        self.untouchable = True
         self.stealthbreak = True
 
     def notify(self, event, trace):
         logger.debug("PosixLibLoadHookBreakpoint: reanalyze maps and resolve symbols")
-        trace._findLibraryMaps(b'\x7fELF', always=True)
-        trace.runAgain()
+        if not trace._findLibraryMaps(b'\x7fELF', always=True):
+            # if we find new maps, we'll let the LOAD_LIBRARY Autoload config setting handle
+            # whether we continue or not.  if we fire this and *don't* find a new map, 
+            # let's just continue like nothing ever happened.  "Nothing to see here."
+            trace.runAgain()

--- a/vtrace/notifiers.py
+++ b/vtrace/notifiers.py
@@ -136,3 +136,12 @@ class DistributedNotifier(Notifier):
     def deregisterNotifier(self, event, notif):
         nlist = self.notifiers.get(event)
         nlist.remove(notif)
+
+class LibraryNotifier(Notifier):
+    def notify(self, event, trace):
+        logger.info("LibraryNotifier.notify(%r, %r)", event, trace)
+
+        # update unresolved breakpoints:
+        trace._updateBreakAddresses()
+
+

--- a/vtrace/platforms/base.py
+++ b/vtrace/platforms/base.py
@@ -537,6 +537,7 @@ class TracerBase(vtrace.Notifier):
         about a LOAD_LIBRARY. (This means *not* from inside another
         notifer)
         """
+        logger.info("addLibraryBase(%r, 0x%x, %r)", libname, address, always)
 
         self.setMeta("LatestLibrary", None)
         self.setMeta("LatestLibraryNorm", None)
@@ -878,7 +879,7 @@ class TracerBase(vtrace.Notifier):
 
 def threadwrap(func):
     def trfunc(self, *args, **kwargs):
-        if threading.currentThread().__class__ == TracerThread:
+        if threading.current_thread().__class__ == TracerThread:
             return func(self, *args, **kwargs)
         # Proxy the call through a single thread
         q = queue.Queue()
@@ -904,9 +905,8 @@ class TracerThread(threading.Thread):
     to make particular calls and on what platforms...  YAY!
     """
     def __init__(self):
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self.queue = queue.Queue()
-        self.setDaemon(True)
         self.start()
 
     def run(self):

--- a/vtrace/platforms/linux.py
+++ b/vtrace/platforms/linux.py
@@ -414,7 +414,7 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
             raise Exception("PT_ATTACH failed!")
         self.setMeta("ExeName", self._findExe(pid))
 
-    def _LibraryLoadHack(self):
+    def _LibraryLoadHook(self):
         # drop special breakpoint at ld._dl_catch_exception
         bp = v_bp.PosixLibLoadHookBreakpoint('ld._dl_catch_exception')
         self.addBreakpoint(bp)

--- a/vtrace/platforms/linux.py
+++ b/vtrace/platforms/linux.py
@@ -413,6 +413,12 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
             raise Exception("PT_ATTACH failed!")
         self.setMeta("ExeName", self._findExe(pid))
 
+    def _LibraryLoadHack(self):
+        # drop special breakpoint at ld._dl_catch_exception
+        import vtrace.breakpoints as v_bp
+        bp = v_bp.PosixLibLoadHookBreakpoint('ld._dl_catch_exception')
+        self.addBreakpoint(bp)
+
     def platformPs(self):
         pslist = []
         for dname in self.platformListDir('/proc'):

--- a/vtrace/platforms/linux.py
+++ b/vtrace/platforms/linux.py
@@ -17,6 +17,7 @@ import envi.memory as e_mem
 
 import vtrace
 import vtrace.exc as v_exc
+import vtrace.breakpoints as v_bp
 
 import vtrace.archs.arm as v_arm
 import vtrace.archs.i386 as v_i386
@@ -415,7 +416,6 @@ class LinuxMixin(v_posix.PtraceMixin, v_posix.PosixMixin):
 
     def _LibraryLoadHack(self):
         # drop special breakpoint at ld._dl_catch_exception
-        import vtrace.breakpoints as v_bp
         bp = v_bp.PosixLibLoadHookBreakpoint('ld._dl_catch_exception')
         self.addBreakpoint(bp)
 

--- a/vtrace/platforms/posix.py
+++ b/vtrace/platforms/posix.py
@@ -62,9 +62,9 @@ class PosixMixin:
         self.runAgain(False)  # Clear this, if they want BREAK to run, it will
         self.fireNotifiers(vtrace.NOTIFY_BREAK)
         # POSIX hack - Windows signals on library load, POSIX doesn't
-        self._LibraryLoadHack()
+        self._LibraryLoadHook()
         
-    def _LibraryLoadHack(self):
+    def _LibraryLoadHook(self):
         '''
         Implement at the platform level
         '''

--- a/vtrace/platforms/posix.py
+++ b/vtrace/platforms/posix.py
@@ -61,6 +61,14 @@ class PosixMixin:
         # break after our library load events to make things easy
         self.runAgain(False)  # Clear this, if they want BREAK to run, it will
         self.fireNotifiers(vtrace.NOTIFY_BREAK)
+        # POSIX hack - Windows signals on library load, POSIX doesn't
+        self._LibraryLoadHack()
+        
+    def _LibraryLoadHack(self):
+        '''
+        Implement at the platform level
+        '''
+        pass
 
     def platformProcessEvent(self, event):
         pid, status = event

--- a/vtrace/tests/testbasic.py
+++ b/vtrace/tests/testbasic.py
@@ -59,6 +59,6 @@ class VtraceBasicTest(vt_tests.VtraceProcessTest):
 class VtraceBasicExecTest(VtraceBasicTest, vt_tests.VtraceExecTest):
     breakpoints = {
         'windows': 'ntdll.NtTerminateProcess',
-        'linux': 'ld.malloc',
+        'linux': 'libc.malloc',
         'freebsd': 'ld._rtld_thread_init',
     }


### PR DESCRIPTION
 (since PTRACE event model doesn't alert on library loads like Windows does).

a couple other general bugfixes/deprecation-cleanup "because we're in the area."
this is ripped out of the Vtrace PR because it's important enough to get it's own

this does *not* include Break on Library Load/Init.  that is still in the vtrace PR.