### PR TITLE
Migrate away from deprecated `assertRaisesRegexp`

### DIFF
--- a/vstruct/tests/tests_vstruct.py
+++ b/vstruct/tests/tests_vstruct.py
@@ -47,11 +47,11 @@ class VStructTests(unittest.TestCase):
             tup = self.s.vsGetFieldByOffset(-1)
 
     def test_vsGetFieldByOffset_maxval_pos(self):
-        with self.assertRaisesRegexp(Exception, 'Invalid Offset Specified'):
+        with self.assertRaisesRegex(Exception, 'Invalid Offset Specified'):
             tup = self.s.vsGetFieldByOffset(0xffffffff)
 
     def test_vsGetFieldByOffset_maxval_plus1_pos(self):
-        with self.assertRaisesRegexp(Exception, 'Invalid Offset Specified'):
+        with self.assertRaisesRegex(Exception, 'Invalid Offset Specified'):
             tup = self.s.vsGetFieldByOffset(len(self.s))
 
     def test_vsGetFieldByOffset_nested1(self):


### PR DESCRIPTION
In Python 3.12 `assertRaisesRegexp` will no longer work.  Replace it with `assertRaisesRegex`.