### PR TITLE
Quality: code.interact() dropped inside production loop halts execution

### DIFF
--- a/PE/petool.py
+++ b/PE/petool.py
@@ -4,7 +4,6 @@ For now, all this does is rename files to their exportname and version info.
 '''
 
 import sys
-import code
 import optparse
 import binascii
 
@@ -45,7 +44,6 @@ def main():
                     val = vs.getVersionValue(k)
                     print('%s: %r' % (k, val))
 
-        code.interact(local=locals())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`code.interact(local=locals())` is called inside the `for fname in argv` loop. This drops into an interactive Python REPL after processing the first file, blocking all subsequent file processing. This is almost certainly a debugging artifact left in production code. It will also block CI/automation if this script is ever invoked non-interactively.


**Severity**: `critical`
**File**: `PE/petool.py`

## Solution

Remove the `code.interact(local=locals())` line (and the unused `import code`). If interactive inspection is genuinely needed for debugging, gate it behind a CLI flag like `--interactive`.


## Changes

- `PE/petool.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
