### PR TITLE
PE/ELF loader fixes

### DIFF
--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -1072,7 +1072,12 @@ class PE(object):
                 entry_name_rva = self.vaToRva(entry_name)
 
             # RP BUG FIX - we can't assume that we have 256 bytes to read
-            libname = self.readStringAtRva(entry_name_rva, maxsize=256).decode('utf-8')
+            try:
+                libname = self.readStringAtRva(entry_name_rva, maxsize=256).decode('utf-8')
+            except UnicodeDecodeError:
+                # if we're getting decode errors, then we're probably not reading real string data
+                # and the table is probably corrupt, so bail.
+                break
             idx = 0
 
             if flavor == "import table":

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -638,6 +638,10 @@ def loadElfIntoWorkspace(vw, elf, filename=None, baseaddr=None):
                         byts = vw.readMemory(sva, psize)
                         if len(byts) == psize:
                             new_pointers.append((sva, valu, symname))
+                    elif s.st_size == 0:
+                        # the object doesn't have any size, 
+                        # so don't try to create anything at its location.
+                        pass
                     elif vw.isProbablyUnicode(sva):
                         vw.makeUnicode(sva, size=s.st_size)
                     elif vw.isProbablyString(sva):

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -184,6 +184,13 @@ def makeFunctionTable(elf, vw, tbladdr, size, tblname, funcs, ptrs, baseoff=0):
     psize = vw.getPointerSize()
     fmtgrps = e_bits.fmt_chars[vw.getEndian()]
     pfmt = fmtgrps[psize]
+
+    if size % psize != 0:
+        # If the table size isn't a multiple of the pointer size, round down.
+        # It doesn't really make sense for this to be the case, 
+        # but this is seen in a small number of real world samples.
+        size -= (size % psize)
+
     secbytes = elf.readAtRva(tbladdr, size)
     tbladdr += baseoff
 


### PR DESCRIPTION
This PR fixes four loader bugs encountered while running vivisect against a large number of real world samples. The associated capa issue #s (and ultimately sample hashes) are referenced in the individual commit messages.

f280156636a9c5d9a4748410aafe80bb3467f92f - bail when import strings aren't valid unicode, which probably indicates a corrupt file
9c7b9b895c941e8f519e414e795cff7bc4dafcc5 - handle function tables where the size isn't a multiple of the pointer size. not sure when/why this happens, but seems to involve e.g., 4 padding bytes on a 64-bit system.
c8019edb8cd6425925cc78f878d4395bc085565a - don't try to create data (string/numbers/etc.) for symbols with zero size.
b3e538b2f528765c4f28ef5eaff09e381dd677dd - handle extern object symbols, like the environ pointer provided by glibc.