### PR TITLE
sped up vsEmit() of ihex and srec file formats

### DIFF
--- a/vivisect/parsers/ihex.py
+++ b/vivisect/parsers/ihex.py
@@ -51,7 +51,7 @@ def parseFile(vw, filename, baseaddr=None):
 
         # calculate IHEX-specific hash - only the fields copied into memory
         ihdata = ihex.vsEmit()
-        vw.setFileMeta(fname, 'sha256_ihex', v_parsers.sha256Bytes(ihdata.encode('utf-8')))
+        vw.setFileMeta(fname, 'sha256_ihex', v_parsers.sha256Bytes(ihdata))
 
         for eva in ihex.getEntryPoints():
             if eva is not None:

--- a/vivisect/parsers/srec.py
+++ b/vivisect/parsers/srec.py
@@ -49,7 +49,7 @@ def parseFile(vw, filename, baseaddr=None):
 
         # calculate SREC-specific hash - only the fields copied into memory
         srdata = srec.vsEmit()
-        vw.setFileMeta(fname, 'sha256_srec', v_parsers.sha256Bytes(srdata.encode('utf-8')))
+        vw.setFileMeta(fname, 'sha256_srec', v_parsers.sha256Bytes(srdata))
 
         for eva in srec.getEntryPoints():
             if eva is not None:

--- a/vstruct/defs/ihex.py
+++ b/vstruct/defs/ihex.py
@@ -77,10 +77,7 @@ class IHexFile(vstruct.VArray):
             ffvals = [ ff.vsGetValue() for ff in self._vs_fastfields ]
             return struct.pack(self._vs_fastfmt, *ffvals)
 
-        ret = b''
-        for fname, fobj in self.vsGetFields():
-            ret += fobj.vsEmit() + b'\r\n'
-        return ret.decode('utf-8')
+        return b''.join(fobj.vsEmit() + b'\r\n' for _, fobj in self.vsGetFields())
 
 
     def getEntryPoints(self):

--- a/vstruct/defs/ihex.py
+++ b/vstruct/defs/ihex.py
@@ -77,8 +77,7 @@ class IHexFile(vstruct.VArray):
             ffvals = [ ff.vsGetValue() for ff in self._vs_fastfields ]
             return struct.pack(self._vs_fastfmt, *ffvals)
 
-        return b''.join(fobj.vsEmit() + b'\r\n' for _, fobj in self.vsGetFields())
-
+        return b'\r\n'.join(fobj.vsEmit() for _, fobj in self.vsGetFields())
 
     def getEntryPoints(self):
         '''

--- a/vstruct/defs/srec.py
+++ b/vstruct/defs/srec.py
@@ -106,10 +106,7 @@ class SRecFile(vstruct.VArray):
             ffvals = [ ff.vsGetValue() for ff in self._vs_fastfields ]
             return struct.pack(self._vs_fastfmt, *ffvals)
 
-        ret = b''
-        for fname, fobj in self.vsGetFields():
-            ret += fobj.vsEmit() + b'\r\n'
-        return ret.decode('utf-8')
+        return b''.join(fobj.vsEmit() + b'\r\n' for _, fobj in self.vsGetFields())
 
     def getEntryPoints(self):
         '''

--- a/vstruct/defs/srec.py
+++ b/vstruct/defs/srec.py
@@ -106,7 +106,7 @@ class SRecFile(vstruct.VArray):
             ffvals = [ ff.vsGetValue() for ff in self._vs_fastfields ]
             return struct.pack(self._vs_fastfmt, *ffvals)
 
-        return b''.join(fobj.vsEmit() + b'\r\n' for _, fobj in self.vsGetFields())
+        return b'\r\n'.join(fobj.vsEmit() for _, fobj in self.vsGetFields())
 
     def getEntryPoints(self):
         '''


### PR DESCRIPTION
While testing parsing of large ihex and srec files identified that the `vsEmit()` functions for ihex and srec structures was inefficient.