### PR TITLE
emucode: try more REF_PTR candidates

### DIFF
--- a/vivisect/analysis/__init__.py
+++ b/vivisect/analysis/__init__.py
@@ -110,8 +110,8 @@ def addAnalysisModules(vw):
         vw.addAnalysisModule("vivisect.analysis.generic.relocations")
         vw.addAnalysisModule("vivisect.analysis.elf.libc_start_main")
         vw.addAnalysisModule("vivisect.analysis.generic.funcentries")
-        vw.addAnalysisModule("vivisect.analysis.generic.emucode")
         vw.addAnalysisModule("vivisect.analysis.generic.pointertables")
+        vw.addAnalysisModule("vivisect.analysis.generic.emucode")
 
         # Generic code block analysis
         vw.addFuncAnalysisModule("vivisect.analysis.generic.codeblocks")

--- a/vivisect/analysis/generic/emucode.py
+++ b/vivisect/analysis/generic/emucode.py
@@ -113,7 +113,7 @@ def analyze(vw):
         bcode = []
 
         vatodo = set([va for va, name in vw.getNames() if vw.getLocation(va) is None and va not in tried])
-        vatodo = vatodo.union([tova for _, tova, _, _ in vw.getXrefs(rtype=REF_PTR) if vw.getLocation(tova) is None and tova not in tried])
+        vatodo = vatodo.union([tova for _, tova, _, _ in vw.getXrefs(rtype=REF_PTR) if tova not in tried])
         for va in vatodo:
             loc = vw.getLocation(va)
             if loc is not None:


### PR DESCRIPTION
#### edit: i have the logic wrong, re-reviewing now.

(this derives from a triage session started in https://github.com/mandiant/capa/issues/1268)

I suspect that the criteria used to select candidate pointers for emucode analysis is too strict. this PR relaxes the requirements a bit.

emucode is the analysis pass that emulates unknown data and tries to guess if it might be valid code. its used to check dangling pointers after other analysis passes have run to improve the total code coverage recovered by viv.

today, emucode considers `REF_PTR` xrefs that point to a location with a known type (e.g., string, code, data, etc.). it does *not* consider valid pointers to executable regions whose type is not yet known. given that the purpose of this analysis pass is to find new valid code and create those locations, I think that this behavior is too restrictive.

as a case study, the ELF file with SHA256 294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc has a sequence of instructions like:

```
.text:0000000000409EC2 48 C7 40 10 10 BB 40 00 mov     qword ptr [rax+10h], offset sub_40BB10
.text:0000000000409ECA 48 8B 44 24 08          mov     rax, [rsp+10A8h+arg]
.text:0000000000409ECF 48 89 47 18             mov     [rdi+18h], rax
```

ideally, vivisect should identify the reference to `sub_40BB10` at 0x409EC2. in practice, viv recognizes and creates the `REF_PTR` reference [while disassembling the opcode](https://github.com/vivisect/vivisect/blob/ff87de9947a5e91d11082ca1730fe9aa899200b1/vivisect/__init__.py#L1431-L1432); however, it doesn't know what type of data it points to, so it doesn't create a location at 0x40BB10. when emucode has a chance to consider all the dangling pointers, it skips this candidate.

given that the emucode loop has explicit location type checks [here](https://github.com/vivisect/vivisect/blob/ff87de9947a5e91d11082ca1730fe9aa899200b1/vivisect/analysis/generic/emucode.py#L119-L126), i think its ok to relax the restrictions on candidate pointers. i wonder if maybe this check was a copy-pasta issue?

i've also included a tweak that defers emucode pass until after pointertables, since otherwise the example ELF sample also does not match. this seems reasonable, since we'd want emucode to run after most/all other passes so that it can check those dangling pointers.