### PR TITLE
Lazy load of opcode methods in symbolik translator

### DIFF
--- a/vivisect/symboliks/translator.py
+++ b/vivisect/symboliks/translator.py
@@ -11,10 +11,7 @@ class SymbolikTranslator:
         self.vw = vw
         self._eff_log = []
         self._con_log = []
-        self._op_methods = {}
-        for name in dir(self):
-            if name.startswith("i_"):
-                self._op_methods[name[2:]] = getattr(self, name)
+        self._op_methods = None
         self._cur_va = None
 
     def effSetVariable(self, rname, rsym):
@@ -44,6 +41,14 @@ class SymbolikTranslator:
 
     def translateOpcode(self, op):
         self._cur_va = op.va
+
+        if self._op_methods is None:
+            # Lazy loading since this method is the only place it's used.
+            self._op_methods = {}
+            for name in dir(self):
+                if name.startswith("i_"):
+                    self._op_methods[name[2:]] = getattr(self, name)
+
         meth = self._op_methods.get(op.mnem, None)
         if meth is None:
             # print('Symboliks: %s: %s Needs: %s' % (hex(op.va), self.__class__.__name__, repr(op)))


### PR DESCRIPTION
This PR is just to improve performance.  The _op_methods array in the symbolik translator is only needed if opcodes are translated.  It is expensive to load, with about 180 i_* methods in the source.  In our application, a translator instance is constructed every time a function emulator is needed, but op codes are usually not translated.  Making this a lazy load speeds up our application by more than 8%.