### PR TITLE
added i386 opcode vpcext

### DIFF
--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -2643,6 +2643,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         self.i_pextrb(op, width=4)
         
     def i_vpcext(self, op):
-        # return value is stored in ebx
-        # if ebx == 0: Virtual PC detected, else: illegal instruction exception
-        pass
+        # expected behavior: EBX is set to 0 if Virtual PC is detected or an exception is raised
+        # in a malware sample with an anti-vm check using this instruction, vpcext is followed by a "test ebx, ebx" and exception handling code. 
+        # to avoid a "non-defined" value in the register it is set to zero
+        self.setRegister(REG_EBX, 0)

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -2646,4 +2646,4 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         # expected behavior: EBX is set to 0 if Virtual PC is detected or an exception is raised
         # in a malware sample with an anti-vm check using this instruction, vpcext is followed by a "test ebx, ebx" and exception handling code. 
         # to avoid a "non-defined" value in the register it is set to zero
-        self.setRegister(REG_EBX, 0)
+        self.setRegister(REG_EBX, 0xffffffff)

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -2641,3 +2641,8 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
 
     def i_pextrd(self, op):
         self.i_pextrb(op, width=4)
+        
+    def i_vpcext(self, op):
+        # return value is stored in ebx
+        # if ebx == 0: Virtual PC detected, else: illegal instruction exception
+        pass

--- a/envi/archs/i386/opcode86.py
+++ b/envi/archs/i386/opcode86.py
@@ -354,7 +354,7 @@ tbl32_0F = [
 (0, 0, ARG_NONE, ARG_NONE, ARG_NONE, 0, 0, 0, 0, 0),  
 (0, 0, ARG_NONE, ARG_NONE, ARG_NONE, 0, 0, 0, 0, 0),  
 (0, 0, ARG_NONE, ARG_NONE, ARG_NONE, 0, 0, 0, 0, 0),  
-(0, INS_OTHER, ADDRMETH_I | OPTYPE_b | OP_R, ADDRMETH_I | OPTYPE_b | OP_R, ARG_NONE, cpu_80386, "vpcext", 0, 0, 0),  
+(0, INS_OTHER, ADDRMETH_I | OPTYPE_b | OP_R, ADDRMETH_I | OPTYPE_b | OP_R, ARG_NONE, cpu_VIRTUALPC, "vpcext", 0, 0, 0),  
 # 0f40
 ( 0, INS_MOVCC, ADDRMETH_G | OPTYPE_v | OP_W, ADDRMETH_E | OPTYPE_v | OP_R, ARG_NONE, cpu_PENTPRO, "cmovo", 0, 0, 0),  
 ( 0, INS_MOVCC, ADDRMETH_G | OPTYPE_v | OP_W, ADDRMETH_E | OPTYPE_v | OP_R, ARG_NONE, cpu_PENTPRO, "cmovno", 0, 0, 0),  

--- a/envi/archs/i386/opcode86.py
+++ b/envi/archs/i386/opcode86.py
@@ -354,7 +354,7 @@ tbl32_0F = [
 (0, 0, ARG_NONE, ARG_NONE, ARG_NONE, 0, 0, 0, 0, 0),  
 (0, 0, ARG_NONE, ARG_NONE, ARG_NONE, 0, 0, 0, 0, 0),  
 (0, 0, ARG_NONE, ARG_NONE, ARG_NONE, 0, 0, 0, 0, 0),  
-(0, 0, ARG_NONE, ARG_NONE, ARG_NONE, 0, 0, 0, 0, 0),  
+(0, INS_OTHER, ADDRMETH_I | OPTYPE_b | OP_R, ADDRMETH_I | OPTYPE_b | OP_R, ARG_NONE, cpu_80386, "vpcext", 0, 0, 0),  
 # 0f40
 ( 0, INS_MOVCC, ADDRMETH_G | OPTYPE_v | OP_W, ADDRMETH_E | OPTYPE_v | OP_R, ARG_NONE, cpu_PENTPRO, "cmovo", 0, 0, 0),  
 ( 0, INS_MOVCC, ADDRMETH_G | OPTYPE_v | OP_W, ADDRMETH_E | OPTYPE_v | OP_R, ARG_NONE, cpu_PENTPRO, "cmovno", 0, 0, 0),  

--- a/envi/archs/i386/opconst.py
+++ b/envi/archs/i386/opconst.py
@@ -265,6 +265,7 @@ cpu_AESNI = 0x0000b000
 cpu_AVX   = 0x0000c000
 cpu_BMI   = 0x0000d000
 cpu_OSPKE = 0x0000e000
+cpu_VIRTUALPC = 0x0000f000
 
 #eventually, change this for your own codes
 #ADDEXP_SCALE_OFFSET= 0 

--- a/envi/tests/test_arch_i386.py
+++ b/envi/tests/test_arch_i386.py
@@ -219,6 +219,7 @@ i386MultiByteOpcodes = [
     ('PMAXUB', '660FDE2541414141', 0x40, 'pmaxub xmm4,oword [0x41414141]', 'pmaxub xmm4,oword [0x41414141]'),
     ('MOVNTDQ', '660FE73D78563412', 0x40, 'movntdq oword [0x12345678],xmm7', 'movntdq oword [0x12345678],xmm7'),
     ('PADDD', '660FFECE', 0x40, 'paddd xmm1,xmm6', 'paddd xmm1,xmm6'),
+    ('VPCEXT', '0F3F070B', 0x40, 'vpcext 7, 0xB','vpcext imm8, imm8'),
 
     ('MOV AMETH_C', '0f20d0', 0x40, 'mov eax,ctrl2', 'mov eax,ctrl2'),
     ('MOV AMETH_C 2', '0f20f1', 0x40, 'mov ecx,ctrl6', 'mov ecx,ctrl6'),

--- a/envi/tests/test_arch_i386.py
+++ b/envi/tests/test_arch_i386.py
@@ -219,7 +219,7 @@ i386MultiByteOpcodes = [
     ('PMAXUB', '660FDE2541414141', 0x40, 'pmaxub xmm4,oword [0x41414141]', 'pmaxub xmm4,oword [0x41414141]'),
     ('MOVNTDQ', '660FE73D78563412', 0x40, 'movntdq oword [0x12345678],xmm7', 'movntdq oword [0x12345678],xmm7'),
     ('PADDD', '660FFECE', 0x40, 'paddd xmm1,xmm6', 'paddd xmm1,xmm6'),
-    ('VPCEXT', '0F3F070B', 0x40, 'vpcext 7, 11','vpcext imm8, imm8'),
+    ('VPCEXT', '0F3F070B', 0x40, 'vpcext 7,11','vpcext imm8, imm8'),
 
     ('MOV AMETH_C', '0f20d0', 0x40, 'mov eax,ctrl2', 'mov eax,ctrl2'),
     ('MOV AMETH_C 2', '0f20f1', 0x40, 'mov ecx,ctrl6', 'mov ecx,ctrl6'),

--- a/envi/tests/test_arch_i386.py
+++ b/envi/tests/test_arch_i386.py
@@ -219,7 +219,7 @@ i386MultiByteOpcodes = [
     ('PMAXUB', '660FDE2541414141', 0x40, 'pmaxub xmm4,oword [0x41414141]', 'pmaxub xmm4,oword [0x41414141]'),
     ('MOVNTDQ', '660FE73D78563412', 0x40, 'movntdq oword [0x12345678],xmm7', 'movntdq oword [0x12345678],xmm7'),
     ('PADDD', '660FFECE', 0x40, 'paddd xmm1,xmm6', 'paddd xmm1,xmm6'),
-    ('VPCEXT', '0F3F070B', 0x40, 'vpcext 7,11','vpcext imm8, imm8'),
+    ('VPCEXT', '0F3F070B', 0x40, 'vpcext 7,11','vpcext 7,11'),
 
     ('MOV AMETH_C', '0f20d0', 0x40, 'mov eax,ctrl2', 'mov eax,ctrl2'),
     ('MOV AMETH_C 2', '0f20f1', 0x40, 'mov ecx,ctrl6', 'mov ecx,ctrl6'),

--- a/envi/tests/test_arch_i386.py
+++ b/envi/tests/test_arch_i386.py
@@ -219,7 +219,7 @@ i386MultiByteOpcodes = [
     ('PMAXUB', '660FDE2541414141', 0x40, 'pmaxub xmm4,oword [0x41414141]', 'pmaxub xmm4,oword [0x41414141]'),
     ('MOVNTDQ', '660FE73D78563412', 0x40, 'movntdq oword [0x12345678],xmm7', 'movntdq oword [0x12345678],xmm7'),
     ('PADDD', '660FFECE', 0x40, 'paddd xmm1,xmm6', 'paddd xmm1,xmm6'),
-    ('VPCEXT', '0F3F070B', 0x40, 'vpcext 7, 0xB','vpcext imm8, imm8'),
+    ('VPCEXT', '0F3F070B', 0x40, 'vpcext 7, 11','vpcext imm8, imm8'),
 
     ('MOV AMETH_C', '0f20d0', 0x40, 'mov eax,ctrl2', 'mov eax,ctrl2'),
     ('MOV AMETH_C 2', '0f20f1', 0x40, 'mov ecx,ctrl6', 'mov ecx,ctrl6'),


### PR DESCRIPTION
Dear vivisect team,

I tried to add "vpcext" mnemonic for i386 architecture. Would be amazing, if you could modify the types of the operands, if necessary.

The reason is, that the analysis will stop at the instruction "vpcext".

Thank you very much!