### PR TITLE
Fix 64-bit emulation of div

### DIFF
--- a/envi/tests/test_arch_amd64_emu.py
+++ b/envi/tests/test_arch_amd64_emu.py
@@ -6,6 +6,14 @@ amd64Tests = [
     {'bytes': '48f7ff',
      'setup': ({'rax': 0xffffffffffffffe2, 'rdx': 0xffffffffffffffff}, {}),
      'tests': ({'rax': 0, 'rdx': 0xffffffffffffffe2}, {})},
+    # div eax with 32-bit args
+    {'bytes': 'f7f0',
+     'setup': ({'rax': 48, 'rdx': 1}, {}),
+     'tests': ({'rax': 89478486, 'rdx': 16}, {})},
+    # div rax with 64-bit args
+    {'bytes': '48f7f0',
+     'setup': ({'rax': 48, 'rdx': 1}, {}),
+     'tests': ({'rax': 384307168202282326, 'rdx': 16}, {})},
 ]
 
 class Amd64EmulatorTests(i386etest.i386EmulatorTests):


### PR DESCRIPTION
64-bit emulation of div defaults to the i386 implementation, which raises an exception if the combined rdx:rax is more than 64 bits.  This fix implements div for amd64.  Unit test demonstrates the fix.