### PR TITLE
readMemString() Wide Bugfix

### DIFF
--- a/envi/memory.py
+++ b/envi/memory.py
@@ -739,6 +739,10 @@ class MemoryObject(IMemory):
 
                 # now find the end of the string based on either \x00, maxlen, or end of map
                 end = mbytes.find(terminator, offset)
+                while (end > offset) and (end-offset) % len(terminator) != 0:
+                    # with codepage 0, we really need \0\0\0 because the first
+                    #   0 is part of the last character
+                    end = mbytes.find(terminator, end+1)
 
                 left = end - offset
                 if end == -1:

--- a/envi/tests/test_memory.py
+++ b/envi/tests/test_memory.py
@@ -64,4 +64,18 @@ class EnviMemoryTest(unittest.TestCase):
         with self.assertRaises(e_exc.NoValidFreeMemoryFound):
             failmap = mem.allocateMemory(0x100000)
 
+    def test_readMemString(self):
+        mem = e_mem.MemoryObject()
+        mem.addMemoryMap(0x41410000, e_const.MM_RWX, 'test', b'\0'*1024)
+        mem.addMemoryMap(0x41420000, e_const.MM_RWX, 'test', b'abcdefghijklmnop\0' + b'\0'*1024)
+        mem.addMemoryMap(0x41430000, e_const.MM_RWX, 'test', b'a\0b\0c\0d\0e\0f\0g\0h\0i\0j\0k\0l\0m\0n\0o\0p\0' + b'\0'*1024)
+
+        self.assertEqual(mem.readMemString(0x41410000), b'')
+        self.assertEqual(mem.readMemString(0x41420000), b'abcdefghijklmnop')
+        self.assertEqual(mem.readMemString(0x41430000), b'a')
+
+        self.assertEqual(mem.readMemString(0x41410000, wide=True), b'',)
+        self.assertEqual(mem.readMemString(0x41420000, wide=True), b'abcdefghijklmnop') # only looks for '\0\0' terminator
+        self.assertEqual(mem.readMemString(0x41430000, wide=True), b'a\0b\0c\0d\0e\0f\0g\0h\0i\0j\0k\0l\0m\0n\0o\0p\0')
+
 


### PR DESCRIPTION
fix bug in readMemString(<>, wide=True) where the last \x00 is considered part of the terminator instead of the last character

with unittests