### PR TITLE
naming_loc_help

### DIFF
--- a/vivisect/qt/main.py
+++ b/vivisect/qt/main.py
@@ -145,7 +145,7 @@ class VQVivMainWindow(viv_base.VivEventDist, vq_app.VQMainCmdWindow):
 
         curname = self.vw.getName(va)
         if curname is None:
-            curname = ''
+            curname = 'loc_%.8x' % va
 
         name, ok = QInputDialog.getText(parent, 'Enter...', 'Name', text=curname)
         if ok:


### PR DESCRIPTION
give a default name of "loc_########" so the address shows up while editing (in case you want to keep it there).  displaying always defaults to that naming convention.