### PR TITLE
Fix missing ARM alias in arch_defs (#666)

### DIFF
--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -72,7 +72,7 @@ arch_defs = {
     
     ARCH_ARMV7:     {
         'name':     'arm',
-        'aliases':  ('armv7a', 'armv6l', 'armv7l', 'a32', 'leg', 'leg32'),
+        'aliases':  ('armv7a', 'armv7', 'armv7l', 'armv6l', 'arm32', 'a32', 'leg', 'leg32'),
         'modpath':  ('envi', 'archs', 'arm'),
         'clsname':  'ArmModule',
         'version':  (1,0,0),

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -72,7 +72,7 @@ arch_defs = {
     
     ARCH_ARMV7:     {
         'name':     'arm',
-        'aliases':  ('armv6l', 'armv7l', 'a32', 'leg', 'leg32'),
+        'aliases':  ('armv7a', 'armv6l', 'armv7l', 'a32', 'leg', 'leg32'),
         'modpath':  ('envi', 'archs', 'arm'),
         'clsname':  'ArmModule',
         'version':  (1,0,0),
@@ -1555,7 +1555,7 @@ def getArchByName(archname):
     '''
     Get the architecture constant by the humon name.
     '''
-    return arch_by_name_and_aliases.get(archname)
+    return arch_by_name_and_aliases.get(archname.lower())
 
 def getArchById(archid):
     '''


### PR DESCRIPTION
This adds "armv7a" to the list of aliases for the arm module.
It also ensures the checks are lowercase.