### PR TITLE
ARM arch name normalization (fka: arm _arch_id bugfix)

### DIFF
--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -72,7 +72,7 @@ arch_defs = {
     
     ARCH_ARMV7:     {
         'name':     'arm',
-        'aliases':  ('armv6l', 'armv7l', 'a32', 'leg', 'leg32', 'armv7a', 'armv7'),
+        'aliases':  ('armv6l', 'armv7l', 'a32', 'leg', 'leg32'),
         'modpath':  ('envi', 'archs', 'arm'),
         'clsname':  'ArmModule',
         'version':  (1,0,0),
@@ -365,7 +365,6 @@ class ArchitectureModule:
     _default_call = None
     _plat_def_calls = {}
     def __init__(self, archname, maxinst=32, endian=ENDIAN_LSB):
-        print("archname: %r" %  archname)
         self._arch_id = getArchByName(archname)
         self._arch_name = archname
         self._arch_maxinst = maxinst
@@ -1556,7 +1555,7 @@ def getArchByName(archname):
     '''
     Get the architecture constant by the humon name.
     '''
-    return arch_by_name_and_aliases.get(archname.lower())
+    return arch_by_name_and_aliases.get(archname)
 
 def getArchById(archid):
     '''

--- a/envi/__init__.py
+++ b/envi/__init__.py
@@ -72,7 +72,7 @@ arch_defs = {
     
     ARCH_ARMV7:     {
         'name':     'arm',
-        'aliases':  ('armv6l', 'armv7l', 'a32', 'leg', 'leg32'),
+        'aliases':  ('armv6l', 'armv7l', 'a32', 'leg', 'leg32', 'armv7a', 'armv7'),
         'modpath':  ('envi', 'archs', 'arm'),
         'clsname':  'ArmModule',
         'version':  (1,0,0),
@@ -365,6 +365,7 @@ class ArchitectureModule:
     _default_call = None
     _plat_def_calls = {}
     def __init__(self, archname, maxinst=32, endian=ENDIAN_LSB):
+        print("archname: %r" %  archname)
         self._arch_id = getArchByName(archname)
         self._arch_name = archname
         self._arch_maxinst = maxinst
@@ -1555,7 +1556,7 @@ def getArchByName(archname):
     '''
     Get the architecture constant by the humon name.
     '''
-    return arch_by_name_and_aliases.get(archname)
+    return arch_by_name_and_aliases.get(archname.lower())
 
 def getArchById(archid):
     '''

--- a/envi/archs/arm/__init__.py
+++ b/envi/archs/arm/__init__.py
@@ -10,7 +10,7 @@ from envi.archs.arm.disasm import *
 
 class ArmModule(envi.ArchitectureModule):
 
-    def __init__(self, name='ARMv7A'):
+    def __init__(self, name='arm'):
         import envi.archs.thumb16.disasm as eatd
         # these are required for setEndian() which is called from ArchitectureModule.__init__()
         self._arch_dis = ArmDisasm()


### PR DESCRIPTION
fix `ARMv7A` not having/being a valid archname, so `getArchByName()` returns None... causing `ArmModule.getArchId()` to return `None`