### PR TITLE
detectString: correctly compute substring length

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -1029,7 +1029,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                             # technically the start of the full string, but the binary does
                             # some optimizations and just ref's inside the full string to save 
                             # some space
-                            return count + loc[L_SIZE]
+                            return loc[L_SIZE] - (va - loc[L_VA])
                         return loc[L_VA] - (va + count) + loc[L_SIZE]
                     return -1
 
@@ -1081,7 +1081,7 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
                         if bytes[offset+count] != 0:
                             # same thing as in the string case, a binary can ref into a string
                             # only part of the full string.
-                            return count + loc[L_SIZE]
+                            return loc[L_SIZE] - (va - loc[L_VA])
                         return loc[L_VA] - (va + count) + loc[L_SIZE]
                     return -1
 


### PR DESCRIPTION
this PR fixes the string length calculation when the requested string is a substring of a longer string that begins somewhere before it. when we find there's an existing string location that contains the substring, take its length and subtract the amount they overlap. i can't quite understand what the existing code was supposed to do; any ideas @atlas0fd00m ?

for example, in 294b8db1f2702b60fb2e42fdc50c2cee6a5046112da9a5703a548a4fa50477bc there is the data:

```
.rodata:00000000004120A2 ; const char asc_4120A2[]
.rodata:00000000004120A2 asc_4120A2      db 0Dh,0Ah              ; DATA XREF: sub_40D0A0+B3↑o
.rodata:00000000004120A2                                         ; sub_404970+2F↑o ...
.rodata:00000000004120A2                 db 0Dh,0Ah,0
.rodata:00000000004120A7 ; const char aHttps[]
```

and this instruction:

```
.text:000000000040499F BE A4 20 41 00          mov     esi, (offset asc_4120A2+2) ; char *
```

references the substring two characters into the longer string ("\r\n" versus "\r\n\r\n").