### PR TITLE
cli: update regex that has an invalid escape sequence (currently a wa…

### DIFF
--- a/envi/cli.py
+++ b/envi/cli.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 
 def splitargs(cmdline):
     cmdline = cmdline.replace('\\\\"', '"').replace('\\"', '')
-    patt = re.compile('\".+?\"|\S+')
+    patt = re.compile(r'".+?"|\S+')
     for item in cmdline.split('\n'):
         return [s.strip('"') for s in patt.findall(item)]
 
@@ -398,7 +398,7 @@ class EnviCli(Cmd):
                 return
 
             if len(parts) == 2:
-                # the config entry already has a value, let's use it to decide 
+                # the config entry already has a value, let's use it to decide
                 # whether to convert it to an int or leave it as a str.
                 if type(cfg[optname]) == int:
                     newval = int(parts[1], 0)


### PR DESCRIPTION
This regex string currently generates a `DeprecationWarning` (Python 3.11).

Python 3.12 will generate a `SyntaxWarning` (https://docs.python.org/3.12/whatsnew/3.12.html#other-language-changes), and a future Python version will raise a `SyntaxError`.

The current DeprecationWarning impacts our test suite; we have worked around it but it'll be good to have this fixed for the future.