### PR TITLE
resilience for testremote unittest

### DIFF
--- a/vivisect/tests/testremote.py
+++ b/vivisect/tests/testremote.py
@@ -28,6 +28,18 @@ def runServer(name, port):
     v_r_server.runMainServer(dirn, port)
 
 
+def getOutput(strcanv, timeout=10):
+    '''
+    Watches a StringCanvas for data up to a given timeout
+    '''
+    starttime = time.time()
+    output = strcanv.strval
+    while not output and (time.time() - starttime) < timeout:
+        time.sleep(.1)
+
+    strcanv.strval = ''
+    return output
+
 class VivisectRemoteTests(unittest.TestCase):
     '''
     So...what would be fun is basically a chain of remote workspaces all tied in interesting
@@ -148,15 +160,13 @@ class VivisectRemoteTests(unittest.TestCase):
 
                 # empty leaders
                 rmtvw.do_leaders('')
-                output = rmtvw.canvas.strval
+                output = getOutput(rmtvw.canvas)
                 self.assertIn('Manage Leader Sessions.', output)
-                rmtvw.canvas.strval = ''
 
                 # list leaders
                 rmtvw.do_leaders('list')
-                output = rmtvw.canvas.strval
+                output = getOutput(rmtvw.canvas)
                 self.assertIn("rakuy0's moving castle", output)
-                rmtvw.canvas.strval = ''
 
                 # modify a leader session
                 rmtvw.do_leaders('mod %s foo foo bar baz' % testuuid)
@@ -172,9 +182,8 @@ class VivisectRemoteTests(unittest.TestCase):
                     time.sleep(.1)
                     sys.stderr.write('%d' % retry)
 
-                output = rmtvw.canvas.strval
+                output = getOutput(rmtvw.canvas)
                 self.assertIn("foo bar baz", output)
-                rmtvw.canvas.strval = ''
 
                 # kill leader session
                 rmtvw.do_leaders('kill %s' % testuuid)
@@ -188,9 +197,8 @@ class VivisectRemoteTests(unittest.TestCase):
                     time.sleep(.1)
                     sys.stderr.write('%d' % retry)
 
-                output = rmtvw.canvas.strval
+                output = getOutput(rmtvw.canvas)
                 self.assertIn("*Ended: foo's session 'foo bar baz'", output)
-                rmtvw.canvas.strval = ''
 
 
                 # kill all (which means we need to add a few)
@@ -222,10 +230,9 @@ class VivisectRemoteTests(unittest.TestCase):
                     time.sleep(.1)
                     sys.stderr.write('%d' % retry)
 
-                output = rmtvw.canvas.strval
+                output = getOutput(rmtvw.canvas)
                 self.assertIn("castle 3", output)
                 self.assertEqual(len(rmtvw2.getLeaderSessions()), 0)
-                rmtvw.canvas.strval = ''
 
 
                 # close down tests


### PR DESCRIPTION
functionalize and add resilience to the method of checking output via the hacked up StringCanvas used by the unittests.

we wait for the buffer to have length for up to 10 seconds, and clear the canvas before returning the results.  much cleaner.