### PR TITLE
Move getAdminRighits() from VivWorkspaceCore to MemoryObject

### DIFF
--- a/envi/memory.py
+++ b/envi/memory.py
@@ -150,7 +150,7 @@ class IMemory:
         mapend = mapva+mapsize
         if va+size > mapend:
             return False
-        if mapperm & perm != perm:
+        if mapperm & perm != perm and not self._supervisor:
             return False
         return True
 
@@ -572,7 +572,7 @@ class MemoryObject(IMemory):
         for mva, mmaxva, mmap, mbytes in self._map_defs:
             if mva <= va < mmaxva:
                 mva, msize, mperms, mfname = mmap
-                if not mperms & MM_READ:
+                if not (mperms & MM_READ or self._supervisor):
                     msg = "Bad Memory Read (no READ permission): %s: %s" % (hex(va), hex(size))
                     if _origva is not None:
                         msg += " (original va: %s)" % hex(_origva)

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -146,12 +146,15 @@ class IMemory:
         mmap = self.getMemoryMap(va)
         if mmap is None:
             return False
+
         mapva, mapsize, mapperm, mapfile = mmap
         mapend = mapva+mapsize
         if va+size > mapend:
             return False
+
         if mapperm & perm != perm and not self._supervisor:
             return False
+
         return True
 
     def allocateMemory(self, size, perms=MM_RWX, suggestaddr=0):

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -544,6 +544,20 @@ class MemoryObject(IMemory):
     def getMemoryMaps(self):
         return [mmap for mva, mmaxva, mmap, mbytes in self._map_defs]
 
+    @contextlib.contextmanager
+    def getAdminRights(self):
+        '''
+        Useful for accessing memory in ways not permitted by the map permissions
+
+        eg.
+
+        with mem.getAdminRights():
+            mem.writeMemory(addr, data)
+        '''
+        self._supervisor = True
+        yield
+        self._supervisor = False
+
     def readMemory(self, va, size, _origva=None):
         '''
         Read memory from maps stored in memory maps.

--- a/envi/memory.py
+++ b/envi/memory.py
@@ -1,6 +1,7 @@
 import re
 import struct
 import logging
+import contextlib
 
 import envi
 import envi.exc as e_exc

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -3,7 +3,6 @@ import base64
 import logging
 import traceback
 import threading
-import contextlib
 import collections
 
 import envi

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -208,12 +208,6 @@ class VivWorkspaceCore(viv_impapi.ImportApi):
         '''
         self._event_saved = len(self._event_list)
 
-    @contextlib.contextmanager
-    def getAdminRights(self):
-        self._supervisor = True
-        yield
-        self._supervisor = False
-
     def _handleADDLOCATION(self, loc):
         lva, lsize, ltype, linfo = loc
         self.locmap.setMapLookup(lva, lsize, loc)


### PR DESCRIPTION
There it can be used by all subclasses, not just Vivisect Workspace.
This makes it available for Emulators as well.  
For context:  `_supervisor`, which accesses, is already a part of MemoryObject.