### PR TITLE
minidump: parse Threads from MiniDumpThreadListStream

### DIFF
--- a/vstruct/defs/minidump.py
+++ b/vstruct/defs/minidump.py
@@ -486,7 +486,9 @@ class MiniDumpThreadListStream(vstruct.VStruct):
     def __init__(self):
         vstruct.VStruct.__init__(self)
         self.NumberOfThreads = v_uint32()
-        self.Threads = MiniDumpThread()
+
+    def pcb_NumberOfThreads(self):
+        self.Threads = vstruct.VArray([MiniDumpThread() for i in range(self.NumberOfThreads)])
 
 class MiniDumpReservedStream1(vstruct.VStruct):
     '''


### PR DESCRIPTION
currently a single thread is parsed, independent of `NumberOfThreads`. this PR parses all the threads.

before:
<img width="398" alt="image" src="https://github.com/vivisect/vivisect/assets/156560/0c5f0db2-834c-4b13-86b3-ed37c423c05f">


after:
<img width="394" alt="image" src="https://github.com/vivisect/vivisect/assets/156560/1bc10c75-127a-4826-844f-5d04c4d7b631">
