### PR TITLE
tag tracking in fg/memview

### DIFF
--- a/envi/qt/html.py
+++ b/envi/qt/html.py
@@ -106,6 +106,9 @@ function nameclick(elem) {
     var newclass = "envi-" + tagname + "-" + tagval;
     $("." + selclass).removeClass(selclass);
     $("." + newclass).addClass(selclass);
+
+    console.log("click name " + tagname + " : " + tagval);
+    vnav._jsSetCurTag(tagname, tagval);
 }
 
 var curva = null;
@@ -116,6 +119,8 @@ document.addEventListener("DOMContentLoaded", function () {
         vnav = channel.objects.vnav;
     });
 });
+
+
 
 function vaclick(elem) {
     var elem = $(elem);

--- a/envi/qt/memcanvas.py
+++ b/envi/qt/memcanvas.py
@@ -16,6 +16,7 @@ import envi.qt.jquery as e_q_jquery
 qt_horizontal = 1
 qt_vertical = 2
 
+from binascii import *
 from vqt.main import *
 from vqt.common import *
 
@@ -35,6 +36,7 @@ class VQMemoryCanvas(e_memcanvas.MemoryCanvas, QWebEngineView):
 
         self._canv_cache = None
         self._canv_curva = None
+        self._canv_curtag = None
         self._canv_rend_middle = False
         self.fname = None
 
@@ -243,6 +245,11 @@ class VQMemoryCanvas(e_memcanvas.MemoryCanvas, QWebEngineView):
     def _jsSetCurVa(self, vastr):
         self._canv_curva = int(str(vastr), 0)
 
+    @QtCore.pyqtSlot(str, str)
+    def _jsSetCurTag(self, tagname, tagval):
+        print("_jsSetCurTag(%r, %r)" % (tagname, tagval))
+        self._canv_curtag = (str(tagname), unhexlify(str(tagval)))
+
     # NOTE: doing append / scroll seperately allows render to catch up
     @idlethread
     def _appendInside(self, text, cb=None, sel=None):
@@ -291,16 +298,17 @@ class VQMemoryCanvas(e_memcanvas.MemoryCanvas, QWebEngineView):
 
     def contextMenuEvent(self, event):
         va = self._canv_curva
+        tag = self._canv_curtag
         menu = QMenu()
         if self._canv_curva is not None:
-            self.initMemWindowMenu(va, menu)
+            self.initMemWindowMenu(va, tag, menu)
 
         viewmenu = menu.addMenu('view   ')
         viewmenu.addAction("Save frame to HTML", ACT(self._menuSaveToHtml))
 
         menu.exec_(event.globalPos())
 
-    def initMemWindowMenu(self, va, menu):
+    def initMemWindowMenu(self, va, tag, menu):
         initMemSendtoMenu('0x%.8x' % va, menu)
 
     def dumpHtml(self, data):

--- a/envi/qt/memcanvas.py
+++ b/envi/qt/memcanvas.py
@@ -244,6 +244,9 @@ class VQMemoryCanvas(e_memcanvas.MemoryCanvas, QWebEngineView):
     @QtCore.pyqtSlot(str)
     def _jsSetCurVa(self, vastr):
         self._canv_curva = int(str(vastr), 0)
+        # if we click on a VA, we no longer want a tag to show up 
+        # (could do this another way so we keep "last tag" but indicate which has preference??)
+        self._canv_curtag = None
 
     @QtCore.pyqtSlot(str, str)
     def _jsSetCurTag(self, tagname, tagval):

--- a/vivisect/extensions/example_gui_extension.py
+++ b/vivisect/extensions/example_gui_extension.py
@@ -53,7 +53,7 @@ def vprint(vw, s, *args, **kwargs):
     print(s % args)
 
 
-def ctxMenuHook(vw, va, expr, menu, parent, nav):
+def ctxMenuHook(vw, va, expr, menu, parent, nav, tag=None):
     '''
     Context Menu handler (adds options as we wish)
     '''

--- a/vivisect/qt/ctxmenu.py
+++ b/vivisect/qt/ctxmenu.py
@@ -107,7 +107,7 @@ def buildContextMenu(vw, va=None, expr=None, menu=None, parent=None, nav=None, t
     if menu is None:
         menu = QMenu(parent=parent)
 
-    menu.addAction('rename (n)', ACT(vw.getVivGui().setVaName, va))
+    menu.addAction('rename (n)', ACT(vw.getVivGui().setName, va, tag))
     menu.addAction('comment (;)', ACT(vw.getVivGui().setVaComment, va))
     menu.addAction('print location', ACT(vw.getVivGui().getLocation, va))
 

--- a/vivisect/qt/ctxmenu.py
+++ b/vivisect/qt/ctxmenu.py
@@ -86,7 +86,7 @@ def initMemSendtoMenu(vw, xexpr, xmenu):
     
     submenu.addAction('FuncGraph View', ACT(newFuncGraph, vw, xexpr))
 
-def buildContextMenu(vw, va=None, expr=None, menu=None, parent=None, nav=None):
+def buildContextMenu(vw, va=None, expr=None, menu=None, parent=None, nav=None, tag=None):
     '''
     Return (optionally construct) a menu to use for handling a context click
     at the given virtual address or envi expression.
@@ -252,6 +252,6 @@ def buildContextMenu(vw, va=None, expr=None, menu=None, parent=None, nav=None):
     # give any extensions a chance to play
     for extname, exthook in vw._ext_ctxmenu_hooks.items():
         logger.info('exthook: %r', exthook)
-        exthook(vw, va, expr, menu, parent, nav)
+        exthook(vw, va, expr, menu, parent, nav, tag)
 
     return menu

--- a/vivisect/qt/funcgraph.py
+++ b/vivisect/qt/funcgraph.py
@@ -150,8 +150,9 @@ class VQVivFuncgraphCanvas(vq_memory.VivCanvasBase):
         pass
 
     def contextMenuEvent(self, event):
+        tag = self._canv_curtag
         if self._canv_curva is not None:
-            menu = vq_ctxmenu.buildContextMenu(self.vw, va=self._canv_curva, parent=self, nav=self.parent())
+            menu = vq_ctxmenu.buildContextMenu(self.vw, va=self._canv_curva, parent=self, nav=self.parent(), tag=tag)
         else:
             menu = QMenu(parent=self)
 

--- a/vivisect/qt/main.py
+++ b/vivisect/qt/main.py
@@ -156,6 +156,35 @@ class VQVivMainWindow(viv_base.VivEventDist, vq_app.VQMainCmdWindow):
 
             self.vw.makeName(va, name)
 
+    def setName(self, va, tag, parent=None):
+        '''
+        Set the name for a given Tag or VA 
+        '''
+        if parent is None:
+            parent = self
+
+        if tag and tag[0] == 'name':
+            # do tag things
+            ttype, tagname = tag
+            
+            if tagname:
+                tagname = tagname.decode('utf8')
+                fva = self.vw.getFunction(va)
+                if fva:
+                    rtype, rname, cconv, cname, cargs = self.vw.getFunctionApi(fva)
+                    if cargs:
+                        for i, (atype, aname) in enumerate(cargs):
+                            if aname == tagname:
+                                self.setFuncArgName(fva, i, atype, aname)
+                            else:
+                                logger.warning("%s != %s" % (aname, tagname))
+                    else:
+                        logger.warning("setName(va=0x%x, tag=%r) called on a 'name' but function has no args: fva: 0x%x", va, repr(tag), fva)
+                else:
+                    vw.vprint("setName(va=0x%x, tag=%r):  can't determine what function we're in", va, repr(tag))
+        else:
+            self.setVaName(va)
+
     def setVaComment(self, va, parent=None):
         if parent is None:
             parent = self

--- a/vivisect/qt/memory.py
+++ b/vivisect/qt/memory.py
@@ -411,9 +411,9 @@ class VQVivMemoryCanvas(VivCanvasBase):
         if self._canv_navcallback:
             self._canv_navcallback(expr)
 
-    def initMemWindowMenu(self, va, menu):
+    def initMemWindowMenu(self, va, tag, menu):
         nav = self.parent()  # our parent is always a VQVivMemoryWindow (nav target)
-        viv_q_ctxmenu.buildContextMenu(self.vw, va=va, menu=menu, nav=nav)
+        viv_q_ctxmenu.buildContextMenu(self.vw, va=va, menu=menu, nav=nav, tag=tag)
 
     def _loc_helper(self, va):
         '''

--- a/vivisect/qt/memory.py
+++ b/vivisect/qt/memory.py
@@ -258,7 +258,7 @@ class VivCanvasBase(vq_hotkey.HotKeyMixin, e_mem_canvas.VQMemoryCanvas):
     @vq_hotkey.hotkey('viv:setname')
     def _hotkey_setname(self):
         if self._canv_curva is not None:
-            self.vw.getVivGui().setVaName(self._canv_curva, parent=self)
+            self.vw.getVivGui().setName(self._canv_curva, self._canv_curtag, parent=self)
 
     @vq_hotkey.hotkey('viv:bookmark')
     def _hotkey_bookmark(self):


### PR DESCRIPTION
this PR adds tag-tracking to the MemoryCanvas and FuncgraphCanvas objects for enhanced context tracking... allowing greater granularity for event handling.

just as we currently nearly always have `curva` available, this PR also gives us `curtag`

this should allow us to better track non-VA items selected in the GUI.  for example, right-clicking on a function argument or local variable tag to rename it, instead of `right-click -> function -> args -> arg2` when `arg2` is right there in front of you!