### PR TITLE
Validate Extensions (easy)

### DIFF
--- a/vdb/extensions/__init__.py
+++ b/vdb/extensions/__init__.py
@@ -62,7 +62,7 @@ def loadExtensions(vdb, trace):
                 spec.loader.exec_module(module)
 
                 if not hasattr(module, 'vdbExtension'):
-                    logger.info("Skipping python module %r, not a valid extension", modpath)
+                    logger.warning("Skipping python module %r, not a valid extension (module has no vdbExtension() function)", modpath)
                     continue
 
                 logger.info("Loading extension: %r", modpath)

--- a/vdb/extensions/__init__.py
+++ b/vdb/extensions/__init__.py
@@ -5,8 +5,11 @@ commands and modules.
 
 import os
 import sys
+import logging
 import importlib
 import traceback
+
+logger = logging.getLogger(__name__)
 
 __all__ = ['loadExtensions', 'windows', 'i386', 'darwin', 'amd64', 'gdbstub', 'arm', 'android', 'winkern']
 
@@ -57,8 +60,15 @@ def loadExtensions(vdb, trace):
                 module.vdb = vdb
                 module.__file__ = modpath
                 spec.loader.exec_module(module)
+
+                if not hasattr(module, 'vdbExtension'):
+                    logger.info("Skipping python module %r, not a valid extension", modpath)
+                    continue
+
+                logger.info("Loading extension: %r", modpath)
                 module.vdbExtension(vdb, trace)
                 vdb.addExtension(fname, module)
+
             except Exception:
                 vdb.vprint('VDB Extension Error: %s' % modpath)
                 vdb.vprint(traceback.format_exc())

--- a/vivisect/extensions/__init__.py
+++ b/vivisect/extensions/__init__.py
@@ -12,9 +12,11 @@ The module's vivExtension function takes a vivisect workspace
 
 import os
 import sys
+import logging
 import importlib
 import traceback
 
+logger = logging.getLogger(__name__)
 
 def loadExtensions(vw, vwgui):
 
@@ -52,8 +54,15 @@ def loadExtensions(vw, vwgui):
                 module.vw = vw
                 spec.loader.exec_module(module)
 
+                if not hasattr(module, 'vivExtension'):
+                    logger.info("Skipping python module %r, not a valid extension", modpath)
+                    continue
+
+                logger.info("Loading extension: %r", modpath)
                 module.vivExtension(vw, vwgui)
                 vw.addExtension(fname, module)
+
+
             except Exception:
                 vw.vprint('Extension Error: %s' % modpath)
                 vw.vprint(traceback.format_exc())

--- a/vivisect/extensions/__init__.py
+++ b/vivisect/extensions/__init__.py
@@ -55,7 +55,7 @@ def loadExtensions(vw, vwgui):
                 spec.loader.exec_module(module)
 
                 if not hasattr(module, 'vivExtension'):
-                    logger.info("Skipping python module %r, not a valid extension", modpath)
+                    logger.warning("Skipping python module %r, not a valid extension (module has no vivExtension() function)", modpath)
                     continue
 
                 logger.info("Loading extension: %r", modpath)


### PR DESCRIPTION
validate each module in the VIV_EXT_PATH and VDB_EXT_PATH is a valid module, with a `vivExtension()` or `vdbExtension()` function.

log skips and loaded modules