### PR TITLE
VivServer enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 coverage_html_report*
 *~
 _build
+build

--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -20,6 +20,7 @@ import logging
 import traceback
 import urllib.parse
 import envi.common as e_cmn
+import envi.config as e_config
 
 from threading import current_thread, Thread, RLock, Timer, Lock
 from socketserver import ThreadingTCPServer, BaseRequestHandler
@@ -38,6 +39,20 @@ except ImportError:
     msgpack = None
 
 logger = logging.getLogger(__name__)
+
+defconfig = {
+
+    'cobra':{
+        'base_timeout': 120,
+    },
+
+}
+
+docconfig = {
+    'cobra':{
+        'base_timeout': "Default timeout for cobra connections",
+    }
+}
 
 daemon = None
 version = "Cobra2"
@@ -457,7 +472,7 @@ class CobraClientSocket(CobraSocket):
 
 class CobraDaemon(ThreadingTCPServer):
 
-    def __init__(self, host="", port=COBRA_PORT, sslcrt=None, sslkey=None, sslca=None, msgpack=False, json=False):
+    def __init__(self, host="", port=COBRA_PORT, sslcrt=None, sslkey=None, sslca=None, msgpack=False, json=False, config=None):
         '''
         Construct a cobra daemon object.
 
@@ -471,6 +486,11 @@ class CobraDaemon(ThreadingTCPServer):
         sslca               - Specify an SSL CA key to use validating client certs
 
         '''
+        if config is None:
+            # If we don't provide a config, grab a default
+            config = e_config.loadConfig(defconfig, docconfig)
+
+        self.config = config
         self.thr = None
         self.run = True
         self.shared = {}
@@ -944,6 +964,12 @@ class CobraProxy:
         self._cobra_spoolcnt = int(urlparams.get('sockpool', 0))
         self._cobra_sockpool = None
 
+        self._cobra_config = kwargs.get('config')
+        if self._cobra_config is None:
+            # If we don't provide a config, grab a default
+            self._cobra_config = e_config.loadConfig(defconfig, docconfig)
+
+
         if self._cobra_timeout is not None:
             self._cobra_timeout = int(self._cobra_timeout)
 
@@ -974,7 +1000,7 @@ class CobraProxy:
             self._cobra_sockpool = queue.Queue()
             # timeout reqeuired for pool usage
             if not self._cobra_timeout:
-                self._cobra_timeout = 120
+                self._cobra_timeout = self._cobra_config.cobra.base_timeout
             # retry max required on pooling
             if not self._cobra_retrymax:
                 self._cobra_retrymax = 3

--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -795,6 +795,7 @@ class CobraConnectionHandler:
                 handler(csock, name, obj, data)
             except Exception as e:
                 logger.warning("cobra handler hit exception: %s" % str(e))
+                logger.debug("", exc_info=1)
                 try:
                     csock.sendMessage(COBRA_ERROR, name, e)
                 except TypeError as typee:

--- a/cobra/__init__.py
+++ b/cobra/__init__.py
@@ -19,6 +19,7 @@ import struct
 import logging
 import traceback
 import urllib.parse
+import envi.common as e_cmn
 
 from threading import current_thread, Thread, RLock, Timer, Lock
 from socketserver import ThreadingTCPServer, BaseRequestHandler
@@ -194,11 +195,11 @@ class CobraSocket:
                 raise Exception('Missing "msgpack" python module ( http://visi.kenshoto.com/viki/Msgpack )')
 
             def msgpackloads(b):
-                logger.debug("<< %r  (%r)", b, loadargs)
+                logger.log(e_cmn.MIRE, "<< %r  (%r)", b, loadargs)
                 return msgpack.loads(b, **loadargs)
 
             def msgpackdumps(b):
-                logger.debug(">> %r  (%r)", b, dumpargs)
+                logger.log(e_cmn.MIRE, ">> %r  (%r)", b, dumpargs)
                 return msgpack.dumps(b, **dumpargs)
 
             self.dumps = msgpackdumps
@@ -972,7 +973,7 @@ class CobraProxy:
             self._cobra_sockpool = queue.Queue()
             # timeout reqeuired for pool usage
             if not self._cobra_timeout:
-                self._cobra_timeout = 60
+                self._cobra_timeout = 120
             # retry max required on pooling
             if not self._cobra_retrymax:
                 self._cobra_retrymax = 3

--- a/envi/common.py
+++ b/envi/common.py
@@ -34,7 +34,7 @@ def initLogging(logger, level=None, fmt=LOG_FORMAT):
     Setup logging and log levels
     '''
     if level is None:
-        level = os.environ.get('LOGLEVEL')
+        level = os.environ.get('VIV_LOGLEVEL')
 
     if type(level) == str:
         level = getLogLevelFromString(level)

--- a/envi/common.py
+++ b/envi/common.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import binascii
 
@@ -19,10 +20,25 @@ LOG_LEVELS = (
     MIRE,
 )
 
+def getLogLevelFromString(loglvlstr):
+    '''
+    Translate a string to a Logging constant
+    '''
+    if hasattr(logging, loglvlstr):
+        return getattr(logging, loglvlstr)
+    return globals().get(loglvlstr)
+
+
 def initLogging(logger, level=None, fmt=LOG_FORMAT):
     '''
     Setup logging and log levels
     '''
+    if level is None:
+        level = os.environ.get('LOGLEVEL')
+
+    if type(level) == str:
+        level = getLogLevelFromString(level)
+
     if level:
         if level not in LOG_LEVELS:
             raise ValueError('Invalid log level of %r' % level)

--- a/envi/config.py
+++ b/envi/config.py
@@ -28,6 +28,23 @@ def gethomedir(*paths, **kwargs):
     return path
 
 
+def loadConfig(defaults=None, docs=None, autosave=False, cfgdir=None):
+    '''
+    Loads config from a viv.json file.  If one does not exist, loads the 
+    provided defaults.
+
+    Returns: EnviConfig with appropriate config data
+    '''
+    if cfgdir:
+        vivhome = os.path.abspath(cfgdir)
+    else:
+        vivhome = gethomedir(".viv", makedir=autosave)
+
+    cfgpath = os.path.join(vivhome, 'viv.json')
+    config = EnviConfig(filename=cfgpath, defaults=defaults, docs=docs, autosave=autosave)
+    return config
+
+
 class EnviConfig:
     '''
     EnviConfig basically works like a multi-layer dictionary that

--- a/envi/threads.py
+++ b/envi/threads.py
@@ -127,6 +127,7 @@ class ChunkQueue:
             # Clear the event so we can wait...
             self.event.clear()
 
+        logger.log(e_cmn.MIRE, "self.event.wait(%d)", timeout)
         self.event.wait(timeout=timeout)
         if self.shut:
             raise e_exc.QueueShutdown()
@@ -214,6 +215,7 @@ class EnviQueue:
 
         while True:
             if self.shut:
+                logger.debug("get() SHUTDOWN")
                 raise e_exc.QueueShutdown()
 
             with self.lock:

--- a/envi/threads.py
+++ b/envi/threads.py
@@ -8,6 +8,7 @@ import functools
 import collections
 
 import envi.exc as e_exc
+import envi.common as e_cmn
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class ChunkQueue:
     when requested to minimize round tripping.  It's also keeps track
     of client checkins to help identify "abandonment" behaviors.
     '''
-    def __init__(self, items=None):
+    def __init__(self, items=None, chunksize=None):
         self.shut = False
         self.last = time.time()
         self.lock = threading.Lock()
@@ -66,6 +67,7 @@ class ChunkQueue:
         if items is None:
             items = []
         self.items = items
+        self.chunksize = chunksize
 
     def shutdown(self):
         self.shut = True
@@ -138,8 +140,14 @@ class ChunkQueue:
         return list(self.items)
 
     def _get_items(self):
-        ret = self.items
-        self.items = []
+        if self.chunksize is not None:
+            ret = self.items[:self.chunksize]
+            self.items = self.items[self.chunksize:]
+            logger.debug("_get_items() - returning %d items (%d remaining)", len(ret), len(self.items))
+        else:
+            ret = self.items
+            self.items = []
+            logger.debug("_get_items() - returning %d items (%d remaining)", len(ret), len(self.items))
         return ret
 
 class EnviQueue:

--- a/vivisect/base.py
+++ b/vivisect/base.py
@@ -680,6 +680,19 @@ class VivWorkspaceCore(viv_impapi.ImportApi):
     def getEndian(self):
         return self.bigend
 
+    def notifyLoadEvent(self):
+        '''
+        There are a couple components required before we the "load event" is
+        complete.  Each component calls this function, and based on the state
+        of other components, the _load_event is set
+        '''
+        if self.getMeta('Architecture') is None:
+            return
+
+        if self.getMeta('Platform') is None:
+            return
+
+        self._load_event.set()
 
 #################################################################
 #
@@ -705,7 +718,7 @@ class VivWorkspaceCore(viv_impapi.ImportApi):
         if defcall:
             self.setMeta('DefaultCall', defcall)
 
-        self._load_event.set()
+        self.notifyLoadEvent()
 
     def _mcb_bigend(self, name, value):
         self.setEndian(bool(value))
@@ -718,7 +731,7 @@ class VivWorkspaceCore(viv_impapi.ImportApi):
         if defcall:
             self.setMeta('DefaultCall', defcall)
 
-        self._load_event.set()
+        self.notifyLoadEvent()
 
     def _mcb_FileBytes(self, name, value):
         if not self.parsedbin:

--- a/vivisect/defconfig.py
+++ b/vivisect/defconfig.py
@@ -1,4 +1,5 @@
 import vdb
+import cobra
 import getpass
 
 
@@ -49,13 +50,16 @@ defconfig = {
         },
         'remote':{
             'wait_for_plat_arch': 10,
+            'timeo_wait': 10,
+            'timeo_aban': 120,
         },
         'server':{
-            'queue_chunksize': 70000,  # average small packets add up to ~1400 bytes
+            'queue_chunksize': 70000,
         },
     },
     'cli':vdb.defconfig.get('cli'), # FIXME make our own...
     'vdb':vdb.defconfig.get('vdb'),
+    'cobra':cobra.defconfig.get('cobra'),
     'user':{
         'name': getpass.getuser(),
     }
@@ -104,6 +108,8 @@ docconfig = {
         },
         'remote':{
             'wait_for_plat_arch':'How many secs to wait for the remote server/workspace to provide a Platform or Architecture before moving on.',
+            'timeo_wait': "Timeout waiting for getNextEvent() to have more Viv events to send.",
+            'timeo_aban': "Server channel timeout.  At this point, clean up and delete the channel.  The connection is dead.",
         },
 
         'server':{

--- a/vivisect/defconfig.py
+++ b/vivisect/defconfig.py
@@ -50,8 +50,8 @@ defconfig = {
         },
         'remote':{
             'wait_for_plat_arch': 10,
-            'timeo_wait': 10,
-            'timeo_aban': 120,
+            'timeout_wait': 10,
+            'timeout_aban': 120,
         },
         'server':{
             'queue_chunksize': 70000,
@@ -108,8 +108,8 @@ docconfig = {
         },
         'remote':{
             'wait_for_plat_arch':'How many secs to wait for the remote server/workspace to provide a Platform or Architecture before moving on.',
-            'timeo_wait': "Timeout waiting for getNextEvent() to have more Viv events to send.",
-            'timeo_aban': "Server channel timeout.  At this point, clean up and delete the channel.  The connection is dead.",
+            'timeout_wait': "Timeout waiting for getNextEvent() to have more Viv events to send.",
+            'timeout_aban': "Server channel timeout.  At this point, clean up and delete the channel.  The connection is dead.",
         },
 
         'server':{

--- a/vivisect/defconfig.py
+++ b/vivisect/defconfig.py
@@ -50,6 +50,9 @@ defconfig = {
         'remote':{
             'wait_for_plat_arch': 10,
         },
+        'server':{
+            'queue_chunksize': 70000,  # average small packets add up to ~1400 bytes
+        },
     },
     'cli':vdb.defconfig.get('cli'), # FIXME make our own...
     'vdb':vdb.defconfig.get('vdb'),
@@ -101,12 +104,15 @@ docconfig = {
         },
         'remote':{
             'wait_for_plat_arch':'How many secs to wait for the remote server/workspace to provide a Platform or Architecture before moving on.',
-        }
+        },
 
+        'server':{
+            'queue_chunksize':"VivServer Queue Chunk Size, the largest chunk of events the server will send at a time.  This affects queue time and overall efficiency of serving large workspaces",
+        },
     },
 
     'vdb':vdb.docconfig.get('vdb'),
     'user':{
         'name': 'Username.  When not set, defaults to current system user.',
-        }
+    }
 }

--- a/vivisect/qt/remote.py
+++ b/vivisect/qt/remote.py
@@ -168,7 +168,7 @@ def selectServerWorkspace(vw, server, workspaces, parent=None):
 @vq_main.workthread
 def loadServerWorkspace(oldvw, server, workspace):
     oldvw.vprint('Loading Workspace: %s' % workspace)
-    vw = viv_server.getServerWorkspace(server, workspace)
+    vw = viv_server.getServerWorkspace(server, workspace, block=False)
     # reset the FunctionGraph Counter
     v_q_funcgraph.reset()
 

--- a/vivisect/qt/remote.py
+++ b/vivisect/qt/remote.py
@@ -168,7 +168,7 @@ def selectServerWorkspace(vw, server, workspaces, parent=None):
 @vq_main.workthread
 def loadServerWorkspace(oldvw, server, workspace):
     oldvw.vprint('Loading Workspace: %s' % workspace)
-    vw = viv_server.getServerWorkspace(server, workspace, block=False)
+    vw = viv_server.getServerWorkspace(server, workspace)
     # reset the FunctionGraph Counter
     v_q_funcgraph.reset()
 

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -353,15 +353,17 @@ class VivChunkQueue(e_threads.ChunkQueue):
             return []
 
         # watch for event groups
-        # we're looking for groupings of events.  but each event is a tuple.
-        #    so we want to look for a tuple of tuples or lists
+        # "event groups" are a dict with a list stored at key 0.  this list is
+        # then able to be shoved over the Cobra channel immediately, front-loading
+        # any preparation, and drastically speeding up initial message glut on
+        # workspace loading.
         if type(self.items[0]) == dict:
             evtgroup = self.items.pop(0)
             evts = evtgroup[0]
             logger.debug("_get_items: STORED EVENT GROUP of size %d (queue remaining: %d)", len(evts), len(self.items))
             return evts
 
-        # probably revamp this to simply do event at a time.
+        # handle events in "chunks"
         if self.chunksize is not None:
             logger.debug('_get_items(): chunksize: %d', self.chunksize)
 

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -516,7 +516,7 @@ class VivChunkQueue(e_threads.ChunkQueue):
 
 
 
-def getServerWorkspace(server, wsname, block=True):
+def getServerWorkspace(server, wsname):
     vw = v_cli.VivCli()
     logger.debug("Starting:  VivServerClient(%r, %r)", server, wsname)
     cliproxy = VivServerClient(vw, server, wsname)

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -28,6 +28,7 @@ viv_port = 0x4074
 viv_s_ip = '224.56.56.56'
 viv_s_port = 26998
 
+# DEFAULTS for non-configured use
 timeo_wait = 10
 timeo_sock = 50
 timeo_aban = 120   # 2 minute timeout for abandon
@@ -161,6 +162,9 @@ class VivServer:
             self.vivhome = e_config.gethomedir(".viv", makedir=True)
         cfgpath = os.path.join(self.vivhome, 'viv.json')
         self.config = e_config.EnviConfig(filename=cfgpath, defaults=defconfig, docs=docconfig, autosave=True)
+
+        self.timeo_wait = self.config.viv.remote.timeo_wait
+        self.timeo_aban = self.config.viv.remote.timeo_aban
         self.wsdict = {}
         self.chandict = {}
         self.wslock = threading.Lock()
@@ -185,7 +189,7 @@ class VivServer:
                 continue
 
             wsinfo, queue, chanleaders = chaninfo
-            if queue.abandoned(timeo_aban):
+            if queue.abandoned(self.timeo_aban):
                 self.cleanupChannel(chan)
 
     @e_threads.maintthread(30)
@@ -265,7 +269,7 @@ class VivServer:
         if chaninfo is None:
             raise Exception('Invalid Channel: %s' % chan)
         logger.debug("getNextEvents(%r)", repr(chaninfo))
-        return chaninfo[1].get(timeout=timeo_wait)
+        return chaninfo[1].get(timeout=self.timeo_wait)
 
     # All APIs from here down are basically mirrors of the workspace APIs
     # used with remote workspaces, with a prepended chan first argument

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -433,6 +433,12 @@ class VivChunkQueue(e_threads.ChunkQueue):
 
     @e_threads.firethread
     def asyncAddLargeEventList(self, evts):
+        '''
+        Break up a large list of events into appropriately pre-sized chunks,
+        allowing for high efficiency in serving them.  This is a @firethread
+        function, meaning that it runs in its own thread, making it "fire-and-
+        forget".
+        '''
         evtcount = len(evts)
         idx = 0
         logger.debug("... adding %d events to the Queue", evtcount)

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -349,7 +349,7 @@ class VivServer:
 class VivChunkQueue(e_threads.ChunkQueue):
     '''
     Vivisect Event specific version of the ChunkQueue
-    This ChunkQueue implements a form of ChunkQueue specifically designed to
+    This ChunkQueue implements ChunkQueue helpers specifically designed to
     handle VivServer requirements, namely:
     1) Chunking Around VWE_ADDMMAP events to reduce delays between request to
         response

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -347,6 +347,20 @@ class VivServer:
 # TODO: queue events to a list...  after a few ms (or CHUNKSIZE reached), convert to a Dict/List and send it?
 
 class VivChunkQueue(e_threads.ChunkQueue):
+    '''
+    Vivisect Event specific version of the ChunkQueue
+    This ChunkQueue implements a form of ChunkQueue specifically designed to
+    handle VivServer requirements, namely:
+    1) Chunking Around VWE_ADDMMAP events to reduce delays between request to
+        response
+    2) Front-loading chunking of the initial file VivServer download. Again,
+        this helps avoid timeouts while processing large workspaces.  With
+        the addition of multi-library VivWorkspaces, this can be a *real*
+        problem.  VivChunkQueue helps solve those problems
+    3) Introduction of the Event Group, enabling the functionality required
+        to do #2 efficiently.  Front-loading pre-analyzed groups of events
+        speeds up loading dramatically
+    '''
     def _get_items(self):
         '''
         Already has self.lock when called.

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import cobra
 import queue
 import logging
@@ -59,6 +60,7 @@ class VivServerClient:
                     count += 1
                     self.q.put(event)
             logger.debug("Workspace Event Processing run Complete. (%d events processed)", count)
+            time.sleep(.01)
 
     def vprint(self, msg):
         return self.server.vprint(msg)
@@ -373,6 +375,10 @@ class VivChunkQueue(e_threads.ChunkQueue):
             # workspaces)
             idx = None
             for idx in range(self.chunksize-1):
+                # break if we reach the end of the event list
+                if idx >= len(self.items):
+                    break
+
                 evtitem = self.items[idx]
 
                 # search for Event Groups
@@ -385,10 +391,6 @@ class VivChunkQueue(e_threads.ChunkQueue):
                 evtype, evtdata = evtitem
                 # search for ADDMMAP events
                 if evtype == vivisect.VWE_ADDMMAP:
-                    break
-
-                # break if we reach the end of the event list
-                if idx > len(self.items):
                     break
 
 

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -222,7 +222,7 @@ class VivServer:
                     logger.debug('loaded: %s', wsname)
                     self.wsdict[wsname] = wsinfo
 
-    def getNextEvents(self, chan, maxevts=None):
+    def getNextEvents(self, chan):
         chaninfo = self.chandict.get(chan)
         if chaninfo is None:
             raise Exception('Invalid Channel: %s' % chan)

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -422,7 +422,7 @@ class VivChunkQueue(e_threads.ChunkQueue):
             return evts
 
         # handle events in "chunks"
-        if self.chunksize is not None:
+        if self.chunksize:
             logger.debug('_get_items(): chunksize: %d', self.chunksize)
 
             # search for ADDMMAPs so we don't group two in one transmission

--- a/vivisect/remote/server.py
+++ b/vivisect/remote/server.py
@@ -353,7 +353,7 @@ class VivServer:
             fileevts = viv_basicfile.vivEventsFromFile(fpath)
             fileevts.extend(pevents)
             # use this firethread function to add events while we return the channel
-            queue.asyncAddLargeEventList(fileevts)
+            queue.chunkedAddLargeEventList(fileevts)
 
         return chan
 
@@ -474,7 +474,7 @@ class VivChunkQueue(e_threads.ChunkQueue):
         return ret
 
     @e_threads.firethread
-    def asyncAddLargeEventList(self, evts):
+    def chunkedAddLargeEventList(self, evts):
         '''
         Break up a large list of events into appropriately pre-sized chunks,
         allowing for high efficiency in serving them.  This is a @firethread

--- a/vivisect/tests/testremote.py
+++ b/vivisect/tests/testremote.py
@@ -13,6 +13,9 @@ import vivisect.tests.helpers as helpers
 import vivisect.remote.server as v_r_server
 
 import envi.memcanvas as e_mcanvas
+import envi.common as ecmn
+logger = ecmn.logging.getLogger(__name__)
+ecmn.initLogging(logger)
 
 def runServer(name, port):
     dirn = os.path.dirname(name)

--- a/vivisect/vivbin.py
+++ b/vivisect/vivbin.py
@@ -37,6 +37,10 @@ def main():
                         help='Manually specify the parser module (pe/elf/blob/...)')
     parser.add_argument('-s', '--storage', dest='storage_name', default=None, action='store',
                         help='Specify a storage module by name')
+    parser.add_argument('-S', '--server', dest='server_mode', default=False, action='store_true',
+                        help='Run Vivisect Server.  Last argument should be the VivWorkspaces directory.')
+    parser.add_argument('-P', '--port', dest='server_port', default=None, action='store',
+                        help='Port to run Vivisect Server on (only meaningful with --server)')
     parser.add_argument('-v', '--verbose', dest='verbose', default=False, action='count',
                         help='Enable verbose mode (multiples matter: -vvvv)')
     parser.add_argument('-V', '--version', dest='version', default=None, action='store',
@@ -59,6 +63,24 @@ def main():
     vw.verbose = min(args.verbose, len(e_common.LOG_LEVELS)-1)
     level = e_common.LOG_LEVELS[vw.verbose]
     e_common.initLogging(logger, level=level)
+
+    if args.server_mode:
+        import vivisect.remote.server as vr_server
+        if len(args.file):
+            file = args.file[-1]
+
+        else:
+            print("Server mode requires directory name as last argument")
+            sys.exit(-1)
+
+        print("args.file: %r" % repr(args.file))
+        print("file: %r" % repr(file))
+        if args.server_port is None:
+            vr_server.runMainServer(dirname=file)
+        else:
+            server_port = int(args.server_port)
+            vr_server.runMainServer(dirname=file, port=server_port)
+        sys.exit(0)
 
     if args.outfile:
         vw.setMeta('StorageName', args.outfile)

--- a/vivisect/vivbin.py
+++ b/vivisect/vivbin.py
@@ -73,8 +73,6 @@ def main():
             print("Server mode requires directory name as last argument")
             sys.exit(-1)
 
-        print("args.file: %r" % repr(args.file))
-        print("file: %r" % repr(file))
         if args.server_port is None:
             vr_server.runMainServer(dirname=file)
         else:


### PR DESCRIPTION
first off:  

* `vivbin -S` now starts the VivServer.  `-P` sets the listening port.  you can still use `python -m vivisect.remote.server` but that is so hackery, i wanted something up front and personal.  i could easily be swayed to making a standalone script `vivserver` instead, which would simply hand off to `vivisect.remote.server.main()` and not collide with `vivbin`'s command line arguments.

more importantly: 

* this PR modifies VivServer comms to break up massive event dumps into max chunk sizes, and favors sending Memory Maps individually. (ie. as soon as a VWE_ADDMAP event occurs, just send them).

* these changes help reduce timeouts while loading massive remote workspaces (i'm currently working on a 500MB workspace right now). tweaking the timeouts and chunk sizes still.  was taking 35 minutes to load, now down to ~16minutes over Wifi.  i'm still not happy, looking for other ways to enhance performance, but i'm happy with this direction as i believe it is necessary.  i think there are unnecessary delays in `master` branch vivserver, so i'm looking for them.  when i cut chunk size down to small amounts, like 10 events, i am seeing a consistent .3s delay between sends.  when i use tcpdump to watch traffic, i'm consistently seeing delays, but i'm not sure if that's because it takes so long to send 1MB-10MB memory maps.

if i make no further changes, this PR stands on its own and is worth reviewing and merging.

future PR's may include:

* further performance enhancements
* status updates (think, percent done loading)
* a few other items percolating