### PR TITLE
Cleanup deprecated/removed AST module items

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install dependencies
       run: pip install 'isort==5.*' black
     - name: Lint with isort

--- a/Elf/__init__.py
+++ b/Elf/__init__.py
@@ -375,7 +375,7 @@ class Elf(vs_elf.Elf32, vs_elf.Elf64):
 
         if self.dynstrtabmeta != (None, None):
             curtab = self.dynstrtabmeta[0]
-            logger.warning('wtf?  multiple dynamic string tables?  old: 0x%x  new: 0x%x', curtab, rva)
+            logger.warning('wtf?  multiple dynamic string tables?  old: 0x%x  new: 0x%x', curtab, dynstrtabva)
 
         strtabbytes = self.readAtRva(dynstrtabva, strsz)
 

--- a/PE/__init__.py
+++ b/PE/__init__.py
@@ -250,7 +250,7 @@ class VS_VERSIONINFO:
         offset += 6
         offset, vinfosig = self._eatStringAndAlign(bytes, offset)
         if vinfosig != 'VS_VERSION_INFO':
-            Exception('Invalid VS_VERSION_INFO signature!: %s' % repr(vinfosig))
+            raise Exception('Invalid VS_VERSION_INFO signature!: %s' % repr(vinfosig))
 
         if valsize and valsize >= len(vs_pe.VS_FIXEDFILEINFO()):
             ffinfo = vs_pe.VS_FIXEDFILEINFO()
@@ -1227,7 +1227,7 @@ class PE(object):
         if e is None:
             return None
 
-        return self.readAtRva(e.Name, 128).split('\x00')[0]
+        return self.readAtRva(e.Name, 128).split(b'\x00')[0]
 
     def parseExports(self):
 
@@ -1284,7 +1284,7 @@ class PE(object):
 
                 ordl = ordlist[i]
                 nameoff = self.rvaToOffset(namelist[i])
-                if ordl > len(funclist):
+                if ordl >= len(funclist):
                     self.IMAGE_EXPORT_DIRECTORY = None
                     return
 

--- a/PE/carve.py
+++ b/PE/carve.py
@@ -92,7 +92,7 @@ def main(argv):
         fbytes = fd.read()
         for offset, i in carve(fbytes):
             print('OFFSET: %d (xor: %d)' % (offset, i))
-            p = CarvedPE(fbytes, offset, chr(i))
+            p = CarvedPE(fbytes, offset, i.to_bytes())
             print('SIZE: %d' % p.getFileSize())
 
 

--- a/PE/tools/printord.py
+++ b/PE/tools/printord.py
@@ -26,7 +26,8 @@ def main(argv):
             ords[ord+base] = name
 
         keys = list(ords.keys())
-        for k in keys.sort():
+        keys.sort()
+        for k in keys:
             print('    %d:"%s",' % (k, ords.get(k)))
 
 

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -2390,21 +2390,11 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         self.setOperValue(op, 0, res)
 
     def i_pcmpeqb(self, op, width=1, off=0):
-        # TODO: I should collapse you with _simdcmpr, yea?
-        res = 0
-        dest = self.getOperValue(op, off)
-        src = self.getOperValue(op, off+1)
-        packed = zip(yieldPacked(dest, op.opers[off].tsize, width),
-                     yieldPacked(src, op.opers[off+1].tsize, width))
-
         eql = e_bits.u_maxes[width]
-        for idx, (lft, rgt) in enumerate(packed):
-            if lft == rgt:
-                cmp = eql
-            else:
-                cmp = 0
-            res |= cmp << (8 * width * idx)
-        self.setOperValue(op, 0, res)
+
+        def cmpr(a, b):
+            return eql if a == b else 0
+        self._simdcmpr(op, cmpr, width, off)
 
     def i_pcmpeqw(self, op):
         self.i_pcmpeqb(op, width=2, off=0)

--- a/envi/archs/i386/emu.py
+++ b/envi/archs/i386/emu.py
@@ -573,6 +573,8 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
             s = (lft + rgt) & mask
             res |= s << (idx * (8 * width))
 
+        self.setOperValue(op, 0, res)
+
     def i_paddw(self, op):
         self.i_paddb(op, width=2)
 
@@ -1324,7 +1326,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
             # so technically we're supposed to zero out the upper ymm bits
             mask = 0xFFFFFFFFFFFFFFFFFFFFFFFF00000000
             dst &= ~mask
-            dst | src & 0xFFFFFFFF
+            dst |= src & 0xFFFFFFFF
 
         self.setOperValue(op, 0, dst)
 
@@ -1864,9 +1866,10 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         shft = self.getOperValue(op, 2)
 
         dsize = op.opers[1].tsize
-        msb = e_bits.msb(res, dsize)
+        msb = e_bits.msb(base, dsize)
 
         base >>= shft
+        # TODO: confirm your behavior
         if msb:
             # propagate the MSB down
             for i in range(shft):
@@ -2264,9 +2267,10 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
                      yieldPacked(src, tsize, width))
 
         consumed = 0
-        for i, (dst, src) in enumerate(values):
-            res |= dst << (width*i)
-            res |= src << (width * (i+1))
+        bitwidth = 8 * width
+        for i, (vdst, vsrc) in enumerate(values):
+            res |= vdst << (bitwidth * 2 * i)
+            res |= vsrc << (bitwidth * (2*i + 1))
             consumed += 2 * width
             if consumed >= limit:
                 break
@@ -2280,14 +2284,13 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
                      yieldPacked(src, tsize, width))
         values = list(values)
         values = values[(len(values) >> 1):]
-        for i, (dst, src) in enumerate(values):
-            res |= dst << (8 * width * i)
-            res |= src << (8 * width * (i + 1))
+        for i, (vdst, vsrc) in enumerate(values):
+            res |= vdst << (8 * width * (2*i))
+            res |= vsrc << (8 * width * (2*i + 1))
             consumed += 2 * width
             if consumed >= limit:
                 break
         return res
-
 
     def i_punpcklbw(self, op, width=1, off=0, override=False):
         name = self.getRealRegisterNameByIdx(op.opers[0].reg)
@@ -2387,6 +2390,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         self.setOperValue(op, 0, res)
 
     def i_pcmpeqb(self, op, width=1, off=0):
+        # TODO: I should collapse you with _simdcmpr, yea?
         res = 0
         dest = self.getOperValue(op, off)
         src = self.getOperValue(op, off+1)
@@ -2399,7 +2403,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
                 cmp = eql
             else:
                 cmp = 0
-            res |= cmp << (width * idx)
+            res |= cmp << (8 * width * idx)
         self.setOperValue(op, 0, res)
 
     def i_pcmpeqw(self, op):
@@ -2519,7 +2523,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         mask = e_bits.u_maxes[width]
 
         valus = zip(yieldPacked(src1, tsize, width),
-                    yieldPacked(src1, tsize, width))
+                    yieldPacked(src2, tsize, width))
 
         for idx, (lft, rgt) in enumerate(valus):
             s = (lft - rgt) & mask
@@ -2559,7 +2563,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
         res = 0
         bitwidth = width * 8
         valus = zip(yieldPacked(src1, tsize, width),
-                    yieldPacked(src1, tsize, width))
+                    yieldPacked(src2, tsize, width))
 
         shigh = e_bits.signed((2 ** (bitwidth - 1)) - 1, width)
         slow = e_bits.signed((2 ** (bitwidth - 1)), width)
@@ -2570,6 +2574,8 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
             elif s < slow:
                 s = slow
             res |= s << (idx * bitwidth)
+
+        self.setOperValue(op, 0, res)
 
     def i_psubsw(self, op):
         self.i_psubsb(op, width=2)
@@ -2631,7 +2637,7 @@ class IntelEmulator(i386RegisterContext, envi.Emulator):
 
     def i_pextrd(self, op):
         self.i_pextrb(op, width=4)
-        
+
     def i_vpcext(self, op):
         # expected behavior: EBX is set to 0 if Virtual PC is detected or an exception is raised
         # in a malware sample with an anti-vm check using this instruction, vpcext is followed by a "test ebx, ebx" and exception handling code. 

--- a/envi/bits.py
+++ b/envi/bits.py
@@ -80,7 +80,7 @@ def is_parity(val):
     while val:
         s ^= val & 1
         val = val >> 1
-    return (not s)
+    return not s
 
 parity_table = []
 for i in range(256):
@@ -242,11 +242,11 @@ def byteswap(value, size):
     return ret
 
 hex_fmt = {
-    0:'0x%.1x',
-    1:"0x%.2x",
-    2:"0x%.4x",
-    4:"0x%.8x",
-    8:"0x%.16x",
+    0: "0x%.1x",
+    1: "0x%.2x",
+    2: "0x%.4x",
+    4: "0x%.8x",
+    8: "0x%.16x",
 }
 
 def intwidth(val):
@@ -258,7 +258,10 @@ def intwidth(val):
         val = val >> 8
     return ret
 
+# TODO: Do any of these deserve to live since hex and bin are built-in to python?
 def hex(value, size=None):
+    neg = value < 0
+    value = abs(value)
     if size is None:
         size = intwidth(value)
 
@@ -270,11 +273,13 @@ def hex(value, size=None):
     while value:
         x.append('%.2x' % (value & 0xff))
         value = value >> 8
+
+    if not x:
+        return '0x0'
+
     x.reverse()
-    return '0x%.s' % ''.join(x)
 
-
-    return hex_fmt.get(size) % value
+    return ('-' if neg else '') + '0x%s' % ''.join(x)
 
 def binrepr(intval, bitwidth=None):
     '''
@@ -284,6 +289,8 @@ def binrepr(intval, bitwidth=None):
     while intval:
         ret.append(str(intval & 0x1))
         intval >>= 1
+    if not ret:
+        return '0'
     ret.reverse()
     binstr = ''.join(ret)
     if bitwidth is not None:
@@ -363,4 +370,3 @@ def align(origsize, alignment):
         return origsize
     else:
         return origsize + (alignment - remainder)
-

--- a/envi/exc.py
+++ b/envi/exc.py
@@ -272,3 +272,20 @@ class InvalidFile(Exception):
 
     def __repr__(self):
         return f"Invalid File: {self.file}"
+
+class ExpressionException(Exception):
+    def __init__(self, pycode, exception):
+        Exception.__init__(self)
+        self.pycode = pycode
+        self.exception = exception
+
+    def __repr__(self):
+        return "%r is not a valid expression in this context (%r)" %  (self.pycode, self.exception)
+
+    def __str__(self):
+        return self.__repr__()
+
+class UnmappedAddress(Exception):
+    def __init__(self, loc):
+        super().__init__(f"Unmapped address in {loc}")
+        self.loc = loc

--- a/envi/expression.py
+++ b/envi/expression.py
@@ -1,21 +1,7 @@
 """
 Unified expression helpers.
 """
-
-
-class ExpressionFail(Exception):
-    def __init__(self, pycode, exception):
-        Exception.__init__(self)
-        self.pycode = pycode
-        self.exception = exception
-
-    def __repr__(self):
-        return "ExpressionFail: %r is not a valid expression in this context (%r)" % \
-                (self.pycode, self.exception)
-
-    def __str__(self):
-        return self.__repr__()
-
+import envi.exc as e_exc
 
 def evaluate(pycode, locvars):
     try:
@@ -37,7 +23,7 @@ def evaluate(pycode, locvars):
             val = eval(pycode, {}, locvars)
 
         except Exception as e:
-            raise ExpressionFail(pycode, e)
+            raise e_exc.ExpressionException(pycode, e)
 
     return val
 
@@ -58,8 +44,7 @@ class ExpressionLocals(dict):
             if ret is not None:
                 if ret.symtype == 3:
                     return ret
-                else:
-                    return ret.value
+                return ret.value
         return dict.__getitem__(self, name)
 
     get = __getitem__
@@ -106,7 +91,7 @@ class MemoryExpressionLocals(ExpressionLocals):
         """
         map = self.memobj.getMemoryMap(address)
         if not map:
-            raise Exception("ERROR - un-mapped address in mapbase()")
+            raise e_exc.UnmappedAddress('mapbase')
         return map[0]
 
     def maplen(self, address):
@@ -116,7 +101,7 @@ class MemoryExpressionLocals(ExpressionLocals):
         """
         map = self.memobj.getMemoryMap(address)
         if not map:
-            raise Exception("ERROR - un-mapped address in maplen()")
+            raise e_exc.UnmappedAddress('maplen')
         return map[1]
 
     def ispoi(self, addr):

--- a/envi/qt/memory.py
+++ b/envi/qt/memory.py
@@ -6,7 +6,7 @@ from PyQt6 import QtCore, QtGui
 from PyQt6.QtGui import QAction, QShortcut
 from PyQt6.QtWidgets import *
 
-import envi.expression as e_expr
+import envi.exc as e_exc
 import envi.qt.memcanvas as e_memcanvas_qt
 import envi.memcanvas.renderers as e_render
 
@@ -236,7 +236,7 @@ class VQMemoryWindow(vq_hotkey.HotKeyMixin, EnviNavMixin, vq_save.SaveableWidget
                 sym = self._mem_obj.getSymByAddr(addr)
                 if sym is not None:
                     menustr += ' - %s' % repr(sym)
-            except e_expr.ExpressionFail:
+            except e_exc.ExpressionException:
                 menustr = "UNKNOWN-Exception (%r)" % expr
 
             self.histmenu.addAction(menustr, ACT(self._histSelected, hinfo))

--- a/envi/tests/test_bits.py
+++ b/envi/tests/test_bits.py
@@ -9,8 +9,23 @@ class EnviBitsTest(unittest.TestCase):
         self.assertTrue(e_bits.masktest('1100xxxx1100xxxx')(0xc2c2))
         self.assertFalse(e_bits.masktest('110011xx110011xx')(0xc2c2))
 
-    def test_ieee754_encode(self):
-        pass
+    def test_envi_bits_hex(self):
+        self.assertEqual(e_bits.hex(0), '0x0')
+        self.assertEqual(e_bits.hex(0, 3), '0x0')
+        self.assertEqual(e_bits.hex(0x112233), '0x112233')
+        self.assertEqual(e_bits.hex(0x112233, 3), '0x112233')
+
+        self.assertEqual(e_bits.hex(0x112233, 99), '0x112233')
+
+        # we default to python's way of doing hex. But should we?
+        # we could always go with a more two's complement repr
+        self.assertEqual(e_bits.hex(-0x112233, 3), '-0x112233')
+
+    def test_envi_bits_binrepr(self):
+        self.assertEqual(e_bits.binrepr(0), '0')
+        self.assertEqual(e_bits.binrepr(0, 3), '0')
+
+        self.assertEqual(e_bits.binrepr(0x112233, 3), '100010010001000110011')
 
     def test_byteswap(self):
         self.assertEqual(0x12345678, e_bits.byteswap(0x78563412, 4))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ authors = [
 ]
 description = 'Pure python disassembler, debugger, emulator, and static analysis framework'
 readme = 'README.md'
-requires-python = '>=3.8'
+requires-python = '>=3.11'
 license = { text = 'Apache License 2.0' }
 classifiers = [
     'Topic :: Security',
     'Topic :: Software Development :: Disassemblers',
     'Topic :: Software Development :: Debuggers',
-    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.11',
     'License :: OSI Approved :: Apache Software License',
 ]
 

--- a/vivisect/analysis/aarch64/emulation.py
+++ b/vivisect/analysis/aarch64/emulation.py
@@ -56,7 +56,7 @@ class AnalysisMonitor(viv_monitor.AnalysisMonitor):
             if op.iflags & envi.IF_RET:
                 self.returns = True
                 if len(op.opers):
-                    if hasattr(op.opers, 'imm'):
+                    if hasattr(op.opers[0], 'imm'):
                         self.retbytes = op.opers[0].imm
 
             if op.opcode == INS_MOV:

--- a/vivisect/analysis/arm/emulation.py
+++ b/vivisect/analysis/arm/emulation.py
@@ -59,7 +59,7 @@ class AnalysisMonitor(viv_monitor.AnalysisMonitor):
             if op.iflags & envi.IF_RET:
                 self.returns = True
                 if len(op.opers):
-                    if hasattr(op.opers, 'imm'):
+                    if hasattr(op.opers[0], 'imm'):
                         self.retbytes = op.opers[0].imm
 
             # ARM gives us nice switchcase handling instructions

--- a/vivisect/analysis/generic/symswitchcase.py
+++ b/vivisect/analysis/generic/symswitchcase.py
@@ -15,10 +15,11 @@ import envi.bits as e_bits
 import vivisect.exc as v_exc
 import vivisect.const as v_const
 import vivisect.tools.graphutil as viv_graph
-import vivisect.symboliks.analysis as vs_anal
 import vivisect.analysis.generic.codeblocks as vagc
 
-from vivisect.symboliks.common import *
+import vivisect.symboliks.common as vs_com
+import vivisect.symboliks.analysis as vs_anal
+
 from vivisect.tools.graphutil import PathForceQuitException
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,7 @@ class TrackingSymbolikEmulator(vs_anal.SymbolikFunctionEmulator):
                 lva, lsize, ltype, linfo = loc
                 if ltype == v_const.LOC_IMPORT:
                     # return name of import
-                    symval = Var(linfo, self.__width__)
+                    symval = vs_com.Var(linfo, self.__width__)
                     self.track(self.getMeta('va'), symaddr, symval)
                     return symval
 
@@ -121,14 +122,14 @@ class TrackingSymbolikEmulator(vs_anal.SymbolikFunctionEmulator):
                     fmt = e_bits.getFormat(size, self._sym_vw.getEndian(), signed=True)
                     val, = self._sym_vw.readMemoryFormat(addrval, fmt)
                     self.track(self.getMeta('va'), symaddr, val)
-                    return Const(val, size)
+                    return vs_com.Const(val, size)
 
                 # return string  (really?)
                 symval = self._sym_vw.readMemory(addrval, size)
                 self.track(self.getMeta('va'), symaddr, symval)
                 return symval
 
-        return Mem(symaddr, symsize)
+        return vs_com.Mem(symaddr, symsize)
 
 
 def contains(symobj, subobj):
@@ -157,8 +158,7 @@ def contains(symobj, subobj):
 
     ctx = {'compare':   subobj.solve(),
            'contains':  False,
-           'path':      ()
-           }
+           'path':      ()}
 
     symobj.walkTree(_cb_contains, ctx)
     return ctx['contains'], ctx['path']
@@ -172,18 +172,18 @@ def getUnknowns(symvar):
         walkTree callback for grabbing Var objects
         '''
         #logging.debug("... unk: %r", symobj)
-        if symobj.symtype == SYMT_VAR:
-            varlist = ctx.get(SYMT_VAR)
+        if symobj.symtype == v_const.SYMT_VAR:
+            varlist = ctx.get(v_const.SYMT_VAR)
             if symobj.name not in varlist:
                 varlist.append(symobj.name)
 
         # sometimes the index comes from a global or local variable...
-        if symobj.symtype == SYMT_MEM:
-            memlist = ctx.get(SYMT_MEM)
+        if symobj.symtype == v_const.SYMT_MEM:
+            memlist = ctx.get(v_const.SYMT_MEM)
             if symobj not in memlist:
                 memlist.append(symobj)
 
-    unks = {SYMT_VAR:[], SYMT_MEM:[]}
+    unks = {v_const.SYMT_VAR: [], v_const.SYMT_MEM: []}
     symvar.walkTree(_cb_grab_vars_n_mems, unks)
     return unks
 
@@ -213,7 +213,7 @@ def hasMul(symobj):
     Returns True or False based on whether the symobj AST has a "Mul" object
     '''
     def _cb_check_for_mul(path, symobj, ctx):
-        if symobj.symtype == SYMT_OPER_MUL:
+        if symobj.symtype == v_const.SYMT_OPER_MUL:
             ctx['inthere'] = True
 
     ctx = {'inthere': False}
@@ -229,21 +229,21 @@ def peelIdxOffset(symobj):
     offset = 0
     while True:
         # peel off o_subs and size-limiting o_ands and o_sextends
-        if isinstance(symobj, o_and) and symobj.kids[1].isDiscrete() and symobj.kids[1].solve() in e_bits.u_maxes:
+        if isinstance(symobj, vs_com.o_and) and symobj.kids[1].isDiscrete() and symobj.kids[1].solve() in e_bits.u_maxes:
             # this wrapper is a size-limiting bitmask
             pass
 
-        elif isinstance(symobj, o_sub):
+        elif isinstance(symobj, vs_com.o_sub):
             # this is an offset, used to rebase the index into a different pointer array
             if symobj.kids[1].isDiscrete():
                 offset += symobj.kids[1].solve()
 
-        elif isinstance(symobj, o_add):
+        elif isinstance(symobj, vs_com.o_add):
             # this is an offset, used to rebase the index into a different pointer array
             if symobj.kids[1].isDiscrete():
                 offset -= symobj.kids[1].solve()
 
-        elif isinstance(symobj, o_sextend):
+        elif isinstance(symobj, vs_com.o_sextend):
             # sign-extension is irrelevant for indexes
             pass
 
@@ -323,9 +323,9 @@ class ThunkReg:
         if oploc is None:
             regval += THUNK_BX_CALL_LEN 
         else:
-            regval += oploc[L_SIZE]
+            regval += oploc[v_const.L_SIZE]
 
-        regobj = Const(regval, vw.psize)
+        regobj = vs_com.Const(regval, vw.psize)
         reg = rctx.getRealRegisterName(self.regname)
         logger.debug("thunk_%s is being called! %s\t%s\t%s", reg, emu, symargs, regobj)
         emu.setSymVariable(reg, regobj)
@@ -431,7 +431,6 @@ class SwitchCase:
         tgtsym = jmpsymvar.update(emu)
         return tgtsym
 
-
     def getSymIdx(self):
         '''
         returns the symbolik index register, and the type of object
@@ -443,17 +442,17 @@ class SwitchCase:
 
         cspath, aspath, fullpath = self.getSymbolikParts()
 
-        for unk in unks.get(SYMT_VAR):
+        for unk in unks.get(v_const.SYMT_VAR):
             unkvar = cspath[0].getSymVariable(unk)
             if unkvar.isDiscrete():
                 continue
-            return (SYMT_VAR, unk)
+            return (v_const.SYMT_VAR, unk)
 
-        for unk in unks.get(SYMT_MEM):
+        for unk in unks.get(v_const.SYMT_MEM):
             unkvar = cspath[0].getSymVariable(unk)
             if unkvar.isDiscrete():
                 continue
-            return (SYMT_MEM, unk)
+            return (v_const.SYMT_MEM, unk)
 
         raise v_exc.SymIdxNotFoundException(cspath, aspath)
 
@@ -466,12 +465,12 @@ class SwitchCase:
         '''
         csp, asp, fullp = self.getSymbolikParts()
 
-        cons = [eff for eff in fullp[1] if eff.efftype==EFFTYPE_CONSTRAIN]
+        cons = [eff for eff in fullp[1] if eff.efftype==v_const.EFFTYPE_CONSTRAIN]
         [con.reduce() for con in cons]
         return cons
 
     def getBoundingCons(self, cplxIdx):
-        return [con for con in self.getConstraints() if contains(con, cplxIdx)[0] ]
+        return [con for con in self.getConstraints() if contains(con, cplxIdx)[0]]
 
     def getSymbolikJmpBlock(self, emuclass=vs_anal.SymbolikFunctionEmulator):
         '''
@@ -560,10 +559,10 @@ class SwitchCase:
 
         cplxIdx = None
         (csemu, cseffs), asp, fullp = self.getSymbolikParts()
-        if symtype == SYMT_VAR:
+        if symtype == v_const.SYMT_VAR:
             cplxIdx = csemu.getSymVariable(smplIdx)
 
-        elif symtype == SYMT_MEM:
+        elif symtype == v_const.SYMT_MEM:
             symloc, symsz = smplIdx.kids
             cplxIdx = csemu.readSymMemory(symloc.update(csemu), symsz)
 
@@ -583,7 +582,7 @@ class SwitchCase:
             '''
             This is for troubleshooting and analysis only.
             '''
-            logger.debug( ' PATH: %r\n SYMOBJ: %r\n CTX: %r\n' % (path, symobj, ctx))
+            logger.debug(' PATH: %r\n SYMOBJ: %r\n CTX: %r\n' % (path, symobj, ctx))
 
         def _cb_mark_longpath(path, symobj, ctx):
             '''
@@ -619,7 +618,7 @@ class SwitchCase:
         #  in order to make all pointer/offset arrays 0-based, the index gets modified (subtracted)
 
 
-        # HACK: this is left-handed, and based on the longpath.  it may also benefit from actual comparing with the 
+        # HACK: this is left-handed, and based on the longpath.  it may also benefit from actual comparing with the
         # known index.
         #logging.info("LONGPATH: " + '\n'.join([repr(x) for x in longpath]))
         for symobj in longpath:
@@ -627,18 +626,18 @@ class SwitchCase:
             logger.debug(" longpath constraints %d: %r" % (count, symobj))
 
             # peel off o_subs and size-limiting o_ands and o_sextends
-            if isinstance(symobj, o_and) and symobj.kids[1].isDiscrete() and symobj.kids[1].solve() in e_bits.u_maxes:
+            if isinstance(symobj, vs_com.o_and) and symobj.kids[1].isDiscrete() and symobj.kids[1].solve() in e_bits.u_maxes:
                 # TODO: Okay. So what do we do here? We're solving but throwing the result away
                 #mask = symobj.kids[1].solve()
                 pass
 
-            elif isinstance(symobj, o_sub):
+            elif isinstance(symobj, vs_com.o_sub):
                 offset += symobj.kids[1].solve() # this is an offset, used to rebase the index into a different pointer array
 
-            elif isinstance(symobj, o_add):
+            elif isinstance(symobj, vs_com.o_add):
                 offset -= symobj.kids[1].solve() # this is an offset, used to rebase the index into a different pointer array
 
-            elif isinstance(symobj, o_sextend):
+            elif isinstance(symobj, vs_com.o_sextend):
                 pass # sign-extension is irrelevant for indexes
 
             # anything else and we're done peeling
@@ -659,21 +658,21 @@ class SwitchCase:
         '''
         retcons = []
         baseIdx, baseoff = self.getBaseSymIdx()
-        SKIPS = (SYMT_CON_GT, SYMT_CON_GE, SYMT_CON_LT, SYMT_CON_LE)
+        SKIPS = (v_const.SYMT_CON_GT, v_const.SYMT_CON_GE, v_const.SYMT_CON_LT, v_const.SYMT_CON_LE)
 
         for con in self.getBoundingCons(baseIdx): # merge the two
             cons = con.cons
 
-            if not cons.symtype in SKIPS:
+            if cons.symtype not in SKIPS:
                 #logger.debug("SKIPPING NON-LIMITING: cons = %s", repr(cons))
                 #return None, None, None
                 continue
 
-            if cons.kids[1].symtype == SYMT_CONST:
+            if cons.kids[1].symtype == v_const.SYMT_CONST:
                 symvar = cons.kids[0]
                 symcmp = cons.kids[1]
 
-            elif cons.kids[0].symtype == SYMT_CONST:
+            elif cons.kids[0].symtype == v_const.SYMT_CONST:
                 symcmp = cons.kids[0]
                 symvar = cons.kids[1]
 
@@ -687,7 +686,7 @@ class SwitchCase:
                 logger.debug("Ignoring Constraint not based on Index: %r" % cons)
                 continue
 
-            if cons.symtype == SYMT_CON_LT and symcmp.solve() == 0:
+            if cons.symtype == v_const.SYMT_CON_LT and symcmp.solve() == 0:
                 #logger.debug("SKIPPING Constraint Checking for Zero: %r" % cons)
                 continue
 
@@ -738,32 +737,32 @@ class SwitchCase:
                 for con, stype, offset in self.getNormalizedConstraints():
 
                     #conthing, consoff = peelIdxOffset(symvar)
-                    if stype == SYMT_CON_GT: # this is setting the lower bound
+                    if stype == v_const.SYMT_CON_GT: # this is setting the lower bound
                         newlower = offset + 1
                         if newlower > lower:
                             logger.info("==setting a lower bound:  %s -> %s", lower, newlower)
                             lower = newlower
 
-                    elif stype == SYMT_CON_GE: # this is setting the lower bound
+                    elif stype == v_const.SYMT_CON_GE: # this is setting the lower bound
                         newlower = offset
                         if newlower > lower:
                             logger.info("==setting a lower bound:  %s -> %s", lower, newlower)
                             lower = newlower
 
-                    elif stype == SYMT_CON_LT: # this is setting the upper bound
+                    elif stype == v_const.SYMT_CON_LT: # this is setting the upper bound
                         newupper = offset - 1
                         if upper is None or newupper < upper and newupper > 0:
                             logger.info("==setting a upper bound:  %s -> %s", upper, newupper)
                             upper = newupper
 
-                    elif stype == SYMT_CON_LE: # this is setting the upper bound
+                    elif stype == v_const.SYMT_CON_LE: # this is setting the upper bound
                         newupper = offset
                         if upper is None or newupper < upper and newupper > 0:
                             logger.info("==setting a upper bound:  %s -> %s", upper, newupper)
                             upper = newupper
 
                     else:
-                        logger.info("Unhandled comparator:  %s\n", repr(cons))
+                        logger.info("Unhandled comparator:  %s\n", repr(con))
 
                 logger.info("Determined bounds: %r %r\n" % (lower, upper))
         except StopIteration:
@@ -802,10 +801,10 @@ class SwitchCase:
         idxtype, symIdx = self.getSymIdx()
 
         # set our index to 0, to get the base of pointer/offset arrays
-        semu.setSymVariable(symIdx, Const(0, 8))
+        semu.setSymVariable(symIdx, vs_com.Const(0, 8))
 
         for eff in aseffs:
-            if eff.efftype == EFFTYPE_READMEM:
+            if eff.efftype == v_const.EFFTYPE_READMEM:
                 if eff.va == self.jmpva:
                     continue
 
@@ -820,7 +819,6 @@ class SwitchCase:
                     target = semu.readSymMemory(eff.symaddr, eff.symsize)
                     size = target.getWidth()
                     derefs.append((eff.va, symaddr, solution, target.solve(), size))
-
 
         return derefs
 
@@ -996,7 +994,7 @@ class SwitchCase:
 
         for va, symaddr, addr, tgt, sz in self.getDerefs():
             # first make the xref from opcode to data:
-            self.vw.addXref(va, addr, REF_DATA)
+            self.vw.addXref(va, addr, v_const.REF_DATA)
 
             if sz == self.vw.psize and self.vw.isValidPointer(tgt):
                 for count in range(upper-lower+1):
@@ -1027,13 +1025,13 @@ class SwitchCase:
         symemu.setSymSnapshot(csemu.getSymSnapshot())
 
         logger.debug("jmpva: 0x%x\t\tsymidx: %r", self.jmpva, symidx)   # TODO: we return either a Var name string or a SymObj (for Mem types)... should we just stick with the symbolik object?  since we're removing the ties to getSymVariable() and moving to replaceObj() and our nifty 'jmpidx' variable.
-        if idxtype == SYMT_VAR:
-            symidx = Var(symidx, self.vw.psize)
-        replaceObj(jmptgt, symidx, Var('jmpidx', symidx.getWidth()))
+        if idxtype == v_const.SYMT_VAR:
+            symidx = vs_com.Var(symidx, self.vw.psize)
+        replaceObj(jmptgt, symidx, vs_com.Var('jmpidx', symidx.getWidth()))
         #workJmpTgt = jmptgt.update(emu=symemu)
 
         for idx in range(lower-offset, upper-offset+1):
-            symemu.setSymVariable('jmpidx', Const(idx, 8))
+            symemu.setSymVariable('jmpidx', vs_com.Const(idx, 8))
             workJmpTgt = jmptgt.update(emu=symemu)  # would "jmptgt.solve(vals={'jmpidx': idx})" work?
             logger.info(" itercases: workJmpTgt: %r (0x%x)", workJmpTgt, self.jmpva)
             coderef = workJmpTgt.solve(emu=symemu, vals={symidx:idx})
@@ -1164,7 +1162,7 @@ def link_up(vw, jmpva, array, count, baseoff, baseva=None, itemsize=None):
         if caselist is None:
             caselist = []
             cases[addr] = caselist
-        caselist.append( idx )
+        caselist.append(idx)
 
         # make the connections
         vw.addXref(jmpva, addr, v_const.REF_CODE)

--- a/vivisect/analysis/ms/msvcfunc.py
+++ b/vivisect/analysis/ms/msvcfunc.py
@@ -13,7 +13,7 @@ def analyze(vw):
             # parse teh first opcode in the function
             op = vw.parseOpcode(fva)
             if len(op.opers) != 2:
-                return
+                continue
 
             gscookie = None
             if op.opers[1].isDeref():
@@ -21,7 +21,7 @@ def analyze(vw):
                 gscookie = op.opers[1].getOperAddr(op, None)
 
             if not gscookie:
-                return
+                continue
 
             # iterate over all references to the cookie
             for fromva, tova, rtype, rflags in vw.getXrefsTo(gscookie):

--- a/vivisect/parsers/macho.py
+++ b/vivisect/parsers/macho.py
@@ -95,8 +95,6 @@ def _loadMacho(vw, filebytes, filename=None, baseaddr=None):
     macho.vsParse(filebytes)
     # find the lowest loadable address, then get an offset so we can apply it later
     fakebase, size = getMemBaseAndSize(vw, macho, baseaddr=baseaddr)
-    offset = baseaddr - fakebase
-    logger.debug('initial file baseva: 0x%x  size: 0x%x (address offset: 0x%x)', fakebase, size, offset)
 
     # Determine base address to load into
     # We fake them to *much* higher than norm so pointer tests do better...
@@ -111,6 +109,9 @@ def _loadMacho(vw, filebytes, filename=None, baseaddr=None):
         logger.info("baseaddr (0x%x) is in use.  Finding appropriate address base.", baseaddr)
         baseaddr = vw.findFreeMemoryBlock(size, fakebase)
         logger.debug("loading %r (size: 0x%x) at 0x%x", filename, size, baseaddr)
+
+    offset = baseaddr - fakebase
+    logger.debug('initial file baseva: 0x%x  size: 0x%x (address offset: 0x%x)', fakebase, size, offset)
 
     if filename is None:
         filename = 'macho_%.8x' % baseaddr  # FIXME more than one!

--- a/vivisect/qt/funcgraph.py
+++ b/vivisect/qt/funcgraph.py
@@ -8,7 +8,7 @@ import collections
 
 import vqt.hotkeys as vq_hotkey
 import vqt.saveable as vq_save
-import envi.expression as e_expr
+import envi.exc as e_exc
 import envi.memcanvas as e_memcanvas
 import envi.qt.memory as e_qt_memory
 import vivisect.qt.views as viv_q_views
@@ -547,7 +547,7 @@ class VQVivFuncgraphView(vq_hotkey.HotKeyMixin, e_qt_memory.EnviNavMixin, QWidge
                 sym = self.vw.getSymByAddr(addr)
                 if sym is not None:
                     menustr += ' - %s' % repr(sym)
-            except e_expr.ExpressionFail:
+            except e_exc.ExpressionException:
                 menustr = "UNKNOWN-Exception (%r)" % expr
 
             history.append((menustr, expr))

--- a/vivisect/symboliks/common.py
+++ b/vivisect/symboliks/common.py
@@ -3,10 +3,11 @@ import operator
 import functools
 import itertools
 
-import vstruct
 import envi.bits as e_bits
 
-from vivisect.const import *
+import vivisect.const as v_const
+
+import vstruct
 
 def symcache(f):
     def docache(*args, **kwargs):
@@ -61,7 +62,7 @@ def getSymbolikImport(vw, impname):
     mod = vw.loadModule(modbase)
     return vstruct.resolve(mod, nameparts)
 
-def cb_astNodeCount(path,obj,ctx):
+def cb_astNodeCount(path, obj, ctx):
     ctx['count'] += 1
     if len(path) > ctx['depth']:
         ctx['depth'] = len(path)
@@ -422,7 +423,7 @@ class cnot(SymbolikBase):
     Mostly used to wrap the reverse of a contraint which is based on
     a variable.
     '''
-    symtype = SYMT_NOT
+    symtype = v_const.SYMT_NOT
 
     def __init__(self, v1):
         SymbolikBase.__init__(self)
@@ -441,7 +442,7 @@ class cnot(SymbolikBase):
 
     def update(self, emu):
         v1 = self.kids[0].update(emu=emu)
-        if v1.symtype & SYMT_CON:
+        if v1.symtype & v_const.SYMT_CON:
             return v1.reverse()
         return cnot(v1)
 
@@ -456,10 +457,10 @@ class cnot(SymbolikBase):
         #self.kids[0] = self.kids[0].reduce(emu=emu)
 
         kidzero = self.kids[0]
-        if kidzero.symtype == SYMT_CON:
+        if kidzero.symtype == v_const.SYMT_CON:
             return kidzero.reverse()
 
-        if kidzero.symtype == SYMT_NOT:
+        if kidzero.symtype == v_const.SYMT_NOT:
             return self.kids[0].kids[0]
 
     def getWidth(self):
@@ -470,7 +471,7 @@ class Call(SymbolikBase):
     This represents the return value of an instance of a call to
     a function.
     '''
-    symtype = SYMT_CALL
+    symtype = v_const.SYMT_CALL
 
     def __init__(self, funcsym, width, argsyms=[]):
         SymbolikBase.__init__(self)
@@ -537,7 +538,7 @@ class Mem(SymbolikBase):
     This is effectivly a cop-out for symbolic states read in from
     memory which has not been initialized yet.
     '''
-    symtype = SYMT_MEM
+    symtype = v_const.SYMT_MEM
 
     def __init__(self, symaddr, symsize):
         SymbolikBase.__init__(self)
@@ -592,7 +593,7 @@ class Mem(SymbolikBase):
 
 class Var(SymbolikBase):
 
-    symtype = SYMT_VAR
+    symtype = v_const.SYMT_VAR
 
     def __init__(self, name, width):
         SymbolikBase.__init__(self)
@@ -651,7 +652,7 @@ class LookupVar(Var):
     data to be tracked between simple effects and applied effects.
     '''
 
-    symtype = SYMT_LOOKUP
+    symtype = v_const.SYMT_LOOKUP
 
     def __init__(self, prefix, offset, lookupdict, width):
         Var.__init__(self, prefix, width)
@@ -705,7 +706,7 @@ class Arg(SymbolikBase):
     An "Arg" is a special kind of variable used to facilitate cross
     function boundary solving.
     '''
-    symtype = SYMT_ARG
+    symtype = v_const.SYMT_ARG
 
     def __init__(self, idx, width):
         SymbolikBase.__init__(self)
@@ -741,7 +742,7 @@ class Arg(SymbolikBase):
 
 class Const(SymbolikBase):
 
-    symtype     = SYMT_CONST
+    symtype     = v_const.SYMT_CONST
     discrete    = True
 
     def __init__(self, value, width, ptrname=None, constname=None):
@@ -891,66 +892,66 @@ class Operator(SymbolikBase):
 class o_add(Operator):
     oper        = operator.add
     operstr     = '+'
-    symtype     = SYMT_OPER_ADD
+    symtype     = v_const.SYMT_OPER_ADD
     commutative = True
 
 class o_sub(Operator):
     oper        = operator.sub
     operstr     = '-'
-    symtype     = SYMT_OPER_SUB
+    symtype     = v_const.SYMT_OPER_SUB
 
 class o_xor(Operator):
     oper        = operator.xor
     operstr     = '^'
-    symtype     = SYMT_OPER_XOR
+    symtype     = v_const.SYMT_OPER_XOR
     commutative = True
 
 class o_and(Operator):
     oper        = operator.and_
     operstr     = '&'
-    symtype     = SYMT_OPER_AND
+    symtype     = v_const.SYMT_OPER_AND
     commutative = True
 
 class o_or(Operator):
     oper        = operator.or_
     operstr     = '|'
-    symtype     = SYMT_OPER_OR
+    symtype     = v_const.SYMT_OPER_OR
     commutative = True
 
 class o_mul(Operator):
     oper        = operator.mul
     operstr     = '*'
-    symtype     = SYMT_OPER_MUL
+    symtype     = v_const.SYMT_OPER_MUL
     commutative = True
 
 class o_div(Operator):
     oper        = operator.floordiv
     operstr     = '/'
-    symtype     = SYMT_OPER_DIV
+    symtype     = v_const.SYMT_OPER_DIV
 
 class o_mod(Operator):
     oper        = operator.mod
     operstr     = '%'
-    symtype     = SYMT_OPER_MOD
+    symtype     = v_const.SYMT_OPER_MOD
 
 class o_lshift(Operator):
     oper        = operator.lshift
     operstr     = '<<'
-    symtype     = SYMT_OPER_LSHIFT
+    symtype     = v_const.SYMT_OPER_LSHIFT
 
 class o_rshift(Operator):
     oper        = operator.rshift
     operstr     = '>>'
-    symtype     = SYMT_OPER_RSHIFT
+    symtype     = v_const.SYMT_OPER_RSHIFT
 
 class o_pow(Operator):
     oper        = operator.pow
     operstr     = '**'
-    symtype     = SYMT_OPER_POW
+    symtype     = v_const.SYMT_OPER_POW
 
 # introduce the concept of a modifier?  or keep this an operator?
 class o_sextend(SymbolikBase):
-    symtype = SYMT_SEXT
+    symtype = v_const.SYMT_SEXT
 
     def __init__(self, v1, tgtsz):
         SymbolikBase.__init__(self)
@@ -1041,49 +1042,49 @@ def oppose(c1, c2):
 class eq(Constraint):
     oper = operator.eq
     operstr = '=='
-    symtype = SYMT_CON_EQ
+    symtype = v_const.SYMT_CON_EQ
 
 
 class ne(Constraint):
     oper = operator.ne
     operstr = '!='
-    symtype = SYMT_CON_NE
+    symtype = v_const.SYMT_CON_NE
 
 
 class le(Constraint):
     oper = operator.le
     operstr = '<='
-    symtype = SYMT_CON_LE
+    symtype = v_const.SYMT_CON_LE
 
 
 class gt(Constraint):
     oper = operator.gt
     operstr = '>'
-    symtype = SYMT_CON_GT
+    symtype = v_const.SYMT_CON_GT
 
 
 class lt(Constraint):
     oper = operator.lt
     operstr = '<'
-    symtype = SYMT_CON_LT
+    symtype = v_const.SYMT_CON_LT
 
 
 class ge(Constraint):
     oper = operator.ge
     operstr = '>='
-    symtype = SYMT_CON_GE
+    symtype = v_const.SYMT_CON_GE
 
 
 class UNK(Constraint):
     operstr = 'UNK'
-    symtype = SYMT_CON_UNK
+    symtype = v_const.SYMT_CON_UNK
     def oper(self, v1, v2):
         raise Exception('Attempted reduce/solve on UNK, which has no oper')
 
 
 class NOTUNK(Constraint):
     operstr = '!UNK'
-    symtype = SYMT_CON_NOTUNK
+    symtype = v_const.SYMT_CON_NOTUNK
     def oper(self, v1, v2):
         raise Exception('Attempted reduce/solve on NOUNK, which has no oper')
 
@@ -1092,4 +1093,3 @@ oppose(ne, eq)
 oppose(le, gt)
 oppose(lt, ge)
 oppose(UNK, NOTUNK)
-

--- a/vivisect/symboliks/expression.py
+++ b/vivisect/symboliks/expression.py
@@ -5,30 +5,31 @@ constraints from humon input.
 '''
 import ast
 
+import vivisect.const as v_const
+
+import vivisect.symboliks.common as v_s_com
 import vivisect.symboliks.effects as v_s_eff
 
-from vivisect.symboliks.common import *
-
 op2op = {
-    ast.Pow: o_pow,
-    ast.Add: o_add,
-    ast.Sub: o_sub,
-    ast.Div: o_div,
-    ast.Mult: o_mul,
-    ast.BitOr: o_or,
-    ast.BitAnd: o_and,
-    ast.BitXor: o_xor,
-    ast.LShift: o_lshift,
-    ast.RShift: o_rshift,
+    ast.Pow: v_s_com.o_pow,
+    ast.Add: v_s_com.o_add,
+    ast.Sub: v_s_com.o_sub,
+    ast.Div: v_s_com.o_div,
+    ast.Mult: v_s_com.o_mul,
+    ast.BitOr: v_s_com.o_or,
+    ast.BitAnd: v_s_com.o_and,
+    ast.BitXor: v_s_com.o_xor,
+    ast.LShift: v_s_com.o_lshift,
+    ast.RShift: v_s_com.o_rshift,
 }
 
 cmp2cons = {
-    ast.LtE: le,
-    ast.GtE: ge,
-    ast.Lt: lt,
-    ast.Gt: gt,
-    ast.Eq: eq,
-    ast.NotEq: ne,
+    ast.LtE: v_s_com.le,
+    ast.GtE: v_s_com.ge,
+    ast.Lt: v_s_com.lt,
+    ast.Gt: v_s_com.gt,
+    ast.Eq: v_s_com.eq,
+    ast.NotEq: v_s_com.ne,
 }
 
 defexp = {}
@@ -70,7 +71,7 @@ class SymbolikExpressionParser:
 
         if isinstance(a, ast.Assign):
             if len(a.targets) != 1:
-                raise Expression('Unsupported multi-asignment: %s' % ast.dump(a))
+                raise Exception('Unsupported multi-asignment: %s' % ast.dump(a))
             if not isinstance(a.targets[0], ast.Name):
                 raise Exception('Unsupported Asigment: %s' % ast.dump(a))
 
@@ -95,10 +96,10 @@ class SymbolikExpressionParser:
 
             # assume basic width promotion
             widths = []
-            if not left.symtype == SYMT_CONST:
+            if not left.symtype == v_const.SYMT_CONST:
                 widths.append(left.getWidth())
 
-            if not right.symtype == SYMT_CONST:
+            if not right.symtype == v_const.SYMT_CONST:
                 widths.append(right.getWidth())
 
             if not widths:
@@ -113,36 +114,33 @@ class SymbolikExpressionParser:
             return myop(left, right, width)
 
         if isinstance(a, ast.Name):
-            return Var(a.id, self._sym_defwidth)
+            return v_s_com.Var(a.id, self._sym_defwidth)
 
-        if isinstance(a, ast.Num):
-            return Const(a.n, self._sym_defwidth)
+        if isinstance(a, ast.Constant):
+            return v_s_com.Const(a.value, self._sym_defwidth)
 
         if isinstance(a, ast.Subscript):
             # value is what's being subscripted
             # slice is either Slice or Index
             # For "index" we assume they mean to specify width
             slclass = a.slice.__class__
-            # TODO: ast.Index is deprecated as of python 3.9 and will be removed in future versions
-            if slclass == ast.Constant or slclass == ast.Index:
+            # TODO: support ast.Name for variable assignment?
+            if slclass == ast.Constant:
                 ival = a.slice.value
-                # TODO: ast.Num is deprecated as of python 3.9 and will be removed in future versions
-                if type(ival) == ast.Num:
-                    ival = ival.n
-                elif type(ival) == int:
+                if isinstance(ival, int):
                     pass
-                elif type(ival) is ast.Constant:
+                elif isinstance(ival, ast.Constant):
                     ival = ival.value
                 else:
                     raise Exception('Unsupported Expression (symbolik width index)')
 
                 # Override width for "value"
                 value = self.astToSymboliks(a.value)
-                if value.symtype == SYMT_VAR:
-                    return Var(value.name, ival)
+                if value.symtype == v_const.SYMT_VAR:
+                    return v_s_com.Var(value.name, ival)
 
-                if value.symtype == SYMT_CONST:
-                    return Const(value.value, ival)
+                if value.symtype == v_const.SYMT_CONST:
+                    return v_s_com.Const(value.value, ival)
 
                 raise Exception('Unsupported Expression (symbolik width on %s)' % value.__class__.__name__)
 
@@ -158,20 +156,20 @@ class SymbolikExpressionParser:
                     # A memory slice expression
                     symaddr = self.astToSymboliks(a.slice.lower)
                     symsize = self.astToSymboliks(a.slice.upper)
-                    return Mem(symaddr, symsize)
+                    return v_s_com.Mem(symaddr, symsize)
 
             raise Exception('Unsupported Subscript: %s' % ast.dump(a))
 
         if isinstance(a, ast.Call):
             funcsym = self.astToSymboliks(a.func)
-            argsyms = [ self.astToSymboliks(a) for a in a.args ]
-            return Call(funcsym, self._sym_defwidth, argsyms=argsyms)
+            argsyms = [self.astToSymboliks(a) for a in a.args]
+            return v_s_com.Call(funcsym, self._sym_defwidth, argsyms=argsyms)
 
         if isinstance(a, ast.Attribute):
             # handle module.function viv style symbols
             if not isinstance(a.value, ast.Name):
                 raise Exception('Unsupported Attribute Base: %s' % ast.dump(a))
-            symname = '%s.%s' % (a.value.id,a.attr)
-            return Var(symname, self._sym_defwidth)
+            symname = '%s.%s' % (a.value.id, a.attr)
+            return v_s_com.Var(symname, self._sym_defwidth)
 
         raise Exception('Unsupported AST Element: %s' % ast.dump(a))

--- a/vivisect/symboliks/expression.py
+++ b/vivisect/symboliks/expression.py
@@ -117,6 +117,8 @@ class SymbolikExpressionParser:
             return v_s_com.Var(a.id, self._sym_defwidth)
 
         if isinstance(a, ast.Constant):
+            if not isinstance(a.value, int):
+                raise Exception('Unsupported constant type: %s' % type(a.value))
             return v_s_com.Const(a.value, self._sym_defwidth)
 
         if isinstance(a, ast.Subscript):

--- a/vtrace/watchpoints.py
+++ b/vtrace/watchpoints.py
@@ -14,7 +14,7 @@ class Watchpoint(vt_bp.Breakpoint):
     Breakpoints and handled almost exactly the same way...
     """
     def __init__(self, addr, expression=None, size=4, perms="rw"):
-        super().__init__(self, addr, expression=expression)
+        super().__init__(addr, expression=expression)
         self.wpsize = size
         self.wpperms = perms
 
@@ -57,7 +57,7 @@ class PageWatchpoint(Watchpoint):
     NOTE: These *must* be added page aligned
     """
     def __init__(self, addr, expression=None, size=4, watchread=False):
-        super().__init__(self, addr, expression=expression, size=size, perms='rw')
+        super().__init__(addr, expression=expression, size=size, perms='rw')
         self._orig_perms = None
         self._new_perms = e_const.MM_READ
         if watchread:


### PR DESCRIPTION
Cleans up #718 (and also about a dozen other small bugs).

Point of discussion: I moved the expression exceptions in `envi/exc.py`, which is technically a breaking change. I can move those back if we don't wanna break anything. But it feels like those should live in `envi/exc.py`.