### PR TITLE
vdb: add "stepo" functionality as an option for "stepi"

### DIFF
--- a/vdb/__init__.py
+++ b/vdb/__init__.py
@@ -1035,11 +1035,12 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
         -V         - Show operand values during single step (verbose!)
         -U         - Remainder of args is "step until" expression (stop on True)
         -Q         - Do not output to canvas
+        -O         - Step Over calls (ie. stay in this function)
         """
         t = self.trace
         argv = e_cli.splitargs(line)
         try:
-            opts,args = getopt(argv, "A:BC:RVUQ")
+            opts,args = getopt(argv, "A:BC:RVUOQ")
         except Exception as e:
             return self.do_help("stepi")
 
@@ -1050,6 +1051,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
         tobrn = False
         showop = False
         quiet = False
+        stepover = False
 
         for opt, optarg in opts:
 
@@ -1073,6 +1075,9 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
 
             elif opt == '-Q':
                 quiet = True
+
+            elif opt == '-O':
+                stepover = True
 
         if ( count is None 
              and taddr is None
@@ -1122,7 +1127,7 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
                     if not quiet:
                         self.canvas.addText('\n')
 
-                    if op.iflags & envi.IF_CALL:
+                    if op.iflags & envi.IF_CALL and not stepover:
                         depth += 1
 
                     elif op.iflags & envi.IF_RET:
@@ -1131,9 +1136,15 @@ class Vdb(e_cli.EnviMutableCli, v_notif.Notifier, v_util.TraceManager):
                     print("[E@0x%x] %r" % (pc, e))
 
 
-                tid = t.getCurrentThread()
+                # execute the instruction
+                if op.iflags & envi.IF_CALL and stepover:
+                    bp = vtrace.breakpoints.OneTimeBreak(op.va + op.size)
+                    self.trace.addBreakpoint(bp)
+                    self.trace.run()
 
-                t.stepi()
+                else:
+                    tid = t.getCurrentThread()
+                    t.stepi()
 
                 if until and t.parseExpression(until):
                     break


### PR DESCRIPTION
this allows you to stepi to the end of a function, stepping over any calls in the interim.  so much functionality exists in stepi that i'm adding this option to stepi to avoid having to dual-maintain that functionality in stepo.

alternately we could merge stepi and stepo into one function and have do_stepi and do_stepo call the same function to actually do the implementation, with "stepo" as an option.