### PR TITLE
Missing IHEX_REC_STARTLINADDR check

### DIFF
--- a/vstruct/defs/ihex.py
+++ b/vstruct/defs/ihex.py
@@ -133,6 +133,9 @@ class IHexFile(vstruct.VArray):
             if ctype == IHEX_REC_EOF:
                 break
 
+            if ctype == IHEX_REC_STARTLINADDR:
+                continue
+
             raise Exception('Unhandled IHEX chunk: %s' % chunk.recordtype)
 
         memparts.sort()


### PR DESCRIPTION
In vstruct/defs/ihex.py, getMemoryMaps, there is not a check for IHEX_REC_STARTLINADDR. The patch adds a check for this record type and skips over the chunk, similarly to IHEX_REC_STARTSEG.