### PR TITLE
Fix references being added for dynamic api calls.

### DIFF
--- a/vivisect/impemu/monitor.py
+++ b/vivisect/impemu/monitor.py
@@ -107,6 +107,12 @@ class AnalysisMonitor(EmulationMonitor):
             reprargs = [emu.reprVivValue(val) for val in argv]
             self.vw.setComment(va, '%s(%s)' % (callname, ','.join(reprargs)))
             cva = self.vw.vaByName(callname)
+            if not cva:
+                # Look for imports that match the call name.
+                for import_va, _, _, import_name in self.vw.getImports():
+                    if import_name == callname:
+                        cva = import_va
+                        break
             if cva:
                 self.vw.addXref(va, cva, REF_CODE, envi.BR_PROC)
 


### PR DESCRIPTION
I ran into an issue where call references were not being included for dynamic api calls such as `call edi  ;ws2_32.htons(0x0)`. Where the function address was previously loaded into a register before being called.

This issue was traced to how the AnalysisMontior was adding the `self.callcomments`. Using `vw.vaByName()` was preventing the import symbol's address from being used because the locations would have the address in its name (e.g. `ws2_32.htons_004291c4` ) but the `callname` did not.

This PR fixes the issue by searching through imports to find an import that matches the emulated `callname`.

NOTE: I wasn't sure if this work should instead be done within the `vaByName()` function. I was afraid that could potentially mess up other code expecting only the raw location names to be used.