### PR TITLE
cobra logger and socket-close bugfixes

### DIFF
--- a/cobra/tests/testbasic.py
+++ b/cobra/tests/testbasic.py
@@ -2,6 +2,9 @@ import time
 import unittest
 import itertools
 import threading
+import logging
+
+logger = logging.getLogger(__name__)
 
 import cobra
 import cobra.auth as c_auth


### PR DESCRIPTION
testbasic.py used logger without importing it, causing NameError.
Added logging import and logger instance creation.
