### PR TITLE
minidump: fix name of MemoryDescriptor range start

### DIFF
--- a/vstruct/defs/minidump.py
+++ b/vstruct/defs/minidump.py
@@ -39,7 +39,7 @@ class MiniDumpLocationDescriptor(vstruct.VStruct):
 class MiniDumpMemoryDescriptor(vstruct.VStruct):
     def __init__(self):
         vstruct.VStruct.__init__(self)
-        self.StartOfMemoryPage = v_uint64()
+        self.StartOfMemoryRange = v_uint64()
         self.Memory = MiniDumpLocationDescriptor()
 
 class MiniDumpMemoryDescriptor64(vstruct.VStruct):


### PR DESCRIPTION
following naming here: https://learn.microsoft.com/en-us/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_memory_descriptor

![image](https://github.com/vivisect/vivisect/assets/156560/061f9a6e-2479-421e-80c3-f83bd1a68692)
