### PR TITLE
simple SymbolResolver (envi.symstore) bugfix (for Windows)

### DIFF
--- a/envi/symstore/resolver.py
+++ b/envi/symstore/resolver.py
@@ -217,6 +217,9 @@ class SymbolResolver:
             if sym.fname in self.symobjsbyname:
                 self.symobjsbyname.pop(sym.fname, None)
 
+            if symval in self.symobjsbyaddr:
+                self.symobjsbyaddr.pop(symval, None)
+
     def addSymbol(self, sym):
         """
         Add a symbol to the resolver.
@@ -285,7 +288,7 @@ class SymbolResolver:
 
         if sym.fname:
             subres = self.symobjsbyname.get(sym.fname)
-            if subres is not None:
+            if subres is not None and isinstance(subres, SymbolResolver):
                 subres._addSymObject(sym)
                 return
 


### PR DESCRIPTION
fix bug assuming that if a symbol exists matching the filename of a symbol, that it must be a FileSymbol (or at least a subclass of SymbolResolver, which FileSymbol is).
complete delSymbol() by removing the Address hash as well

eventually, we need to dig through and overhaul symbols in general, and refreshing this code will play a part of that (possibly creating a greater, universal symbol subsystem for all of Vivisect).  for now, this is necessary.