### PR TITLE
C++ Demangling Library — multi-format, pure-Python, offline

### DIFF
--- a/vivisect/__init__.py
+++ b/vivisect/__init__.py
@@ -2716,6 +2716,54 @@ class VivWorkspace(e_mem.MemoryObject, viv_base.VivWorkspaceCore):
             name = basename
         return name
 
+    def demangle(self, name, structured=False):
+        '''
+        Demangle a C++/Rust/D/Swift/JNI/ObjC mangled symbol name on demand.
+
+        This is the on-demand API — it can be called any time, not just
+        during binary loading.  Uses the vivisect.demangle library which
+        supports all major compiler mangling formats.
+
+        Args:
+            name (str): The mangled symbol name.
+            structured (bool): If True, return a DemangledSymbol object
+                with parsed components (scope, parameters, return type,
+                etc.).  If False (default), return the demangled string.
+
+        Returns:
+            str or DemangledSymbol: The demangled name, or the original
+            if demangling fails (graceful degradation).
+        '''
+        from vivisect.demangle import demangle as _demangle
+        return _demangle(name, structured=structured)
+
+    def demangleNameAtVa(self, va, apply=True):
+        '''
+        Demangle the name at a given VA and optionally apply the
+        demangled name to the workspace.
+
+        Args:
+            va (int): The virtual address of the symbol.
+            apply (bool): If True (default), update the workspace name
+                at this VA with the demangled result.
+
+        Returns:
+            str: The demangled name, or the original if demangling fails.
+        '''
+        curname = self.getName(va)
+        if curname is None:
+            return None
+
+        from vivisect.demangle import demangle as _demangle
+        newname = _demangle(curname)
+        if newname != curname:
+            # Preserve the _%.8x suffix if present
+            if curname.endswith("_%.8x" % va) and not newname.endswith("_%.8x" % va):
+                newname += ("_%.8x" % va)
+            if apply:
+                self.makeName(va, newname)
+        return newname
+
     def makeName(self, va, name, filelocal=False, makeuniq=False):
         """
         Set a readable name for the given location by va. There

--- a/vivisect/demangle/__init__.py
+++ b/vivisect/demangle/__init__.py
@@ -1,0 +1,177 @@
+"""
+vivisect.demangle - Multi-format C++ symbol demangling library.
+
+This package provides pure-Python demangling for all major compiler mangling
+schemes:
+
+    - Itanium C++ ABI  (GCC, Clang, ICC on Linux/macOS)   _Z...
+    - MSVC C++ ABI     (Microsoft Visual C++)              ?...@@...
+    - Rust            (legacy and v0)                      _Z...  /  _R...
+    - D language                                           _D...
+    - Swift                                               $s... / _T0... / $S...
+    - Java/JNI                                            Java_...
+    - Objective-C                                         _OBJC_...
+
+The public API is :func:`demangle`, which auto-detects the mangling format
+from the symbol prefix and returns the demangled string.  Pass
+``structured=True`` to receive a :class:`DemangledSymbol` AST object that
+exposes the parsed components (scope, name, template args, return type,
+parameters, calling convention, access, etc.) for downstream analysis.
+
+This library replaces the previous ``cxxfilt``-only implementation (which
+was Itanium-only and broken on Windows) and the VivisectION ``demangle.py``
+HTTP-to-demangler.com approach (which leaked symbols in cleartext and
+required internet access).  It works fully offline with no native
+dependencies.
+"""
+
+from vivisect.demangle.common import DemangledSymbol, DemangleError, normalize_name
+from vivisect.demangle.itanium import demangle_itanium
+from vivisect.demangle.msvc import demangle_msvc
+from vivisect.demangle.rust import demangle_rust
+from vivisect.demangle.dlang import demangle_d
+from vivisect.demangle.swift import demangle_swift
+from vivisect.demangle.jni import demangle_jni
+from vivisect.demangle.objc import demangle_objc
+
+__all__ = [
+    'demangle', 'detect_format',
+    'DemangledSymbol', 'DemangleError',
+    'FORMAT_ITANIUM', 'FORMAT_MSVC', 'FORMAT_RUST', 'FORMAT_D',
+    'FORMAT_SWIFT', 'FORMAT_JNI', 'FORMAT_OBJC', 'FORMAT_UNKNOWN',
+]
+
+FORMAT_ITANIUM = 'itanium'
+FORMAT_MSVC = 'msvc'
+FORMAT_RUST = 'rust'
+FORMAT_D = 'd'
+FORMAT_SWIFT = 'swift'
+FORMAT_JNI = 'jni'
+FORMAT_OBJC = 'objc'
+FORMAT_UNKNOWN = 'unknown'
+
+# Dispatch table mapping format name -> demangle function.
+# Each function signature: demangle_xxx(mangled: str, structured: bool = False)
+_DISPATCH = {
+    FORMAT_ITANIUM: demangle_itanium,
+    FORMAT_MSVC: demangle_msvc,
+    FORMAT_RUST: demangle_rust,
+    FORMAT_D: demangle_d,
+    FORMAT_SWIFT: demangle_swift,
+    FORMAT_JNI: demangle_jni,
+    FORMAT_OBJC: demangle_objc,
+}
+
+
+def detect_format(mangled):
+    """
+    Identify the mangling format from the symbol prefix.
+
+    Args:
+        mangled (str): The mangled symbol string.
+
+    Returns:
+        str: One of the FORMAT_* constants.  Returns FORMAT_UNKNOWN if no
+        known prefix is recognized.
+    """
+    if not mangled:
+        return FORMAT_UNKNOWN
+
+    # Itanium: _Z or __Z prefix (old GCC used __Z)
+    if mangled.startswith('_Z') or mangled.startswith('__Z'):
+        # Rust legacy also uses _Z but with specific patterns (e.g. _ZN3foo...h<hex>E)
+        # We try Itanium first; the Rust handler will fall back if Itanium parse
+        # produces something that looks like a Rust hash suffix.
+        return FORMAT_ITANIUM
+
+    # MSVC: ? prefix
+    if mangled.startswith('?'):
+        return FORMAT_MSVC
+
+    # Rust v0: _R prefix (RFC 2603)
+    if mangled.startswith('_R'):
+        return FORMAT_RUST
+
+    # D language: _D prefix (but not _GLOBAL__ etc.)
+    if mangled.startswith('_D') and not mangled.startswith('_GLOBAL'):
+        return FORMAT_D
+
+    # Swift: $s, $S, _T0, $e prefixes
+    if mangled.startswith('$s') or mangled.startswith('$S') or mangled.startswith('_T0'):
+        return FORMAT_SWIFT
+    # Embedded Swift uses $e
+    if mangled.startswith('$e') and len(mangled) > 2:
+        return FORMAT_SWIFT
+
+    # Java/JNI: Java_ prefix
+    if mangled.startswith('Java_'):
+        return FORMAT_JNI
+
+    # Objective-C: _OBJC_ prefix or +[/-[ method syntax
+    if mangled.startswith('_OBJC_'):
+        return FORMAT_OBJC
+    if mangled.startswith('+[') or mangled.startswith('-['):
+        return FORMAT_OBJC
+
+    return FORMAT_UNKNOWN
+
+
+def demangle(mangled, fmt=None, structured=False):
+    """
+    Demangle a C++/Rust/D/Swift/JNI mangled symbol name.
+
+    Args:
+        mangled (str): The mangled symbol string.
+        fmt (str): Force a specific format (one of the FORMAT_* constants).
+            If ``None``, auto-detect from the symbol prefix.
+        structured (bool): If ``True``, return a :class:`DemangledSymbol`
+            AST object.  If ``False`` (default), return the demangled string.
+
+    Returns:
+        str or DemangledSymbol: The demangled name, or the original mangled
+        string if demangling fails (graceful degradation — never raises for
+        unparseable input).  When ``structured=True``, returns a
+        ``DemangledSymbol`` whose ``full_name`` may equal the original
+        mangled name if parsing failed.
+
+    This function never raises ``DemangleError`` for unparseable input — it
+    returns the original string instead.  Parse warnings are recorded in the
+    ``DemangledSymbol.parse_warnings`` list when ``structured=True``.
+    """
+    if not mangled:
+        return mangled
+
+    # Normalize the name (strip @@VERSION suffixes, trailing NUL, etc.)
+    # before format detection so that e.g. "foo@@GLIBC_2.4" is handled
+    # correctly.
+    normalized = normalize_name(mangled)
+
+    if fmt is None:
+        fmt = detect_format(normalized)
+
+    handler = _DISPATCH.get(fmt)
+    if handler is None:
+        # Unknown format — return normalized name (strips @@VERSION etc.)
+        if structured:
+            return DemangledSymbol(
+                format=FORMAT_UNKNOWN,
+                full_name=normalized,
+                name=normalized,
+                original_mangled=mangled,
+                parse_warnings=['unknown mangling format'],
+            )
+        return normalized
+
+    try:
+        return handler(normalized, structured=structured)
+    except Exception as e:
+        # Graceful degradation: never crash binary loading
+        if structured:
+            return DemangledSymbol(
+                format=fmt,
+                full_name=normalized,
+                name=normalized,
+                original_mangled=mangled,
+                parse_warnings=['demangle failed: %r' % e],
+            )
+        return normalized

--- a/vivisect/demangle/__init__.py
+++ b/vivisect/demangle/__init__.py
@@ -77,7 +77,7 @@ def detect_format(mangled):
     if not mangled:
         return FORMAT_UNKNOWN
 
-    # Itanium: _Z or __Z prefix (old GCC used __Z)
+    # Itanium: _Z prefix, or __Z prefix (old GCC/NM)
     if mangled.startswith('_Z') or mangled.startswith('__Z'):
         # Rust legacy also uses _Z but with specific patterns (e.g. _ZN3foo...h<hex>E)
         # We try Itanium first; the Rust handler will fall back if Itanium parse
@@ -92,9 +92,11 @@ def detect_format(mangled):
     if mangled.startswith('_R'):
         return FORMAT_RUST
 
-    # D language: _D prefix (but not _GLOBAL__ etc.)
-    if mangled.startswith('_D') and not mangled.startswith('_GLOBAL'):
-        return FORMAT_D
+    # D language: _D prefix followed by a digit (length-prefixed name) or 'main'
+    # Must be tight to avoid matching common ELF symbols like _DYNAMIC, _DATA, etc.
+    if mangled.startswith('_D') and len(mangled) > 2:
+        if mangled[2].isdigit() or mangled[2:6] == 'main':
+            return FORMAT_D
 
     # Swift: $s, $S, _T0, $e prefixes
     if mangled.startswith('$s') or mangled.startswith('$S') or mangled.startswith('_T0'):
@@ -141,17 +143,15 @@ def demangle(mangled, fmt=None, structured=False):
     if not mangled:
         return mangled
 
-    # Normalize the name (strip @@VERSION suffixes, trailing NUL, etc.)
-    # before format detection so that e.g. "foo@@GLIBC_2.4" is handled
-    # correctly.
-    normalized = normalize_name(mangled)
-
+    # Detect format from the normalized name (so @@VERSION suffixes don't
+    # interfere with prefix detection), but pass the ORIGINAL to handlers.
     if fmt is None:
-        fmt = detect_format(normalized)
+        fmt = detect_format(normalize_name(mangled))
 
     handler = _DISPATCH.get(fmt)
     if handler is None:
         # Unknown format — return normalized name (strips @@VERSION etc.)
+        normalized = normalize_name(mangled)
         if structured:
             return DemangledSymbol(
                 format=FORMAT_UNKNOWN,
@@ -163,9 +163,12 @@ def demangle(mangled, fmt=None, structured=False):
         return normalized
 
     try:
-        return handler(normalized, structured=structured)
+        # Pass the ORIGINAL mangled name — handlers normalize internally
+        # and preserve the true original in DemangledSymbol.original_mangled
+        return handler(mangled, structured=structured)
     except Exception as e:
         # Graceful degradation: never crash binary loading
+        normalized = normalize_name(mangled)
         if structured:
             return DemangledSymbol(
                 format=fmt,

--- a/vivisect/demangle/common.py
+++ b/vivisect/demangle/common.py
@@ -100,6 +100,9 @@ class DemangledSymbol:
             return NotImplemented
         return self.full_name == other.full_name and self.format == other.format
 
+    def __hash__(self):
+        return hash((self.format, self.full_name))
+
     def __str__(self):
         return self.full_name
 
@@ -128,11 +131,10 @@ def normalize_name(name):
         return name
     # Strip @@VERSION suffixes (ELF dynamic linker convention).
     # MSVC mangled symbols start with '?' and use @@ as a scope terminator,
-    # so don't strip those.
+    # so don't strip those.  Use the regex to only strip if the content after
+    # @@ looks like a version string (not just any @@).
     if not name.startswith('?'):
-        idx = name.find('@@')
-        if idx > -1:
-            name = name[:idx]
+        name = _VERSION_SUFFIX_RE.sub('', name)
     # Strip trailing NUL
     if name.endswith('\x00'):
         name = name[:-1]

--- a/vivisect/demangle/common.py
+++ b/vivisect/demangle/common.py
@@ -1,0 +1,139 @@
+"""
+vivisect.demangle.common - Shared types and utilities for all demanglers.
+"""
+
+import re
+
+__all__ = [
+    'DemangledSymbol', 'DemangleError',
+    'normalize_name',
+]
+
+
+class DemangleError(Exception):
+    """
+    Raised internally by demanglers when parsing fails catastrophically.
+
+    The public :func:`vivisect.demangle.demangle` wrapper catches this and
+    returns the original mangled string (graceful degradation).
+    """
+    pass
+
+
+class DemangledSymbol:
+    """
+    Structured representation of a demangled symbol.
+
+    Not all fields are populated by every format demangler.  Fields that
+    don't apply to a given format are left at their default (``None``,
+    ``False``, ``[]``, ``''``).
+
+    Attributes:
+        format (str): The mangling format ('itanium', 'msvc', 'rust', etc.).
+        full_name (str): The fully rendered demangled name.
+        kind (str): Symbol kind: 'function', 'variable', 'vtable',
+            'typeinfo', 'ctor', 'dtor', 'thunk', 'guard', 'template', etc.
+        scope (list[str]): Namespace/class path (e.g. ['std', '__cxx11', 'string']).
+        name (str): The unqualified name.
+        is_template (bool): True if this is a template instantiation.
+        template_args (list): Template parameter type/value strings.
+        is_member (bool): True if this is a class member.
+        is_static (bool): True if this is static (mainly MSVC).
+        is_virtual (bool): True if this is virtual (mainly MSVC).
+        access (str): 'public', 'private', 'protected', or None.
+        calling_convention (str): 'cdecl', 'stdcall', 'thiscall', etc.
+        return_type (str or None): Return type string, if known.
+        parameters (list[str]): Parameter type strings.
+        cv_qualifiers (str): 'const', 'volatile', 'const volatile', or ''.
+        ref_qualifier (str): '', '&', or '&&'.
+        this_adjustment (int): MSVC thunk this-adjustment value.
+        abi_tags (list[str]): ABI tag names (Itanium).
+        storage_class (str or None): MSVC storage class.
+        original_mangled (str): The original mangled name.
+        parse_warnings (list[str]): Non-fatal parse issues.
+    """
+
+    __slots__ = (
+        'format', 'full_name', 'kind', 'scope', 'name',
+        'is_template', 'template_args', 'is_member', 'is_static',
+        'is_virtual', 'access', 'calling_convention', 'return_type',
+        'parameters', 'cv_qualifiers', 'ref_qualifier',
+        'this_adjustment', 'abi_tags', 'storage_class',
+        'original_mangled', 'parse_warnings',
+    )
+
+    def __init__(self, format=None, full_name='', name='', kind='unknown',
+                 scope=None, is_template=False, template_args=None,
+                 is_member=False, is_static=False, is_virtual=False,
+                 access=None, calling_convention=None, return_type=None,
+                 parameters=None, cv_qualifiers='', ref_qualifier='',
+                 this_adjustment=0, abi_tags=None, storage_class=None,
+                 original_mangled='', parse_warnings=None):
+        self.format = format
+        self.full_name = full_name
+        self.kind = kind
+        self.scope = scope if scope is not None else []
+        self.name = name
+        self.is_template = is_template
+        self.template_args = template_args if template_args is not None else []
+        self.is_member = is_member
+        self.is_static = is_static
+        self.is_virtual = is_virtual
+        self.access = access
+        self.calling_convention = calling_convention
+        self.return_type = return_type
+        self.parameters = parameters if parameters is not None else []
+        self.cv_qualifiers = cv_qualifiers
+        self.ref_qualifier = ref_qualifier
+        self.this_adjustment = this_adjustment
+        self.abi_tags = abi_tags if abi_tags is not None else []
+        self.storage_class = storage_class
+        self.original_mangled = original_mangled
+        self.parse_warnings = parse_warnings if parse_warnings is not None else []
+
+    def __repr__(self):
+        return '<DemangledSymbol format=%r kind=%r full_name=%r>' % (
+            self.format, self.kind, self.full_name)
+
+    def __eq__(self, other):
+        if not isinstance(other, DemangledSymbol):
+            return NotImplemented
+        return self.full_name == other.full_name and self.format == other.format
+
+    def __str__(self):
+        return self.full_name
+
+    def to_dict(self):
+        """Return a dict representation suitable for JSON serialization."""
+        return {k: getattr(self, k) for k in self.__slots__}
+
+
+# Regex for stripping ELF @@VERSION suffixes (e.g. @@GLIBC_2.4)
+_VERSION_SUFFIX_RE = re.compile(r'@@[A-Za-z0-9_.+-]+$')
+
+
+def normalize_name(name):
+    """
+    Normalize a mangled symbol name by stripping platform-specific suffixes.
+
+    Currently handles:
+        - ELF ``@@VERSION`` suffixes (e.g. ``foo@@GLIBC_2.4``) — but only
+          for non-MSVC symbols, since MSVC uses ``@@`` as a scope terminator
+        - Trailing NUL bytes
+
+    This replaces the ELF-specific ``normName()`` in the old elf.py parser
+    so it can be shared across all binary formats.
+    """
+    if not name:
+        return name
+    # Strip @@VERSION suffixes (ELF dynamic linker convention).
+    # MSVC mangled symbols start with '?' and use @@ as a scope terminator,
+    # so don't strip those.
+    if not name.startswith('?'):
+        idx = name.find('@@')
+        if idx > -1:
+            name = name[:idx]
+    # Strip trailing NUL
+    if name.endswith('\x00'):
+        name = name[:-1]
+    return name

--- a/vivisect/demangle/dlang/__init__.py
+++ b/vivisect/demangle/dlang/__init__.py
@@ -1,11 +1,11 @@
 """
 vivisect.demangle.dlang - D language symbol demangling (_D prefix).
 
-Phase 0: Stub.  Phase 5 will implement the full D demangler.
+D mangling uses _D prefix followed by length-prefixed names and type codes.
 
 Reference:
     - LLVM DLangDemangle.cpp
-    - D ABI documentation
+    - D ABI documentation (https://dlang.org/spec/abi.html#name_mangling)
 """
 
 import logging
@@ -18,21 +18,165 @@ __all__ = ['demangle_d']
 
 
 def demangle_d(mangled, structured=False):
-    """
-    Demangle a D language mangled symbol (_D prefix).
-
-    Phase 0: Returns the original name.
-    """
+    """Demangle a D language mangled symbol (_D prefix)."""
     original = mangled
     mangled = normalize_name(mangled)
 
-    if not structured:
+    demangled = None
+    parse_warnings = []
+
+    try:
+        parser = _DParser(mangled)
+        demangled = parser.parse()
+        parse_warnings = parser.warnings
+    except Exception as e:
+        logger.debug('D parser failed for %r: %r', mangled, e)
+        parse_warnings.append('parser error: %r' % e)
+
+    if demangled is None or demangled == mangled or not demangled:
+        if structured:
+            return DemangledSymbol(
+                format='d',
+                full_name=original,
+                name=original,
+                original_mangled=original,
+                parse_warnings=parse_warnings or ['unable to demangle'],
+            )
         return original
 
-    return DemangledSymbol(
+    if not structured:
+        return demangled
+
+    sym = DemangledSymbol(
         format='d',
-        full_name=original,
-        name=original,
+        full_name=demangled,
         original_mangled=original,
-        parse_warnings=['D demangler not yet implemented (Phase 5)'],
+        parse_warnings=parse_warnings,
     )
+    _parse_basic_structure(sym, demangled)
+    return sym
+
+
+class _DParser:
+    """Parser for D language mangled symbols."""
+
+    TYPE_MAP = {
+        'v': 'void', 'b': 'bool', 'y': 'byte', 'g': 'ubyte',
+        'h': 'short', 't': 'ushort', 'i': 'int', 'j': 'uint',
+        'k': 'long', 'm': 'ulong', 'l': 'real', 'f': 'float',
+        'd': 'double', 'e': 'real', 'c': 'ifloat', 'q': 'idouble',
+        'r': 'ireal', 'p': 'creal',
+        'a': 'char', 'u': 'wchar', 'w': 'dchar', 's': 'string',
+        'o': 'wstring', 'x': 'dstring',
+        'n': 'char[]', 'z': 'void',
+    }
+
+    def __init__(self, mangled):
+        self.mangled = mangled
+        self.pos = 0
+        self.warnings = []
+
+    def _peek(self, offset=0):
+        idx = self.pos + offset
+        if idx >= len(self.mangled):
+            return '\x00'
+        return self.mangled[idx]
+
+    def _next(self):
+        if self.pos >= len(self.mangled):
+            raise ValueError('unexpected end of input')
+        ch = self.mangled[self.pos]
+        self.pos += 1
+        return ch
+
+    def parse(self):
+        if not self.mangled.startswith('_D'):
+            raise ValueError('D symbols must start with _D')
+        self.pos = 2
+
+        result = self._parse_mangled_name()
+        return result
+
+    def _parse_mangled_name(self):
+        """Parse <mangled-name> ::= <number> <name> <type>"""
+        name_parts = []
+        while self._peek().isdigit():
+            length = self._parse_number()
+            if length == 0 or self.pos + length > len(self.mangled):
+                break
+            name = self.mangled[self.pos:self.pos + length]
+            self.pos += length
+            name_parts.append(name)
+
+        name = '.'.join(name_parts) if name_parts else self.mangled[2:]
+
+        if not self._at_end():
+            type_str = self._parse_type()
+            if type_str:
+                if type_str.startswith('('):
+                    return '%s%s' % (name, type_str)
+                else:
+                    return '%s %s' % (type_str, name)
+
+        return name
+
+    def _parse_number(self):
+        result = 0
+        while self._peek().isdigit():
+            result = result * 10 + int(self._next())
+        return result
+
+    def _parse_type(self):
+        ch = self._peek()
+
+        if ch in self.TYPE_MAP:
+            self._next()
+            return self.TYPE_MAP[ch]
+
+        if ch == 'P':
+            self._next()
+            inner = self._parse_type()
+            return '%s*' % inner
+
+        if ch == 'A':
+            self._next()
+            inner = self._parse_type()
+            return '%s[]' % inner
+
+        if ch == 'G':
+            self._next()
+            n = self._parse_number()
+            inner = self._parse_type()
+            return '%s[%d]' % (inner, n)
+
+        if ch == 'F':
+            self._next()
+            params = []
+            while self._peek() != 'Z' and self._peek() != '\x00':
+                params.append(self._parse_type())
+            if self._peek() == 'Z':
+                self._next()
+            return '(%s)' % ', '.join(params)
+
+        if ch.isdigit():
+            length = self._parse_number()
+            if length > 0 and self.pos + length <= len(self.mangled):
+                name = self.mangled[self.pos:self.pos + length]
+                self.pos += length
+                return name
+
+        self._next()
+        return '?%s' % ch
+
+    def _at_end(self):
+        return self.pos >= len(self.mangled)
+
+
+def _parse_basic_structure(sym, demangled):
+    if '.' in demangled:
+        parts = demangled.rsplit('.', 1)
+        sym.scope = parts[0].split('.')
+        sym.name = parts[1]
+    else:
+        sym.name = demangled
+    sym.kind = 'function' if '(' in sym.name else 'variable'

--- a/vivisect/demangle/dlang/__init__.py
+++ b/vivisect/demangle/dlang/__init__.py
@@ -1,0 +1,38 @@
+"""
+vivisect.demangle.dlang - D language symbol demangling (_D prefix).
+
+Phase 0: Stub.  Phase 5 will implement the full D demangler.
+
+Reference:
+    - LLVM DLangDemangle.cpp
+    - D ABI documentation
+"""
+
+import logging
+
+from vivisect.demangle.common import DemangledSymbol, normalize_name
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['demangle_d']
+
+
+def demangle_d(mangled, structured=False):
+    """
+    Demangle a D language mangled symbol (_D prefix).
+
+    Phase 0: Returns the original name.
+    """
+    original = mangled
+    mangled = normalize_name(mangled)
+
+    if not structured:
+        return original
+
+    return DemangledSymbol(
+        format='d',
+        full_name=original,
+        name=original,
+        original_mangled=original,
+        parse_warnings=['D demangler not yet implemented (Phase 5)'],
+    )

--- a/vivisect/demangle/dlang/__init__.py
+++ b/vivisect/demangle/dlang/__init__.py
@@ -1,11 +1,28 @@
 """
 vivisect.demangle.dlang - D language symbol demangling (_D prefix).
 
-D mangling uses _D prefix followed by length-prefixed names and type codes.
+Full D mangling support per the D ABI specification:
+    https://dlang.org/spec/abi.html#name_mangling
 
-Reference:
-    - LLVM DLangDemangle.cpp
-    - D ABI documentation (https://dlang.org/spec/abi.html#name_mangling)
+Features:
+    - Length-prefixed qualified names (module.class.function)
+    - Function types (F...Z...) with parameters and return type
+    - Delegate types (D...Z...)
+    - All primitive types (void, bool, byte/ubyte, short/ushort, etc.)
+    - Pointers (P), arrays (A), static arrays (G<number>)
+    - Type qualifiers: const (O), immutable (x), shared (O), wildcard (Ng)
+    - Associated types: return (Ni), parameter (Np)
+    - Const/immutable/shared modifiers on types
+    - References (R)
+    - New types: cent/ucent (zi/zk)
+    - noreturn (Nn)
+    - Special suffixes: __initZ, __vtblZ, __ClassZ, __InterfaceZ, __ModuleInfoZ
+    - Type back-references (Q<number>)
+    - Symbol back-references (B<number>)
+
+References:
+    - LLVM DLangDemangle.cpp (llvm/lib/Demangle/DLangDemangle.cpp)
+    - D ABI specification
 """
 
 import logging
@@ -18,7 +35,15 @@ __all__ = ['demangle_d']
 
 
 def demangle_d(mangled, structured=False):
-    """Demangle a D language mangled symbol (_D prefix)."""
+    """Demangle a D language mangled symbol (_D prefix).
+
+    Args:
+        mangled: The mangled symbol string.
+        structured: If True, return a DemangledSymbol object.
+
+    Returns:
+        The demangled name string, or DemangledSymbol if structured=True.
+    """
     original = mangled
     mangled = normalize_name(mangled)
 
@@ -57,24 +82,66 @@ def demangle_d(mangled, structured=False):
     return sym
 
 
-class _DParser:
-    """Parser for D language mangled symbols."""
+# D primitive type codes -> type names
+# From D ABI spec: https://dlang.org/spec/abi.html#name_mangling
+_D_TYPES = {
+    'v': 'void',
+    'b': 'bool',
+    'y': 'byte',
+    'g': 'ubyte',
+    'h': 'short',
+    't': 'ushort',
+    'i': 'int',
+    'j': 'uint',
+    'k': 'long',
+    'm': 'ulong',
+    'l': 'real',
+    'f': 'float',
+    'd': 'double',
+    'e': 'extended',  # real (80-bit on x86)
+    'c': 'cfloat',    # complex float
+    'q': 'cdouble',   # complex double
+    'r': 'creal',     # complex real
+    'p': 'cextended', # complex extended
+    'a': 'char',
+    'u': 'wchar',
+    'w': 'dchar',
+    's': 'string',
+    'o': 'wstring',
+    'x': 'dstring',
+    'n': 'char[]',
+    'z': 'void',      # sometimes used for char[]
+    # Newer D types
+    'zi': 'cent',
+    'zk': 'ucent',
+}
 
-    TYPE_MAP = {
-        'v': 'void', 'b': 'bool', 'y': 'byte', 'g': 'ubyte',
-        'h': 'short', 't': 'ushort', 'i': 'int', 'j': 'uint',
-        'k': 'long', 'm': 'ulong', 'l': 'real', 'f': 'float',
-        'd': 'double', 'e': 'real', 'c': 'ifloat', 'q': 'idouble',
-        'r': 'ireal', 'p': 'creal',
-        'a': 'char', 'u': 'wchar', 'w': 'dchar', 's': 'string',
-        'o': 'wstring', 'x': 'dstring',
-        'n': 'char[]', 'z': 'void',
-    }
+# D type qualifiers
+_D_QUALIFIERS = {
+    'O': 'shared',     # shared (also const shared when combined)
+    'x': 'immutable',  # immutable
+    'Ny': 'wild',      # wildcard (inout)
+    'Nc': 'const',     # const (when used as modifier prefix Nc)
+}
+
+
+class _DParser:
+    """Parser for D language mangled symbols.
+
+    Implements the full D mangling grammar:
+        <mangled-name> ::= _D <LName> <function-type> | <special-name>
+        <function-type> ::= <call-convention>? <function-attributes>* <parameters> <return-type>?
+        <parameters> ::= <type>* Z
+        <type> ::= <primitive> | <pointer> | <array> | <static-array> |
+                   <function> | <delegate> | <qualified-type> | <backref>
+    """
 
     def __init__(self, mangled):
         self.mangled = mangled
         self.pos = 0
         self.warnings = []
+        self._type_backrefs = []  # Type back-references
+        self._symbol_backrefs = []  # Symbol back-references
 
     def _peek(self, offset=0):
         idx = self.pos + offset
@@ -84,35 +151,116 @@ class _DParser:
 
     def _next(self):
         if self.pos >= len(self.mangled):
-            raise ValueError('unexpected end of input')
+            raise ValueError('unexpected end of input at pos %d' % self.pos)
         ch = self.mangled[self.pos]
         self.pos += 1
         return ch
 
+    def _at_end(self):
+        return self.pos >= len(self.mangled)
+
+    def _eat(self, ch):
+        if self._peek() == ch:
+            self.pos += 1
+            return True
+        return False
+
+    def _parse_number(self):
+        """Parse a decimal number."""
+        result = 0
+        while self._peek().isdigit():
+            result = result * 10 + int(self._next())
+        return result
+
     def parse(self):
+        """Entry point: parse a D mangled symbol."""
         if not self.mangled.startswith('_D'):
             raise ValueError('D symbols must start with _D')
         self.pos = 2
 
+        # Check for special names (main, etc.)
+        if self.mangled[2:] == 'main':
+            return 'D main'
+
         result = self._parse_mangled_name()
+
+        # Check for special suffixes (appended after the name+type)
+        if not self._at_end():
+            suffix = self.mangled[self.pos:]
+            result = self._handle_special_suffix(result, suffix)
+
         return result
 
+    def _handle_special_suffix(self, name, suffix):
+        """Handle special name suffixes like __initZ, __vtblZ, etc."""
+        special = {
+            '__initZ': ' __init',
+            '__vtblZ': ' vtbl',
+            '__ClassZ': ' Class',
+            '__InterfaceZ': ' Interface',
+            '__ModuleInfoZ': ' ModuleInfo',
+            '__constZ': ' const',
+            '__sharedZ': ' shared',
+            '__invariantZ': ' invariant',
+        }
+        for sfx, replacement in special.items():
+            if suffix == sfx:
+                return '%s%s' % (name, replacement)
+        # If it ends with Z (end of type list), it's already handled
+        if suffix == 'Z':
+            return name
+        return name
+
     def _parse_mangled_name(self):
-        """Parse <mangled-name> ::= <number> <name> <type>"""
+        """Parse <mangled-name> ::= <number> <name> <type>
+
+        The name is a chain of length-prefixed identifiers separated by dots.
+        After the name comes the function type (parameters + return type).
+        """
         name_parts = []
+
+        # Special case: just "main"
+        if self._peek() == 'm' and self.mangled[self.pos:].startswith('main'):
+            # Check if the full remaining is just "main"
+            if self.mangled[self.pos:] == 'main':
+                return 'D main'
+            # Otherwise it's a length prefix
+
         while self._peek().isdigit():
             length = self._parse_number()
             if length == 0 or self.pos + length > len(self.mangled):
-                break
+                raise ValueError('invalid name length %d at pos %d' % (length, self.pos))
             name = self.mangled[self.pos:self.pos + length]
             self.pos += length
+
+            # Check for special name suffixes (__init, __vtbl, etc.)
+            # These are part of the last name component
+            # They'll be handled after parsing the full name
+
+            # Add this name part to the symbol backrefs
+            self._symbol_backrefs.append(name)
             name_parts.append(name)
 
-        name = '.'.join(name_parts) if name_parts else self.mangled[2:]
+        if not name_parts:
+            raise ValueError('no name parts found')
 
+        name = '.'.join(name_parts)
+
+        # Check for special suffixes BEFORE the type
+        # e.g., _D3foo6__initZ -> foo.__init (no function type)
+        if name_parts and name_parts[-1].startswith('__'):
+            # This is a special name, no type follows
+            return name
+
+        # Parse the function type (parameters + return type)
         if not self._at_end():
-            type_str = self._parse_type()
+            type_str = self._parse_function_type()
             if type_str:
+                # D demangling format: name(params)return_type
+                # But c++filt/demangle format is: return_type name(params)
+                # We use: name(params) -> return_type
+                # Actually, the standard D format is just: name(params)
+                # with the return type shown as a suffix
                 if type_str.startswith('('):
                     return '%s%s' % (name, type_str)
                 else:
@@ -120,63 +268,272 @@ class _DParser:
 
         return name
 
-    def _parse_number(self):
-        result = 0
-        while self._peek().isdigit():
-            result = result * 10 + int(self._next())
-        return result
+    def _parse_function_type(self):
+        """Parse a function type: <call-convention>? <attributes>* <params> Z <return-type>?
+
+        D function types are:
+        F <call-convention>? <function-attributes>* <params> Z <return-type>?
+
+        For the top-level symbol, we just want the parameter list.
+        """
+        # The function type starts with F (function) or is just a type list
+        if self._peek() == 'F':
+            return self._parse_func_type_inner()
+
+        # Some symbols have just the parameter types without F prefix
+        # Parse as a bare type list
+        params = []
+        while not self._at_end() and self._peek() != 'Z':
+            try:
+                ty = self._parse_type()
+                if ty:
+                    params.append(ty)
+            except (ValueError, IndexError):
+                break
+
+        if self._peek() == 'Z':
+            self._next()
+
+        # Parse return type if present
+        ret_type = ''
+        if not self._at_end():
+            try:
+                ret_type = self._parse_type()
+            except (ValueError, IndexError):
+                pass
+
+        if ret_type:
+            return '(%s) %s' % (', '.join(params), ret_type)
+        return '(%s)' % ', '.join(params)
+
+    def _parse_func_type_inner(self):
+        """Parse F <call-convention>? <attrs>* <params> Z <return-type>?"""
+        self._next()  # consume F
+
+        # Calling convention is NOT parsed here because the D ABI
+        # reuses type chars (a=char, w=dchar, u=wchar) as calling
+        # convention codes, making them ambiguous without context.
+        # Since explicit calling conventions are extremely rare in
+        # practice, we skip detection to avoid misinterpreting types.
+        call_conv = ''
+
+        # Function attributes (optional, N-prefixed)
+        attrs = []
+        while self._peek() == 'N':
+            self._next()
+            attr_char = self._next()
+            attr_map = {
+                'a': 'pure',
+                'b': 'nothrow',
+                'c': 'ref',
+                'd': 'return',
+                'e': 'scope',
+                'f': 'return ref',
+                'g': 'scope return',
+                'h': '@nogc',
+                'i': '@live',
+                'j': 'return scope',
+                'k': 'const',
+                'l': 'immutable',
+                'm': 'shared',
+                'n': 'wild',
+                'o': 'return',
+                'p': '@safe',
+                'q': '@trusted',
+                'r': '@system',
+            }
+            attr = attr_map.get(attr_char, '')
+            if attr:
+                attrs.append(attr)
+
+        # Parameters (type list terminated by Z)
+        params = []
+        while not self._at_end() and self._peek() != 'Z':
+            try:
+                ty = self._parse_type()
+                if ty:
+                    params.append(ty)
+            except (ValueError, IndexError):
+                break
+
+        if self._peek() == 'Z':
+            self._next()
+
+        # Return type (optional)
+        ret_type = ''
+        if not self._at_end():
+            try:
+                ret_type = self._parse_type()
+            except (ValueError, IndexError):
+                pass
+
+        # Build the function signature
+        prefix = ' '.join(attrs)
+        if call_conv:
+            prefix = ('%s %s' % (call_conv, prefix)).strip()
+
+        param_str = ', '.join(params)
+        if ret_type:
+            sig = '%s(%s) %s' % (prefix, param_str, ret_type) if prefix else '(%s) %s' % (param_str, ret_type)
+        else:
+            sig = '%s(%s)' % (prefix, param_str) if prefix else '(%s)' % param_str
+
+        return sig
 
     def _parse_type(self):
+        """Parse a D type.
+
+        <type> ::= <primitive>
+                 ::= P <type>           (pointer)
+                 ::= R <type>           (reference)
+                 ::= A <type>           (dynamic array)
+                 ::= G <number> <type>  (static array)
+                 ::= H <type> <type>    (associative array)
+                 ::= F <function-type>  (function pointer)
+                 ::= D <function-type>  (delegate)
+                 ::= O <type>           (shared)
+                 ::= x <type>           (immutable)
+                 ::= Nc <type>          (const)
+                 ::= Ny <type>          (wild/inout)
+                 ::= Nn                 (noreturn)
+                 ::= Q <number>          (type backref)
+                 ::= B <number>         (symbol backref)
+                 ::= <length> <name>    (named type)
+        """
         ch = self._peek()
 
-        if ch in self.TYPE_MAP:
-            self._next()
-            return self.TYPE_MAP[ch]
+        # Two-char type codes (zi, zk, Nn, Ny, Nc, Np, Ni)
+        two_char = self.mangled[self.pos:self.pos + 2]
+        if two_char in _D_TYPES:
+            self.pos += 2
+            return _D_TYPES[two_char]
+        if two_char == 'Nn':
+            self.pos += 2
+            return 'noreturn'
+        if two_char == 'Ny':
+            self.pos += 2
+            inner = self._parse_type()
+            return 'wild(%s)' % inner
+        if two_char == 'Nc':
+            self.pos += 2
+            inner = self._parse_type()
+            return 'const(%s)' % inner
+        if two_char == 'Np':
+            self.pos += 2
+            inner = self._parse_type()
+            return 'param(%s)' % inner
+        if two_char == 'Ni':
+            self.pos += 2
+            inner = self._parse_type()
+            return 'return(%s)' % inner
 
+        # Type qualifiers
+        if ch == 'O':
+            self._next()
+            inner = self._parse_type()
+            return 'shared(%s)' % inner
+        if ch == 'x':
+            self._next()
+            inner = self._parse_type()
+            return 'immutable(%s)' % inner
+
+        # Primitive types
+        if ch in _D_TYPES:
+            self._next()
+            return _D_TYPES[ch]
+
+        # Pointer
         if ch == 'P':
             self._next()
             inner = self._parse_type()
+            self._type_backrefs.append(inner)
             return '%s*' % inner
 
+        # Reference
+        if ch == 'R':
+            self._next()
+            inner = self._parse_type()
+            self._type_backrefs.append(inner)
+            return 'ref %s' % inner
+
+        # Dynamic array
         if ch == 'A':
             self._next()
             inner = self._parse_type()
+            self._type_backrefs.append(inner)
             return '%s[]' % inner
 
+        # Static array
         if ch == 'G':
             self._next()
             n = self._parse_number()
             inner = self._parse_type()
+            self._type_backrefs.append(inner)
             return '%s[%d]' % (inner, n)
 
-        if ch == 'F':
+        # Associative array
+        if ch == 'H':
             self._next()
-            params = []
-            while self._peek() != 'Z' and self._peek() != '\x00':
-                params.append(self._parse_type())
-            if self._peek() == 'Z':
-                self._next()
-            return '(%s)' % ', '.join(params)
+            key = self._parse_type()
+            value = self._parse_type()
+            self._type_backrefs.append(value)
+            return '%s[%s]' % (value, key)
 
+        # Function pointer
+        if ch == 'F':
+            return self._parse_func_type_inner()
+
+        # Delegate
+        if ch == 'D':
+            self._next()
+            func_sig = self._parse_func_type_inner()
+            return 'delegate %s' % func_sig
+
+        # Type back-reference (Q<number>)
+        if ch == 'Q':
+            self._next()
+            idx = self._parse_number()
+            if idx < len(self._type_backrefs):
+                return self._type_backrefs[idx]
+            return '<backref:%d>' % idx
+
+        # Symbol back-reference (B<number>)
+        if ch == 'B':
+            self._next()
+            idx = self._parse_number()
+            if idx < len(self._symbol_backrefs):
+                return self._symbol_backrefs[idx]
+            return '<symref:%d>' % idx
+
+        # Named type (length-prefixed)
         if ch.isdigit():
             length = self._parse_number()
             if length > 0 and self.pos + length <= len(self.mangled):
                 name = self.mangled[self.pos:self.pos + length]
                 self.pos += length
+                self._type_backrefs.append(name)
                 return name
 
+        # Unknown
         self._next()
         return '?%s' % ch
 
-    def _at_end(self):
-        return self.pos >= len(self.mangled)
-
 
 def _parse_basic_structure(sym, demangled):
+    """Parse basic structure from a demangled D name."""
     if '.' in demangled:
         parts = demangled.rsplit('.', 1)
         sym.scope = parts[0].split('.')
         sym.name = parts[1]
     else:
         sym.name = demangled
-    sym.kind = 'function' if '(' in sym.name else 'variable'
+
+    if '(' in sym.name:
+        sym.kind = 'function'
+    elif sym.name.startswith('__'):
+        sym.kind = 'special'
+    else:
+        sym.kind = 'variable'
+
+    if '<' in sym.name:
+        sym.is_template = True

--- a/vivisect/demangle/itanium/__init__.py
+++ b/vivisect/demangle/itanium/__init__.py
@@ -1,0 +1,151 @@
+"""
+vivisect.demangle.itanium - Itanium C++ ABI demangling (_Z prefix).
+
+Phase 0: Uses ``cxxfilt`` as a fallback if available.  The pure-Python
+parser will be implemented in Phase 1.
+
+The Itanium C++ ABI is used by GCC, Clang, and ICC on Linux/macOS.
+Mangled symbols start with ``_Z`` (or ``__Z`` for old GCC).
+
+Reference:
+    - Itanium C++ ABI section 5.1 (External Names)
+    - GNU libiberty cp-demangle.c (the gold standard)
+    - LLVM ItaniumDemangle.cpp
+"""
+
+import logging
+
+from vivisect.demangle.common import DemangledSymbol, normalize_name
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['demangle_itanium']
+
+
+def demangle_itanium(mangled, structured=False):
+    """
+    Demangle an Itanium C++ ABI mangled symbol (_Z prefix).
+
+    Phase 0: Falls back to ``cxxfilt`` if available.  If ``cxxfilt`` is
+    not installed or fails, returns the original name (graceful
+    degradation).
+
+    Args:
+        mangled (str): The mangled symbol string.
+        structured (bool): If True, return a DemangledSymbol object.
+
+    Returns:
+        str or DemangledSymbol: The demangled name, or the original if
+        demangling fails.
+    """
+    original = mangled
+    mangled = normalize_name(mangled)
+
+    demangled = None
+    try:
+        import cxxfilt
+        demangled = cxxfilt.demangle(mangled)
+    except Exception as e:
+        logger.debug('cxxfilt demangle failed for %r: %r', mangled, e)
+        demangled = None
+
+    # cxxfilt returns the original if it can't demangle
+    if demangled is None or demangled == mangled:
+        if structured:
+            return DemangledSymbol(
+                format='itanium',
+                full_name=original,
+                name=original,
+                original_mangled=original,
+                parse_warnings=['cxxfilt unavailable or unable to demangle'],
+            )
+        return original
+
+    if not structured:
+        return demangled
+
+    # Build a minimal structured result from the cxxfilt string.
+    # Phase 1 will replace this with a full AST.
+    sym = DemangledSymbol(
+        format='itanium',
+        full_name=demangled,
+        original_mangled=original,
+    )
+    _parse_basic_structure(sym, demangled)
+    return sym
+
+
+def _parse_basic_structure(sym, demangled):
+    """
+    Best-effort extraction of basic structure from a demangled string.
+
+    This is a placeholder for Phase 1's real AST.  It extracts scope/name
+    split and detects vtables/typeinfo/guard variables.
+    """
+    # Special names
+    if demangled.startswith('vtable for '):
+        sym.kind = 'vtable'
+        sym.name = demangled[len('vtable for '):]
+        sym.scope = sym.name.split('::')
+        return
+    if demangled.startswith('typeinfo for '):
+        sym.kind = 'typeinfo'
+        sym.name = demangled[len('typeinfo for '):]
+        sym.scope = sym.name.split('::')
+        return
+    if demangled.startswith('typeinfo name for '):
+        sym.kind = 'typeinfo_name'
+        sym.name = demangled[len('typeinfo name for '):]
+        sym.scope = sym.name.split('::')
+        return
+    if demangled.startswith('VTT for '):
+        sym.kind = 'vtt'
+        sym.name = demangled[len('VTT for '):]
+        sym.scope = sym.name.split('::')
+        return
+    if demangled.startswith('guard variable for '):
+        sym.kind = 'guard'
+        sym.name = demangled[len('guard variable for '):]
+        sym.scope = sym.name.split('::')
+        return
+
+    # Function or variable: split scope from the last ::
+    if '::' in demangled:
+        # Find the last :: that's not inside template args (<>)
+        depth = 0
+        split_pos = -1
+        for i in range(len(demangled) - 1):
+            c = demangled[i]
+            if c == '<':
+                depth += 1
+            elif c == '>':
+                depth -= 1
+            elif depth == 0 and c == ':' and demangled[i + 1] == ':':
+                split_pos = i
+
+        if split_pos > -1:
+            sym.scope = demangled[:split_pos].split('::')
+            sym.name = demangled[split_pos + 2:]
+        else:
+            sym.name = demangled
+    else:
+        sym.name = demangled
+
+    # Detect template
+    if '<' in sym.name:
+        sym.is_template = True
+
+    # Detect constructor/destructor (common naming patterns)
+    # e.g. foo::bar::ClassName::ClassName() is a constructor
+    if sym.scope and sym.name:
+        last_scope = sym.scope[-1] if sym.scope else ''
+        if sym.name == last_scope + '(' or sym.name.startswith(last_scope + '('):
+            sym.kind = 'ctor'
+        elif sym.name.startswith('~'):
+            sym.kind = 'dtor'
+
+    if sym.kind == 'unknown':
+        if '(' in sym.name:
+            sym.kind = 'function'
+        else:
+            sym.kind = 'variable'

--- a/vivisect/demangle/itanium/__init__.py
+++ b/vivisect/demangle/itanium/__init__.py
@@ -1,8 +1,7 @@
 """
 vivisect.demangle.itanium - Itanium C++ ABI demangling (_Z prefix).
 
-Phase 0: Uses ``cxxfilt`` as a fallback if available.  The pure-Python
-parser will be implemented in Phase 1.
+Phase 1: Pure-Python recursive descent parser.  No cxxfilt dependency.
 
 The Itanium C++ ABI is used by GCC, Clang, and ICC on Linux/macOS.
 Mangled symbols start with ``_Z`` (or ``__Z`` for old GCC).
@@ -16,19 +15,22 @@ Reference:
 import logging
 
 from vivisect.demangle.common import DemangledSymbol, normalize_name
+from vivisect.demangle.itanium.parser import ItaniumParser, ParseError
+from vivisect.demangle.itanium.renderer import render
+from vivisect.demangle.symbol import Symbol
 
 logger = logging.getLogger(__name__)
 
-__all__ = ['demangle_itanium']
+__all__ = ['demangle_itanium', 'demangle_itanium_symbol']
 
 
 def demangle_itanium(mangled, structured=False):
     """
     Demangle an Itanium C++ ABI mangled symbol (_Z prefix).
 
-    Phase 0: Falls back to ``cxxfilt`` if available.  If ``cxxfilt`` is
-    not installed or fails, returns the original name (graceful
-    degradation).
+    Uses the pure-Python recursive descent parser.  Falls back to cxxfilt
+    if available and the pure-Python parser fails (for edge cases not yet
+    handled).
 
     Args:
         mangled (str): The mangled symbol string.
@@ -42,14 +44,39 @@ def demangle_itanium(mangled, structured=False):
     mangled = normalize_name(mangled)
 
     demangled = None
-    try:
-        import cxxfilt
-        demangled = cxxfilt.demangle(mangled)
-    except Exception as e:
-        logger.debug('cxxfilt demangle failed for %r: %r', mangled, e)
-        demangled = None
+    parse_warnings = []
 
-    # cxxfilt returns the original if it can't demangle
+    # Try the pure-Python parser first
+    try:
+        parser = ItaniumParser(mangled)
+        ast_root = parser.parse()
+        demangled = render(ast_root, subs=parser.subs)
+        parse_warnings = parser.warnings
+    except ParseError as e:
+        logger.debug('pure-Python Itanium parser failed for %r: %r', mangled, e)
+        parse_warnings.append('parser error: %r' % e)
+    except Exception as e:
+        logger.debug('Itanium parser exception for %r: %r', mangled, e)
+        parse_warnings.append('parser exception: %r' % e)
+
+    # If the parser failed or produced nothing, try cxxfilt as fallback
+    if demangled is None or demangled == mangled or '/*' in demangled:
+        try:
+            import cxxfilt
+            cxx_result = cxxfilt.demangle(mangled)
+            if cxx_result and cxx_result != mangled:
+                if demangled is None:
+                    demangled = cxx_result
+                    parse_warnings = ['cxxfilt fallback']
+                else:
+                    # Prefer cxxfilt if the parser produced garbage
+                    if '/*' in demangled:
+                        demangled = cxx_result
+                        parse_warnings = ['cxxfilt fallback (parser produced placeholders)']
+        except Exception as e:
+            logger.debug('cxxfilt fallback failed for %r: %r', mangled, e)
+
+    # If all methods failed, return the original
     if demangled is None or demangled == mangled:
         if structured:
             return DemangledSymbol(
@@ -57,61 +84,110 @@ def demangle_itanium(mangled, structured=False):
                 full_name=original,
                 name=original,
                 original_mangled=original,
-                parse_warnings=['cxxfilt unavailable or unable to demangle'],
+                parse_warnings=parse_warnings or ['unable to demangle'],
             )
         return original
 
     if not structured:
         return demangled
 
-    # Build a minimal structured result from the cxxfilt string.
-    # Phase 1 will replace this with a full AST.
+    # Build structured result
+    sym = _build_structured(demangled, original, parse_warnings)
+    return sym
+
+
+def demangle_itanium_symbol(mangled):
+    """
+    Demangle an Itanium symbol and return a Symbol object with full
+    structured data (original, demangled, stripped, type/return/arg info).
+
+    Args:
+        mangled (str): The original mangled symbol string.
+
+    Returns:
+        Symbol: The Symbol object with all available structured data.
+    """
+    original = mangled
+    mangled = normalize_name(mangled)
+
+    stripped = {}
+    if original != mangled:
+        # Record what was stripped
+        suffix = original[len(mangled):]
+        stripped['version_suffix'] = suffix
+
+    demangled = None
+    parse_warnings = []
+    ast_root = None
+    subs = []
+
+    try:
+        parser = ItaniumParser(mangled)
+        ast_root = parser.parse()
+        subs = parser.subs
+        demangled = render(ast_root, subs=subs)
+        parse_warnings = parser.warnings
+    except ParseError as e:
+        parse_warnings.append('parser error: %r' % e)
+    except Exception as e:
+        parse_warnings.append('parser exception: %r' % e)
+
+    # cxxfilt fallback
+    if demangled is None or demangled == mangled or '/*' in demangled:
+        try:
+            import cxxfilt
+            cxx_result = cxxfilt.demangle(mangled)
+            if cxx_result and cxx_result != mangled:
+                if demangled is None or '/*' in (demangled or ''):
+                    demangled = cxx_result
+                    if not ast_root:
+                        parse_warnings = ['cxxfilt fallback']
+        except Exception:
+            pass
+
+    if demangled is None:
+        demangled = original
+
+    # Build the Symbol with structured data from the AST
+    sym = Symbol(original=original, demangled=demangled, format='itanium',
+                 stripped=stripped, parse_warnings=parse_warnings)
+
+    if ast_root is not None:
+        _populate_symbol_from_ast(sym, ast_root, subs)
+
+    return sym
+
+
+def _build_structured(demangled, original, parse_warnings):
+    """Build a DemangledSymbol from the demangled string (Phase 0 compat)."""
     sym = DemangledSymbol(
         format='itanium',
         full_name=demangled,
         original_mangled=original,
+        parse_warnings=parse_warnings,
     )
     _parse_basic_structure(sym, demangled)
     return sym
 
 
 def _parse_basic_structure(sym, demangled):
-    """
-    Best-effort extraction of basic structure from a demangled string.
-
-    This is a placeholder for Phase 1's real AST.  It extracts scope/name
-    split and detects vtables/typeinfo/guard variables.
-    """
+    """Best-effort extraction of basic structure from a demangled string."""
     # Special names
-    if demangled.startswith('vtable for '):
-        sym.kind = 'vtable'
-        sym.name = demangled[len('vtable for '):]
-        sym.scope = sym.name.split('::')
-        return
-    if demangled.startswith('typeinfo for '):
-        sym.kind = 'typeinfo'
-        sym.name = demangled[len('typeinfo for '):]
-        sym.scope = sym.name.split('::')
-        return
-    if demangled.startswith('typeinfo name for '):
-        sym.kind = 'typeinfo_name'
-        sym.name = demangled[len('typeinfo name for '):]
-        sym.scope = sym.name.split('::')
-        return
-    if demangled.startswith('VTT for '):
-        sym.kind = 'vtt'
-        sym.name = demangled[len('VTT for '):]
-        sym.scope = sym.name.split('::')
-        return
-    if demangled.startswith('guard variable for '):
-        sym.kind = 'guard'
-        sym.name = demangled[len('guard variable for '):]
-        sym.scope = sym.name.split('::')
-        return
+    for prefix, kind in [
+        ('vtable for ', 'vtable'),
+        ('typeinfo for ', 'typeinfo'),
+        ('typeinfo name for ', 'typeinfo_name'),
+        ('VTT for ', 'vtt'),
+        ('guard variable for ', 'guard'),
+    ]:
+        if demangled.startswith(prefix):
+            sym.kind = kind
+            sym.name = demangled[len(prefix):]
+            sym.scope = sym.name.split('::')
+            return
 
     # Function or variable: split scope from the last ::
     if '::' in demangled:
-        # Find the last :: that's not inside template args (<>)
         depth = 0
         split_pos = -1
         for i in range(len(demangled) - 1):
@@ -131,21 +207,91 @@ def _parse_basic_structure(sym, demangled):
     else:
         sym.name = demangled
 
-    # Detect template
     if '<' in sym.name:
         sym.is_template = True
-
-    # Detect constructor/destructor (common naming patterns)
-    # e.g. foo::bar::ClassName::ClassName() is a constructor
-    if sym.scope and sym.name:
-        last_scope = sym.scope[-1] if sym.scope else ''
-        if sym.name == last_scope + '(' or sym.name.startswith(last_scope + '('):
-            sym.kind = 'ctor'
-        elif sym.name.startswith('~'):
-            sym.kind = 'dtor'
 
     if sym.kind == 'unknown':
         if '(' in sym.name:
             sym.kind = 'function'
         else:
             sym.kind = 'variable'
+
+
+def _populate_symbol_from_ast(sym, ast_root, subs):
+    """Populate Symbol fields from the parsed AST."""
+    from vivisect.demangle.itanium import ast_nodes as ast
+
+    sym.kind = 'unknown'
+
+    if isinstance(ast_root, ast.SpecialName):
+        sym.kind = ast_root.kind
+        if ast_root.target is not None:
+            target_str = render(ast_root.target, subs=subs)
+            sym.name = target_str
+            sym.scope = target_str.split('::') if '::' in target_str else []
+        return
+
+    if isinstance(ast_root, ast.Name):
+        qualified = ast_root.qualified_name
+
+        # Extract scope and name
+        if isinstance(qualified, ast.NestedName):
+            scope_parts = []
+            for p in qualified.prefix:
+                r = render(p, subs=subs) if not (isinstance(p, ast.UnqualifiedName) and p.kind == 'template') else ''
+                if r and not (isinstance(p, ast.UnqualifiedName) and p.kind == 'template'):
+                    scope_parts.append(r)
+            sym.scope = scope_parts
+            sym.is_member = len(scope_parts) > 0
+
+            # Get the unqualified name
+            unq = qualified.unqualified_name
+            if isinstance(unq, ast.UnqualifiedName):
+                if unq.kind == 'source':
+                    sym.name = render(unq, subs=subs)
+                elif unq.kind == 'ctor':
+                    sym.kind = 'ctor'
+                    sym.name = scope_parts[-1] if scope_parts else '<ctor>'
+                elif unq.kind == 'dtor':
+                    sym.kind = 'dtor'
+                    sym.name = '~' + (scope_parts[-1] if scope_parts else '<dtor>')
+                elif unq.kind == 'operator':
+                    sym.name = 'operator' + unq.value.symbol
+                elif unq.kind == 'template':
+                    base_name = scope_parts[-1] if scope_parts else ''
+                    targs_str = render(unq.value, subs=subs)
+                    sym.name = base_name + targs_str
+                    sym.is_template = True
+        elif isinstance(qualified, ast.UnqualifiedName):
+            if qualified.kind == 'source':
+                sym.name = render(qualified, subs=subs)
+            elif qualified.kind == 'template':
+                sym.is_template = True
+                targs_str = render(qualified.value, subs=subs)
+                sym.name = targs_str
+        elif isinstance(qualified, ast.SourceName):
+            sym.name = qualified.name
+        elif isinstance(qualified, ast.Substitution):
+            sym.name = render(qualified, subs=subs)
+
+        # Extract function signature data
+        if ast_root.is_function and ast_root.bare_function:
+            sym.kind = 'function' if sym.kind == 'unknown' else sym.kind
+
+            types = ast_root.bare_function.types
+            if types:
+                # Determine if there's a return type
+                is_template = sym.is_template
+                if is_template and len(types) > 1:
+                    sym.return_type = render(types[0], subs=subs)
+                    param_nodes = types[1:]
+                else:
+                    param_nodes = types
+
+                # Apply void→empty convention
+                param_strs = [render(t, subs=subs) for t in param_nodes]
+                if len(param_strs) == 1 and param_strs[0] == 'void':
+                    param_strs = []
+                sym.parameters = param_strs
+        else:
+            sym.kind = 'variable' if sym.kind == 'unknown' else sym.kind

--- a/vivisect/demangle/itanium/ast_nodes.py
+++ b/vivisect/demangle/itanium/ast_nodes.py
@@ -1,0 +1,329 @@
+"""
+vivisect.demangle.itanium.ast_nodes - AST node classes for Itanium demangling.
+
+The parser produces an AST of these node objects.  The renderer walks the
+AST to produce the demangled string.  Each node type represents one
+construct from the Itanium C++ ABI mangling grammar.
+
+All nodes inherit from Node and implement:
+    - __repr__: for debugging
+    - children(): list of child nodes (for walking)
+"""
+
+__all__ = [
+    'Node', 'Name', 'SourceName', 'NestedName', 'UnqualifiedName',
+    'OperatorName', 'CtorDtorName', 'TemplateArgs', 'TemplateArg',
+    'BuiltinType', 'PointerType', 'ReferenceType', 'RvalueReferenceType',
+    'CVQualifiedType', 'FunctionType', 'BareFunctionType',
+    'Substitution', 'TemplateParam', 'SpecialName', 'Array',
+    'PointerToMember', 'VendorExtendedType', 'Decltype',
+    'ModuleName', 'AbiTag',
+]
+
+
+class Node:
+    """Base class for all AST nodes."""
+    def children(self):
+        return []
+
+    def __repr__(self):
+        return '<%s>' % self.__class__.__name__
+
+
+class Name(Node):
+    """A top-level name (function or data name)."""
+    def __init__(self, qualified_name, is_function=False, bare_function=None):
+        self.qualified_name = qualified_name  # Node (NestedName, SourceName, etc.)
+        self.is_function = is_function
+        self.bare_function = bare_function  # BareFunctionType or None
+
+    def children(self):
+        c = [self.qualified_name]
+        if self.bare_function:
+            c.append(self.bare_function)
+        return c
+
+    def __repr__(self):
+        return '<Name func=%r %r>' % (self.is_function, self.qualified_name)
+
+
+class SourceName(Node):
+    """A source name: <length><identifier> (e.g. 3foo -> foo)."""
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return '<SourceName %r>' % self.name
+
+
+class NestedName(Node):
+    """A nested name: N [<CV-qualifiers>] [<ref-qualifier>] <prefix> <unqualified-name> E"""
+    def __init__(self, prefix, unqualified_name, cv_qualifiers='',
+                 ref_qualifier=''):
+        self.prefix = prefix            # list of Node (scope chain)
+        self.unqualified_name = unqualified_name  # Node
+        self.cv_qualifiers = cv_qualifiers  # str: 'const', 'volatile', etc.
+        self.ref_qualifier = ref_qualifier  # str: '', '&', '&&'
+        self.bare_function = None  # optional BareFunctionType (set by _parse_encoding)
+
+    def children(self):
+        return self.prefix + [self.unqualified_name]
+
+    def __repr__(self):
+        return '<NestedName prefix=%r unq=%r cv=%r ref=%r>' % (
+            self.prefix, self.unqualified_name, self.cv_qualifiers,
+            self.ref_qualifier)
+
+
+class UnqualifiedName(Node):
+    """An unqualified name: source name, operator, or ctor/dtor."""
+    def __init__(self, kind, value, abi_tags=None):
+        self.kind = kind  # 'source', 'operator', 'ctor', 'dtor', 'unnamed', 'template'
+        self.value = value  # str or Node
+        self.abi_tags = abi_tags or []  # list of str
+
+    def children(self):
+        if isinstance(self.value, Node):
+            return [self.value]
+        return []
+
+    def __repr__(self):
+        return '<UnqualifiedName kind=%r value=%r>' % (self.kind, self.value)
+
+
+class OperatorName(Node):
+    """An operator name: e.g. 'pl' -> '+'."""
+    def __init__(self, code, symbol, num_args=2):
+        self.code = code        # str: the 2-char code
+        self.symbol = symbol   # str: the operator symbol/name
+        self.num_args = num_args
+
+    def __repr__(self):
+        return '<OperatorName %s=%s>' % (self.code, self.symbol)
+
+
+class CtorDtorName(Node):
+    """A constructor or destructor name."""
+    def __init__(self, kind, is_destructor=False):
+        self.kind = kind  # 'complete', 'base', 'allocating', 'deleting', etc.
+        self.is_destructor = is_destructor
+
+    def __repr__(self):
+        return '<CtorDtorName %s%s>' % ('~' if self.is_destructor else '', self.kind)
+
+
+class TemplateArgs(Node):
+    """Template arguments: I <template-arg>+ E"""
+    def __init__(self, args):
+        self.args = args  # list of Node
+
+    def children(self):
+        return self.args
+
+    def __repr__(self):
+        return '<TemplateArgs args=%r>' % (self.args,)
+
+
+class TemplateArg(Node):
+    """A single template argument."""
+    def __init__(self, kind, value):
+        self.kind = kind  # 'type', 'expression', 'pack', 'pack_expansion'
+        self.value = value  # Node or str
+
+    def children(self):
+        if isinstance(self.value, Node):
+            return [self.value]
+        return []
+
+    def __repr__(self):
+        return '<TemplateArg kind=%r value=%r>' % (self.kind, self.value)
+
+
+class BuiltinType(Node):
+    """A builtin type (e.g. 'i' -> int)."""
+    def __init__(self, name, code=None):
+        self.name = name  # str: 'int', 'void', etc.
+        self.code = code  # str: the mangled code (e.g. 'i', 'Dd')
+
+    def __repr__(self):
+        return '<BuiltinType %s>' % self.name
+
+
+class PointerType(Node):
+    """A pointer: P <type>"""
+    def __init__(self, target):
+        self.target = target  # Node
+
+    def children(self):
+        return [self.target]
+
+    def __repr__(self):
+        return '<Pointer %r>' % self.target
+
+
+class ReferenceType(Node):
+    """An lvalue reference: R <type>"""
+    def __init__(self, target):
+        self.target = target
+
+    def children(self):
+        return [self.target]
+
+    def __repr__(self):
+        return '<LvalueRef %r>' % self.target
+
+
+class RvalueReferenceType(Node):
+    """An rvalue reference: O <type>"""
+    def __init__(self, target):
+        self.target = target
+
+    def children(self):
+        return [self.target]
+
+    def __repr__(self):
+        return '<RvalueRef %r>' % self.target
+
+
+class CVQualifiedType(Node):
+    """A CV-qualified type: K (const), V (volatile), r (restrict)."""
+    def __init__(self, base, qualifiers):
+        self.base = base  # Node
+        self.qualifiers = qualifiers  # str: 'const', 'volatile', 'const volatile', etc.
+
+    def children(self):
+        return [self.base]
+
+    def __repr__(self):
+        return '<CVQualified %s %r>' % (self.qualifiers, self.base)
+
+
+class FunctionType(Node):
+    """A full function type: F [Y] <bare-function-type> [<ref-qualifier>] E"""
+    def __init__(self, bare_function, cv='', ref=''):
+        self.bare_function = bare_function  # BareFunctionType
+        self.cv = cv  # CV-qualifiers on the function (for member functions)
+        self.ref = ref  # ref-qualifier on the function
+
+    def children(self):
+        return [self.bare_function]
+
+    def __repr__(self):
+        return '<FunctionType cv=%r ref=%r>' % (self.cv, self.ref)
+
+
+class BareFunctionType(Node):
+    """A bare function type: <type>+ (return type + params, or just params)."""
+    def __init__(self, types):
+        self.types = types  # list of Node: [return_type?, param1, param2, ...]
+
+    def children(self):
+        return self.types
+
+    def __repr__(self):
+        return '<BareFunctionType types=%r>' % (self.types,)
+
+
+class Substitution(Node):
+    """A substitution reference: S_, S0_, SA_, St, Sa, Sb, Ss, Si, So, Sd."""
+    def __init__(self, index=None, std_sub=None):
+        self.index = index  # int: the substitution index (S_ = 0, S0_ = 1, ...)
+        self.std_sub = std_sub  # str: standard sub key ('t','a','b','s','i','o','d') or None
+
+    def __repr__(self):
+        if self.std_sub:
+            return '<Substitution std=%r>' % self.std_sub
+        return '<Substitution %d>' % self.index
+
+
+class TemplateParam(Node):
+    """A template parameter reference: T_, T0_, T1_, ..."""
+    def __init__(self, index):
+        self.index = index  # int: 0 for T_, 1 for T0_, etc.
+
+    def __repr__(self):
+        return '<TemplateParam %d>' % self.index
+
+
+class SpecialName(Node):
+    """A special name: TV (vtable), TT (VTT), TI (typeinfo), TS (typeinfo name), GV (guard), etc."""
+    def __init__(self, kind, target=None):
+        self.kind = kind  # str: 'vtable', 'VTT', 'typeinfo', 'typeinfo name', 'guard', etc.
+        self.target = target  # Node (the type or name this refers to)
+
+    def children(self):
+        if self.target is not None:
+            return [self.target]
+        return []
+
+    def __repr__(self):
+        return '<SpecialName %r>' % self.kind
+
+
+class Array(Node):
+    """An array type: A <dimension> _ <type>"""
+    def __init__(self, dimension, element_type):
+        self.dimension = dimension  # str: the dimension expression
+        self.element_type = element_type  # Node
+
+    def children(self):
+        return [self.element_type]
+
+    def __repr__(self):
+        return '<Array dim=%r %r>' % (self.dimension, self.element_type)
+
+
+class PointerToMember(Node):
+    """A pointer-to-member: M <class-type> <member-type>"""
+    def __init__(self, class_type, member_type):
+        self.class_type = class_type  # Node
+        self.member_type = member_type  # Node
+
+    def children(self):
+        return [self.class_type, self.member_type]
+
+    def __repr__(self):
+        return '<PointerToMember class=%r member=%r>' % (
+            self.class_type, self.member_type)
+
+
+class VendorExtendedType(Node):
+    """A vendor-extended type: u <source-name> [<template-args>]"""
+    def __init__(self, name, template_args=None):
+        self.name = name  # str
+        self.template_args = template_args  # TemplateArgs or None
+
+    def children(self):
+        return [self.template_args] if self.template_args else []
+
+    def __repr__(self):
+        return '<VendorExt %r>' % self.name
+
+
+class Decltype(Node):
+    """A decltype expression: Dt <expression> E or DT <expression> E"""
+    def __init__(self, expression, is_template=False):
+        self.expression = expression  # str or Node
+        self.is_template = is_template  # True for DT (toplevel)
+
+    def __repr__(self):
+        return '<Decltype tmpl=%r %r>' % (self.is_template, self.expression)
+
+
+class ModuleName(Node):
+    """A module name (C++20 modules): C1.2 etc."""
+    def __init__(self, name, is_partition=False):
+        self.name = name  # str
+        self.is_partition = is_partition
+
+    def __repr__(self):
+        return '<Module %r>' % self.name
+
+
+class AbiTag(Node):
+    """An ABI tag: B <source-name>."""
+    def __init__(self, tag):
+        self.tag = tag  # str
+
+    def __repr__(self):
+        return '<AbiTag %r>' % self.tag

--- a/vivisect/demangle/itanium/grammar.py
+++ b/vivisect/demangle/itanium/grammar.py
@@ -1,0 +1,210 @@
+"""
+vivisect.demangle.itanium.grammar - Grammar constants for the Itanium C++ ABI.
+
+This module contains the lookup tables for the Itanium mangling grammar:
+    - Builtin type codes (single char and D* extended types)
+    - Operator name codes (two-char)
+    - Standard substitution abbreviations (St, Sa, Sb, Ss, Si, So, Sd)
+    - Constructor/destructor codes
+    - Special name codes (TV, TT, TI, TS, GV, etc.)
+
+Reference: Itanium C++ ABI section 5.1 (External Names)
+           GNU libiberty cp-demangle.c (the gold standard implementation)
+"""
+
+__all__ = [
+    'BUILTIN_TYPES', 'EXTENDED_BUILTIN_TYPES',
+    'OPERATORS', 'STD_SUBS',
+    'CTOR_KINDS', 'DTOR_KINDS',
+    'SPECIAL_NAMES',
+    'STDLIB_NAMESPACE_PREFIX',
+]
+
+
+# Single-character builtin type codes -> type name
+# From cp-demangle.c cplus_demangle_builtin_types[]
+BUILTIN_TYPES = {
+    'a': 'signed char',
+    'b': 'bool',
+    'c': 'char',
+    'd': 'double',
+    'e': 'long double',
+    'f': 'float',
+    'g': '__float128',
+    'h': 'unsigned char',
+    'i': 'int',
+    'j': 'unsigned int',
+    # 'k' is not used (NULL in the table)
+    'l': 'long',
+    'm': 'unsigned long',
+    'n': '__int128',
+    'o': 'unsigned __int128',
+    # 'p', 'q', 'r' are not used
+    's': 'short',
+    't': 'unsigned short',
+    # 'u' is vendor extended (handled separately)
+    'v': 'void',
+    'w': 'wchar_t',
+    'x': 'long long',
+    'y': 'unsigned long long',
+    'z': '...',
+}
+
+# Extended builtin type codes starting with 'D'
+# From cp-demangle.c d_builtin_type() handling
+EXTENDED_BUILTIN_TYPES = {
+    'Dd': 'decimal64',
+    'De': 'decimal128',
+    'Df': 'decimal32',
+    'Dh': 'half',           # __fp16 / _Float16
+    'Di': 'char32_t',
+    'Ds': 'char16_t',
+    'Du': 'char8_t',         # C++20 char8_t
+    'Da': 'auto',
+    'Dc': 'decltype(auto)',
+    'Dn': 'nullptr_t',
+    # DF<number>_ = _Float<number> (handled specially in parser)
+    # DF<number>b = std::bfloat16_t (handled specially)
+}
+
+
+# Two-character operator codes -> operator symbol/name
+# From cp-demangle.c cplus_demangle_operators[]
+# Each entry: code -> (symbol, num_args)
+OPERATORS = {
+    'nw': ('new', 3),
+    'na': ('new[]', 3),
+    'dl': ('delete', 1),
+    'da': ('delete[]', 1),
+    'ps': ('+', 1),       # unary plus
+    'ng': ('-', 1),       # unary minus
+    'ad': ('&', 1),       # address-of (unary)
+    'de': ('*', 1),       # dereference (unary)
+    'co': ('~', 1),       # bitwise not (unary)
+    'pl': ('+', 2),       # binary plus
+    'mi': ('-', 2),       # binary minus
+    'ml': ('*', 2),
+    'dv': ('/', 2),
+    'rm': ('%', 2),
+    'an': ('&', 2),       # bitwise and
+    'or': ('|', 2),
+    'eo': ('^', 2),
+    'aS': ('=', 2),
+    'pL': ('+=', 2),
+    'mI': ('-=', 2),
+    'mL': ('*=', 2),
+    'dV': ('/=', 2),
+    'rM': ('%=', 2),
+    'aN': ('&=', 2),
+    'oR': ('|=', 2),
+    'eO': ('^=', 2),
+    'ls': ('<<', 2),
+    'rs': ('>>', 2),
+    'lS': ('<<=', 2),
+    'rS': ('>>=', 2),
+    'eq': ('==', 2),
+    'ne': ('!=', 2),
+    'lt': ('<', 2),
+    'gt': ('>', 2),
+    'le': ('<=', 2),
+    'ge': ('>=', 2),
+    'nt': ('!', 1),       # logical not (unary)
+    'aa': ('&&', 2),
+    'oo': ('||', 2),
+    'pp': ('++', 1),
+    'mm': ('--', 1),
+    'cm': (',', 2),
+    'pm': ('->*', 2),
+    'pt': ('->', 2),
+    'cl': ('()', 2),
+    'ix': ('[]', 2),
+    'qu': ('?', 3),
+    'st': ('sizeof', 1),
+    'sz': ('sizeof', 1),
+    'at': ('alignof', 1),
+    'az': ('alignof', 1),
+    'ss': ('<=>', 2),     # C++20 spaceship operator
+    'ds': ('.*', 2),
+    'dt': ('.', 2),       # member access
+    'dx': ('[]=', 2),     # [expr] = expr
+    'dX': ('[...]=', 3),  # [expr...expr] = expr
+    'cv': ('cast', 2),    # conversion operator (special handling)
+    'sc': ('static_cast', 2),
+    'rc': ('reinterpret_cast', 2),
+    'dc': ('dynamic_cast', 2),
+    'cc': ('const_cast', 2),
+    'nx': ('noexcept', 1),
+    'tw': ('throw', 1),
+    'tr': ('throw', 0),   # rethrow
+    'aw': ('co_await', 1),
+    'gs': ('::', 1),      # global scope
+    'li': ('operator""', 1),  # literal operator
+    'sP': ('sizeof...', 1),
+    'sZ': ('sizeof...', 1),
+    'fl': ('...', 2),     # pack fold (left)
+    'fr': ('...', 2),     # pack fold (right)
+    'fL': ('...', 3),     # binary fold (left)
+    'fR': ('...', 3),     # binary fold (right)
+    'di': ('=', 2),       # .name = expr (designated init)
+}
+
+
+# Constructor/destructor kinds
+# C1=complete, C2=base, C3=allocating, CI1/CI2=inheriting
+# D0=deleting, D1=complete, D2=base
+CTOR_KINDS = {
+    'C1': 'complete',
+    'C2': 'base',
+    'C3': 'allocating',
+    'CI1': 'inheriting complete',
+    'CI2': 'inheriting base',
+}
+
+DTOR_KINDS = {
+    'D0': 'deleting',
+    'D1': 'complete',
+    'D2': 'base',
+}
+
+
+# Standard substitution abbreviations
+# From cp-demangle.c standard_subs[]
+# S_ = first substitution (index 0), S0_ = second (index 1), etc.
+# But St, Sa, Sb, Ss, Si, So, Sd are predefined:
+STD_SUBS = {
+    't': 'std',
+    'a': 'std::allocator',
+    'b': 'std::basic_string',
+    's': 'std::string',
+    'i': 'std::istream',
+    'o': 'std::ostream',
+    'd': 'std::iostream',
+}
+
+
+# Special name codes (T* and G*)
+# From cp-demangle.c d_special_name()
+SPECIAL_NAMES = {
+    'TV': 'vtable',          # vtable for <type>
+    'TT': 'VTT',             # VTT for <type>
+    'TI': 'typeinfo',        # typeinfo for <type>
+    'TS': 'typeinfo name',   # typeinfo name for <type>
+    'TF': 'typeinfo fn',     # typeinfo function for <type>
+    'TJ': 'java class',      # Java class
+    'TH': 'tls init',        # TLS init function
+    'TW': 'tls wrapper',     # TLS wrapper function
+    'TA': 'template parm',   # template parameter object
+    'GV': 'guard variable',  # guard variable for <name>
+    'GR': 'reference temp',  # reference temporary for <name>
+    'GA': 'hidden alias',    # hidden alias
+    'GTt': 'transaction clone',
+    'GTn': 'non-transaction clone',
+    'Th': 'thunk',           # non-virtual thunk: Th<offset>_
+    'Tv': 'virtual thunk',   # virtual thunk: Tv<offset>_<offset>_
+    'Tc': 'covariant thunk', # covariant return thunk
+    'TC': 'construction vtable',  # construction vtable
+}
+
+
+# The std:: namespace prefix
+STDLIB_NAMESPACE_PREFIX = 'std::'

--- a/vivisect/demangle/itanium/grammar.py
+++ b/vivisect/demangle/itanium/grammar.py
@@ -171,14 +171,16 @@ DTOR_KINDS = {
 # From cp-demangle.c standard_subs[]
 # S_ = first substitution (index 0), S0_ = second (index 1), etc.
 # But St, Sa, Sb, Ss, Si, So, Sd are predefined:
+# Per the Itanium ABI, Ss/Si/So/Sd expand to the FULL type, not just the name.
+# c++filt expands these to their full template instantiations.
 STD_SUBS = {
     't': 'std',
     'a': 'std::allocator',
     'b': 'std::basic_string',
-    's': 'std::string',
-    'i': 'std::istream',
-    'o': 'std::ostream',
-    'd': 'std::iostream',
+    's': 'std::basic_string<char, std::char_traits<char>, std::allocator<char> >',
+    'i': 'std::basic_istream<char, std::char_traits<char> >',
+    'o': 'std::basic_ostream<char, std::char_traits<char> >',
+    'd': 'std::basic_iostream<char, std::char_traits<char> >',
 }
 
 

--- a/vivisect/demangle/itanium/parser.py
+++ b/vivisect/demangle/itanium/parser.py
@@ -1,0 +1,930 @@
+"""
+vivisect.demangle.itanium.parser - Recursive descent parser for Itanium C++ ABI.
+
+Parses mangled names like ``_ZN3foo3barEv`` into an AST of
+``vivisect.demangle.itanium.ast_nodes`` objects.
+
+The parser is a recursive descent parser with a cursor-based state object.
+It maintains:
+    - The input string and current position
+    - A substitution table (list of AST nodes)
+    - Template parameter context
+    - A list of warnings (non-fatal parse issues)
+
+Reference: Itanium C++ ABI section 5.1 (External Names)
+           GNU libiberty cp-demangle.c
+"""
+
+import logging
+
+from vivisect.demangle.itanium import ast_nodes as ast
+from vivisect.demangle.itanium import grammar
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['ItaniumParser', 'ParseError', 'parse']
+
+
+class ParseError(Exception):
+    """Raised when the parser cannot proceed."""
+    pass
+
+
+# Characters used for base-36 substitution indices
+_DIGITS = '0123456789abcdefghijklmnopqrstuvwxyz'
+
+
+class ItaniumParser:
+    """
+    Recursive descent parser for Itanium C++ ABI mangled names.
+
+    Usage:
+        parser = ItaniumParser('_ZN3foo3barEv')
+        node = parser.parse()
+    """
+
+    def __init__(self, mangled):
+        self.input = mangled
+        self.pos = 0
+        self.subs = []          # Substitution table (list of AST nodes)
+        self.template_subs = [] # Template parameter substitutions (list of AST nodes)
+        self.warnings = []
+        self.last_name = None   # Last unqualified name (for ctor/dtor)
+        self._is_conversion = False
+
+    # --- Cursor helpers ---
+
+    def _peek(self, offset=0):
+        idx = self.pos + offset
+        if idx < len(self.input):
+            return self.input[idx]
+        return ''
+
+    def _remaining(self):
+        return self.input[self.pos:]
+
+    def _at_end(self):
+        return self.pos >= len(self.input)
+
+    def _consume_char(self):
+        if self.pos >= len(self.input):
+            raise ParseError('unexpected end of input at pos %d' % self.pos)
+        c = self.input[self.pos]
+        self.pos += 1
+        return c
+
+    def _check_char(self, c):
+        return self._peek() == c
+
+    def _expect_char(self, c):
+        if self._peek() != c:
+            raise ParseError('expected %r at pos %d, got %r' % (c, self.pos, self._peek()))
+        self.pos += 1
+
+    def _consume_if(self, c):
+        if self._peek() == c:
+            self.pos += 1
+            return True
+        return False
+
+    # --- Number parsing ---
+
+    def _parse_number(self):
+        """Parse a positive integer (for source name lengths, array dims, etc.)."""
+        start = self.pos
+        if self._peek() == 'n':
+            # Negative number (for some contexts)
+            self.pos += 1
+        while self._peek().isdigit():
+            self.pos += 1
+        if self.pos == start:
+            raise ParseError('expected number at pos %d' % self.pos)
+        s = self.input[start:self.pos]
+        return int(s)
+
+    def _parse_seq_id(self):
+        """Parse a base-36 sequence ID (for substitutions)."""
+        if not (self._peek().isdigit() or self._peek().isupper()):
+            raise ParseError('expected seq-id at pos %d' % self.pos)
+        id_val = 0
+        while self._peek().isdigit() or self._peek().isupper():
+            c = self._consume_char()
+            if c.isdigit():
+                id_val = id_val * 36 + (ord(c) - ord('0'))
+            else:
+                id_val = id_val * 36 + (ord(c) - ord('A') + 10)
+        self._expect_char('_')
+        return id_val + 1  # S_ is index 0, S0_ is index 1, etc.
+
+    # --- Substitution management ---
+
+    def _add_substitution(self, node):
+        """Add a node to the substitution table."""
+        self.subs.append(node)
+
+    def _get_substitution(self, index):
+        if index >= len(self.subs):
+            raise ParseError('substitution index %d out of range (have %d)' %
+                             (index, len(self.subs)))
+        return self.subs[index]
+
+    # --- Top-level grammar ---
+
+    def parse(self):
+        """Parse the full mangled name and return the root AST node."""
+        if self.input.startswith('_Z') or self.input.startswith('__Z'):
+            # Strip _Z or __Z prefix
+            if self.input.startswith('__Z'):
+                self.pos = 3
+            else:
+                self.pos = 2
+            node = self._parse_encoding()
+            # Vendor extension suffix (after '.')
+            if self._peek() == '.':
+                self.pos += 1  # skip the dot and the rest is vendor extension
+            return node
+        # Not a valid mangled name
+        raise ParseError('not an Itanium mangled name (missing _Z prefix)')
+
+    def _parse_encoding(self):
+        """<encoding> ::= <function name> <bare-function-type>
+                       ::= <data name>
+                       ::= <special-name>"""
+        if self._peek() == 'T' or self._peek() == 'G':
+            return self._parse_special_name()
+
+        # It's a name, possibly followed by a bare-function-type
+        name = self._parse_name(substable=True)
+
+        # Check for bare-function-type (only if there's more input and it
+        # looks like a type list)
+        if not self._at_end() and self._looks_like_type():
+            bare_func = self._parse_bare_function_type(has_return=False)
+            # Wrap in a Name node indicating this is a function
+            if isinstance(name, ast.NestedName):
+                name.bare_function = bare_func
+            return ast.Name(name, is_function=True, bare_function=bare_func)
+
+        return ast.Name(name, is_function=False)
+
+    def _looks_like_type(self):
+        """Heuristic: does the current position look like the start of a type?"""
+        c = self._peek()
+        if c == '':
+            return False
+        # Most type productions start with one of these
+        if c in grammar.BUILTIN_TYPES or c in ('P', 'R', 'O', 'K', 'V', 'r',
+                                               'F', 'A', 'M', 'N', 'S', 'T',
+                                               'D', 'u', 'L', 'Z'):
+            return True
+        return False
+
+    # --- Name parsing ---
+
+    def _parse_name(self, substable=False):
+        """<name> ::= <nested-name>
+                   ::= <unscoped-name>
+                   ::= <unscoped-template-name> <template-args>
+                   ::= <local-name>"""
+        c = self._peek()
+
+        if c == 'N':
+            return self._parse_nested_name()
+
+        if c == 'Z':
+            return self._parse_local_name()
+
+        if c == 'S':
+            # Could be a substitution (St, Sa, Ss, etc. used as a prefix)
+            node = self._parse_substitution(prefix=True)
+            if node is not None:
+                if isinstance(node, ast.Substitution) and node.std_sub:
+                    # St followed by a source name = std::name
+                    if node.std_sub == 't' and self._peek().isdigit():
+                        # St<source-name> = std::<source-name>
+                        inner_name = self._parse_source_name()
+                        # Check for template args after the name
+                        if self._peek() == 'I':
+                            targs = self._parse_template_args()
+                            result = ast.NestedName(
+                                [ast.SourceName('std'), ast.UnqualifiedName('source', inner_name)],
+                                ast.UnqualifiedName('template', targs)
+                            )
+                            self._add_substitution(result)
+                            return result
+                        result = ast.NestedName(
+                            [ast.SourceName('std')],
+                            ast.UnqualifiedName('source', inner_name)
+                        )
+                        self._add_substitution(result)
+                        return result
+                    # Other std subs (Sa, Sb, Ss, Si, So, Sd) are complete names
+                    return node
+                # Check for template args after a substitution
+                if self._peek() == 'I':
+                    targs = self._parse_template_args()
+                    prefix_name = grammar.STD_SUBS.get(node.std_sub, 'std') if isinstance(node, ast.Substitution) else 'std'
+                    base = ast.SourceName(prefix_name)
+                    result = ast.NestedName([base], ast.UnqualifiedName('template', targs))
+                    return result
+                return node
+
+        # Unscoped name
+        unq = self._parse_unqualified_name()
+        if substable:
+            self._add_substitution(unq)
+
+        # Check for template args (unscoped-template-name)
+        if self._peek() == 'I':
+            targs = self._parse_template_args()
+            # Build a template name: the base name + template args
+            # Store as a NestedName where the prefix is the base name
+            # and the unqualified_name is the template args
+            result = ast.NestedName([unq], ast.UnqualifiedName('template', targs))
+            if substable:
+                self._add_substitution(result)
+            return result
+
+        return unq
+
+    def _parse_nested_name(self):
+        """<nested-name> ::= N [<CV-qualifiers>] [<ref-qualifier>] <prefix> <unqualified-name> E"""
+        self._expect_char('N')
+
+        # CV-qualifiers
+        cv = self._parse_cv_qualifiers()
+
+        # ref-qualifier
+        ref = ''
+        if self._peek() == 'R':
+            self.pos += 1
+            ref = '&'
+        elif self._peek() == 'O':
+            self.pos += 1
+            ref = '&&'
+
+        # Parse the prefix chain
+        prefix = self._parse_prefix()
+
+        # The last element of the prefix is the unqualified name
+        if not prefix:
+            raise ParseError('empty nested name prefix at pos %d' % self.pos)
+
+        unqualified = prefix[-1]
+        prefix_chain = prefix[:-1]
+
+        self._expect_char('E')
+
+        node = ast.NestedName(prefix_chain, unqualified, cv, ref)
+
+        # Add nested name to substitutions
+        self._add_substitution(node)
+
+        return node
+
+    def _parse_prefix(self):
+        """<prefix> ::= <prefix> <unqualified-name>
+                     ::= <template-prefix> <template-args>
+                     ::= ...
+        Returns a list of nodes representing the scope chain.
+        The template args are stored as a separate UnqualifiedName('template')
+        entry, and the renderer combines them with the preceding name."""
+        result = []
+
+        while True:
+            c = self._peek()
+            if c == '' or c == 'E':
+                break
+
+            if c == 'S':
+                # Substitution as a prefix component
+                sub = self._parse_substitution(prefix=True)
+                if sub is not None:
+                    if isinstance(sub, ast.Substitution) and sub.std_sub:
+                        if sub.std_sub == 't':
+                            name = 'std'
+                        else:
+                            name = grammar.STD_SUBS.get(sub.std_sub, 'std')
+                        result.append(ast.SourceName(name))
+                    elif isinstance(sub, ast.Substitution) and sub.index is not None:
+                        # Resolve indexed substitution to the actual node
+                        if sub.index < len(self.subs):
+                            actual = self.subs[sub.index]
+                            if isinstance(actual, ast.NestedName):
+                                # Flatten the NestedName's prefix into our result
+                                result.extend(actual.prefix)
+                                # Don't add the unqualified_name if template
+                                # args follow (they replace it)
+                                if self._peek() != 'I':
+                                    result.append(actual.unqualified_name)
+                            else:
+                                result.append(actual)
+                        else:
+                            result.append(sub)
+                    else:
+                        result.append(sub)
+                    # Check for template args after substitution
+                    if self._peek() == 'I':
+                        targs = self._parse_template_args()
+                        result.append(ast.UnqualifiedName('template', targs))
+                        # Add the combined substitution+template to subs
+                        combined = ast.NestedName(
+                            list(result[:-1]), result[-1]
+                        )
+                        self._add_substitution(combined)
+                    continue
+                break
+
+            # Parse unqualified name
+            unq = self._parse_unqualified_name()
+            result.append(unq)
+
+            # Check for template args
+            if self._peek() == 'I':
+                targs = self._parse_template_args()
+                # The template-prefix (name without args) is a substitution candidate.
+                # result currently has the name components without the template args.
+                # Add it as a substitution before adding the template args.
+                if len(result) == 1:
+                    self._add_substitution(result[0])
+                else:
+                    self._add_substitution(ast.NestedName(list(result[:-1]), result[-1]))
+
+                result.append(ast.UnqualifiedName('template', targs))
+                # Also add the full template instantiation (prefix + args)
+                template_full = ast.NestedName(
+                    list(result[:-1]), result[-1]
+                )
+                self._add_substitution(template_full)
+
+            if self._peek() == 'E':
+                break
+
+            # Add the current prefix chain to substitutions.
+            # For the first component (result has 1 element), add it directly.
+            # For longer chains, add as a NestedName.
+            if not (result and isinstance(result[-1], ast.UnqualifiedName) and result[-1].kind == 'template'):
+                if len(result) == 1:
+                    self._add_substitution(result[0])
+                else:
+                    self._add_substitution(ast.NestedName(list(result[:-1]), result[-1]))
+
+        return result
+
+    def _parse_unqualified_name(self):
+        """<unqualified-name> ::= <operator-name> [<abi-tags>]
+                              ::= <ctor-dtor-name>
+                              ::= <source-name>
+                              ::= <unnamed-type-name>"""
+        c = self._peek()
+
+        if c == 'C':
+            # Constructor: C1, C2, C3, CI1, CI2
+            self.pos += 1
+            kind_char = self._consume_char()
+            if kind_char == 'I':
+                # Inheriting constructor: CI1, CI2
+                num = self._consume_char()
+                kind = 'CI' + num
+            else:
+                kind = 'C' + kind_char
+            ctor_kind = grammar.CTOR_KINDS.get(kind, kind)
+            self.last_name = ast.CtorDtorName(ctor_kind, is_destructor=False)
+            return ast.UnqualifiedName('ctor', self.last_name)
+
+        if c == 'D':
+            # Could be destructor D0, D1, D2 or a D* builtin type
+            next_c = self._peek(1)
+            if next_c in ('0', '1', '2'):
+                self.pos += 1
+                num = self._consume_char()
+                kind = 'D' + num
+                dtor_kind = grammar.DTOR_KINDS.get(kind, kind)
+                self.last_name = ast.CtorDtorName(dtor_kind, is_destructor=True)
+                return ast.UnqualifiedName('dtor', self.last_name)
+            # Otherwise it's a D* builtin type — fall through to type parsing
+
+        if c.isdigit():
+            # Source name
+            name = self._parse_source_name()
+            self.last_name = name
+            unq = ast.UnqualifiedName('source', name)
+
+            # Check for ABI tags
+            if self._peek() == 'B':
+                tags = self._parse_abi_tags()
+                unq.abi_tags = tags
+
+            return unq
+
+        # Operator name (two chars)
+        if self.pos + 1 < len(self.input):
+            c1 = self._consume_char()
+            c2 = self._consume_char()
+            code = c1 + c2
+            if code in grammar.OPERATORS:
+                sym, nargs = grammar.OPERATORS[code]
+                op = ast.OperatorName(code, sym, nargs)
+                self.last_name = op
+                return ast.UnqualifiedName('operator', op)
+            raise ParseError('unknown operator code %r at pos %d' % (code, self.pos - 2))
+
+        raise ParseError('cannot parse unqualified name at pos %d' % self.pos)
+
+    def _parse_source_name(self):
+        """<source-name> ::= <positive length number> <identifier>"""
+        length = self._parse_number()
+        if self.pos + length > len(self.input):
+            raise ParseError('source name length %d exceeds remaining input at pos %d' % (length, self.pos))
+        name = self.input[self.pos:self.pos + length]
+        self.pos += length
+        return ast.SourceName(name)
+
+    def _parse_abi_tags(self):
+        """<abi-tags> ::= B <source-name> <abi-tags>*"""
+        tags = []
+        while self._peek() == 'B':
+            self._consume_char()
+            tag_name = self._parse_source_name()
+            tags.append(tag_name.name)
+        return tags
+
+    # --- Type parsing ---
+
+    def _parse_type(self):
+        """<type> ::= <builtin-type>
+                   ::= <function-type>
+                   ::= <class-enum-type>
+                   ::= <array-type>
+                   ::= <pointer-to-member-type>
+                   ::= <template-param>
+                   ::= <template-template-param> <template-args>
+                   ::= <substitution>
+                   ::= <CV-qualifiers> <type>
+                   ::= P <type>
+                   ::= R <type>
+                   ::= O <type>
+                   ::= C <type>
+                   ::= G <type>
+                   ::= U <source-name> <type>"""
+        # CV-qualifiers (K, V, r) come before the base type
+        cv = self._parse_cv_qualifiers()
+        if cv:
+            base = self._parse_type()
+            node = ast.CVQualifiedType(base, cv)
+            self._add_substitution(node)
+            return node
+
+        c = self._peek()
+
+        # Pointer, reference, rvalue reference
+        if c == 'P':
+            self.pos += 1
+            target = self._parse_type()
+            node = ast.PointerType(target)
+            self._add_substitution(node)
+            return node
+
+        if c == 'R':
+            self.pos += 1
+            target = self._parse_type()
+            node = ast.ReferenceType(target)
+            self._add_substitution(node)
+            return node
+
+        if c == 'O':
+            self.pos += 1
+            target = self._parse_type()
+            node = ast.RvalueReferenceType(target)
+            self._add_substitution(node)
+            return node
+
+        # Function type
+        if c == 'F':
+            node = self._parse_function_type()
+            self._add_substitution(node)
+            return node
+
+        # Array type
+        if c == 'A':
+            node = self._parse_array_type()
+            self._add_substitution(node)
+            return node
+
+        # Pointer to member
+        if c == 'M':
+            self.pos += 1
+            class_type = self._parse_type()
+            member_type = self._parse_type()
+            node = ast.PointerToMember(class_type, member_type)
+            self._add_substitution(node)
+            return node
+
+        # Substitution
+        if c == 'S':
+            sub = self._parse_substitution(prefix=False)
+            if sub is not None:
+                # Could be followed by template args (template-template-param)
+                if self._peek() == 'I':
+                    targs = self._parse_template_args()
+                    # Wrap in a template instantiation
+                    return ast.NestedName([sub], ast.UnqualifiedName('template', targs))
+                return sub
+
+        # Template parameter
+        if c == 'T':
+            return self._parse_template_param()
+
+        # Builtin type (single char or D* extended)
+        if c in grammar.BUILTIN_TYPES:
+            self.pos += 1
+            return ast.BuiltinType(grammar.BUILTIN_TYPES[c], c)
+
+        if c == 'D':
+            # Extended builtin type (Dd, De, Df, etc.)
+            if self.pos + 1 < len(self.input):
+                code = self.input[self.pos:self.pos + 2]
+                if code in grammar.EXTENDED_BUILTIN_TYPES:
+                    self.pos += 2
+                    return ast.BuiltinType(grammar.EXTENDED_BUILTIN_TYPES[code], code)
+                # DF<number>_ = _Float<number>
+                if self._peek(1) == 'F':
+                    self.pos += 2
+                    num = self._parse_number()
+                    self._expect_char('_')
+                    return ast.BuiltinType('_Float%d' % num, 'DF%d_' % num)
+            # Fall through: D could also be a destructor (handled elsewhere)
+
+        # Vendor extended type: u <source-name>
+        if c == 'u':
+            self.pos += 1
+            name = self._parse_source_name()
+            template_args = None
+            if self._peek() == 'I':
+                template_args = self._parse_template_args()
+            node = ast.VendorExtendedType(name.name, template_args)
+            self._add_substitution(node)
+            return node
+
+        # Nested name (class/enum type as a qualified name)
+        if c == 'N':
+            return self._parse_nested_name()
+
+        # Source name as a class-enum-type (unqualified)
+        if c.isdigit():
+            name = self._parse_source_name()
+            # Check for template args
+            if self._peek() == 'I':
+                targs = self._parse_template_args()
+                node = ast.NestedName([name], ast.UnqualifiedName('template', targs))
+                self._add_substitution(node)
+                return node
+            self._add_substitution(name)
+            return name
+
+        # Decltype
+        if c == 'D' and self._peek(1) == 't':
+            self.pos += 2
+            expr = self._parse_until_char('E')
+            self._expect_char('E')
+            return ast.Decltype(expr, is_template=False)
+
+        if c == 'D' and self._peek(1) == 'T':
+            self.pos += 2
+            expr = self._parse_until_char('E')
+            self._expect_char('E')
+            return ast.Decltype(expr, is_template=True)
+
+        raise ParseError('cannot parse type at pos %d (char=%r)' % (self.pos, c))
+
+    def _parse_cv_qualifiers(self):
+        """Parse CV-qualifiers (K=const, V=volatile, r=restrict)."""
+        parts = []
+        while True:
+            c = self._peek()
+            if c == 'K':
+                parts.append('const')
+                self.pos += 1
+            elif c == 'V':
+                parts.append('volatile')
+                self.pos += 1
+            elif c == 'r':
+                parts.append('restrict')
+                self.pos += 1
+            else:
+                break
+        return ' '.join(parts)
+
+    def _parse_function_type(self):
+        """<function-type> ::= F [Y] <bare-function-type> [<ref-qualifier>] E"""
+        self._expect_char('F')
+        # Y = extern "C"
+        self._consume_if('Y')
+        bare = self._parse_bare_function_type(has_return=True)
+        cv = self._parse_cv_qualifiers()
+        ref = ''
+        if self._peek() == 'R':
+            self.pos += 1
+            ref = '&'
+        elif self._peek() == 'O':
+            self.pos += 1
+            ref = '&&'
+        self._expect_char('E')
+        return ast.FunctionType(bare, cv, ref)
+
+    def _parse_bare_function_type(self, has_return=False):
+        """<bare-function-type> ::= <type>+"""
+        types = []
+        if has_return:
+            # First type is the return type
+            ret = self._parse_type()
+            types.append(ret)
+        # Remaining types are parameters
+        while not self._at_end() and self._peek() != 'E' and self._peek() != 'N':
+            # Check if we've hit something that's clearly not a type
+            if not self._looks_like_type() and self._peek() not in grammar.BUILTIN_TYPES:
+                break
+            # Save position — _parse_type() may advance before failing
+            saved_pos = self.pos
+            try:
+                t = self._parse_type()
+                types.append(t)
+            except ParseError:
+                # Restore position so caller can see what stopped us
+                self.pos = saved_pos
+                break
+        return ast.BareFunctionType(types)
+
+    def _parse_array_type(self):
+        """<array-type> ::= A <dimension> _ <type>"""
+        self._expect_char('A')
+        # Dimension: could be a number or an expression
+        dim_start = self.pos
+        if self._peek().isdigit():
+            while self._peek().isdigit():
+                self.pos += 1
+        elif self._peek() == '_':
+            pass  # empty dimension
+        else:
+            # Expression-based dimension (template param reference, etc.)
+            self._parse_until_char('_')
+        dim = self.input[dim_start:self.pos]
+        self._expect_char('_')
+        element = self._parse_type()
+        return ast.Array(dim, element)
+
+    def _parse_template_param(self):
+        """<template-param> ::= T_ # first param
+                            ::= T <parameter-2 non-negative number> _"""
+        self._expect_char('T')
+        if self._peek() == '_':
+            self.pos += 1
+            return ast.TemplateParam(0)
+        num = self._parse_number()
+        self._expect_char('_')
+        return ast.TemplateParam(num + 1)
+
+    def _parse_template_args(self):
+        """<template-args> ::= I <template-arg>+ E"""
+        self._expect_char('I')
+        args = []
+        while self._peek() != 'E' and not self._at_end():
+            arg = self._parse_template_arg()
+            args.append(arg)
+        self._expect_char('E')
+        node = ast.TemplateArgs(args)
+        # NOTE: Template args themselves are NOT added to the substitution
+        # table.  The template-prefix (name before the args) is the
+        # substitution candidate, not the args.
+        return node
+
+    def _parse_template_arg(self):
+        """<template-arg> ::= <type>
+                           ::= X <expression> E
+                           ::= <expr-primary>
+                           ::= J <template-arg>* E"""
+        c = self._peek()
+        if c == 'X':
+            # Expression
+            self.pos += 1
+            expr = self._parse_until_char('E')
+            self._expect_char('E')
+            return ast.TemplateArg('expression', expr)
+        if c == 'J':
+            # Argument pack
+            self.pos += 1
+            pack_args = []
+            while self._peek() != 'E' and not self._at_end():
+                pack_args.append(self._parse_template_arg())
+            self._expect_char('E')
+            return ast.TemplateArg('pack', pack_args)
+        if c == 'L':
+            # Expr-primary: L <type> <value> E
+            self.pos += 1
+            type_node = self._parse_type()
+            value = self._parse_until_char('E')
+            self._expect_char('E')
+            return ast.TemplateArg('primary', '%s%s' % (type_node, value))
+        # Default: it's a type
+        type_node = self._parse_type()
+        return ast.TemplateArg('type', type_node)
+
+    def _parse_substitution(self, prefix=False):
+        """<substitution> ::= S <seq-id> _
+                           ::= S_
+                           ::= St | Sa | Sb | Ss | Si | So | Sd"""
+        if self._peek() != 'S':
+            return None
+        self.pos += 1  # consume S
+        c = self._peek()
+        if c == '_':
+            self.pos += 1
+            return ast.Substitution(index=0)
+        if c.isdigit() or c.isupper():
+            # seq-id
+            id_val = self._parse_seq_id()
+            return ast.Substitution(index=id_val)
+        # Standard substitution
+        if c in grammar.STD_SUBS:
+            self.pos += 1
+            sub = ast.Substitution(std_sub=c)
+            # Check for ABI tags
+            if self._peek() == 'B':
+                tags = self._parse_abi_tags()
+                # Tags make it a substitution candidate
+                self._add_substitution(sub)
+            return sub
+        raise ParseError('invalid substitution at pos %d' % self.pos)
+
+    def _parse_special_name(self):
+        """<special-name> ::= TV <type>   # vtable
+                           ::= TT <type>   # VTT
+                           ::= TI <type>   # typeinfo
+                           ::= TS <type>   # typeinfo name
+                           ::= T <call-offset> <base encoding>  # thunk
+                           ::= GV <object name>  # guard variable
+                           ::= GR <object name> _  # lifetime-extended temporary
+                           ::= GTt <encoding>  # transaction clone"""
+        if self._peek() == 'T':
+            self.pos += 1
+            c = self._consume_char()
+            code = 'T' + c
+
+            # Handle two-char special names
+            if c == 'T':
+                kind = grammar.SPECIAL_NAMES.get('TT', 'VTT')
+                target = self._parse_type()
+                return ast.SpecialName(kind, target)
+            if c == 'V':
+                kind = grammar.SPECIAL_NAMES.get('TV', 'vtable')
+                target = self._parse_type()
+                return ast.SpecialName(kind, target)
+            if c == 'I':
+                kind = grammar.SPECIAL_NAMES.get('TI', 'typeinfo')
+                target = self._parse_type()
+                return ast.SpecialName(kind, target)
+            if c == 'S':
+                kind = grammar.SPECIAL_NAMES.get('TS', 'typeinfo name')
+                target = self._parse_type()
+                return ast.SpecialName(kind, target)
+            if c == 'F':
+                kind = grammar.SPECIAL_NAMES.get('TF', 'typeinfo fn')
+                target = self._parse_type()
+                return ast.SpecialName(kind, target)
+            if c == 'J':
+                kind = grammar.SPECIAL_NAMES.get('TJ', 'java class')
+                target = self._parse_type()
+                return ast.SpecialName(kind, target)
+            if c == 'H':
+                kind = grammar.SPECIAL_NAMES.get('TH', 'tls init')
+                target = self._parse_name()
+                return ast.SpecialName(kind, target)
+            if c == 'W':
+                kind = grammar.SPECIAL_NAMES.get('TW', 'tls wrapper')
+                target = self._parse_name()
+                return ast.SpecialName(kind, target)
+            if c == 'A':
+                kind = grammar.SPECIAL_NAMES.get('TA', 'template parm')
+                target = self._parse_template_arg()
+                return ast.SpecialName(kind, target)
+            if c == 'C':
+                # Construction vtable: TC <type> <number> _ <type>
+                kind = grammar.SPECIAL_NAMES.get('TC', 'construction vtable')
+                derived = self._parse_type()
+                offset = self._parse_number()
+                self._expect_char('_')
+                base = self._parse_type()
+                return ast.SpecialName(kind, base)
+            if c == 'h':
+                # Non-virtual thunk: Th <offset> _ <encoding>
+                self._parse_call_offset('h')
+                kind = grammar.SPECIAL_NAMES.get('Th', 'thunk')
+                target = self._parse_encoding()
+                return ast.SpecialName(kind, target)
+            if c == 'v':
+                # Virtual thunk: Tv <offset> _ <offset> _ <encoding>
+                self._parse_call_offset('v')
+                kind = grammar.SPECIAL_NAMES.get('Tv', 'virtual thunk')
+                target = self._parse_encoding()
+                return ast.SpecialName(kind, target)
+            if c == 'c':
+                # Covariant thunk: Tc <offset> _ <offset> _ <encoding>
+                self._parse_call_offset('')
+                self._parse_call_offset('')
+                kind = grammar.SPECIAL_NAMES.get('Tc', 'covariant thunk')
+                target = self._parse_encoding()
+                return ast.SpecialName(kind, target)
+
+            raise ParseError('unknown special name T%c at pos %d' % (c, self.pos - 1))
+
+        if self._peek() == 'G':
+            self.pos += 1
+            c = self._consume_char()
+            if c == 'V':
+                kind = grammar.SPECIAL_NAMES.get('GV', 'guard variable')
+                target = self._parse_name()
+                return ast.SpecialName(kind, target)
+            if c == 'R':
+                kind = grammar.SPECIAL_NAMES.get('GR', 'reference temp')
+                target = self._parse_name()
+                self._consume_if('_')
+                return ast.SpecialName(kind, target)
+            if c == 'A':
+                kind = grammar.SPECIAL_NAMES.get('GA', 'hidden alias')
+                target = self._parse_encoding()
+                return ast.SpecialName(kind, target)
+            if c == 'T':
+                # GTt or GTn
+                next_c = self._consume_char()
+                code = 'GT' + next_c
+                kind = grammar.SPECIAL_NAMES.get(code, 'transaction clone')
+                target = self._parse_encoding()
+                return ast.SpecialName(kind, target)
+
+            raise ParseError('unknown special name G%c at pos %d' % (c, self.pos - 1))
+
+        raise ParseError('not a special name at pos %d' % self.pos)
+
+    def _parse_call_offset(self, c):
+        """Parse a call-offset: h <number> _ or v <number> _ <number> _"""
+        if c == '':
+            c = self._consume_char()
+        if c == 'h':
+            self._parse_number()
+            self._expect_char('_')
+        elif c == 'v':
+            self._parse_number()
+            self._expect_char('_')
+            self._parse_number()
+            self._expect_char('_')
+        else:
+            raise ParseError('invalid call offset %r' % c)
+
+    def _parse_local_name(self):
+        """<local-name> ::= Z <function encoding> E <entity name> [<discriminator>]
+                         ::= Z <function encoding> E s [<discriminator>]"""
+        self._expect_char('Z')
+        func = self._parse_encoding()
+        self._expect_char('E')
+        if self._peek() == 's':
+            self.pos += 1
+            self._parse_discriminator()
+            return func  # string literal
+        name = self._parse_name()
+        self._parse_discriminator()
+        return ast.NestedName([func], name)
+
+    def _parse_discriminator(self):
+        """<discriminator> ::= _ <non-negative number> _"""
+        if self._peek() == '_':
+            self.pos += 1
+            self._parse_number()
+            self._consume_if('_')
+
+    def _parse_until_char(self, end_char):
+        """Parse raw characters until the end char (for expressions)."""
+        start = self.pos
+        depth = 0
+        while self.pos < len(self.input):
+            c = self.input[self.pos]
+            if c == end_char and depth == 0:
+                break
+            self.pos += 1
+        return self.input[start:self.pos]
+
+
+def parse(mangled):
+    """
+    Parse an Itanium mangled name and return the AST root node.
+
+    Args:
+        mangled (str): The mangled name (with _Z prefix).
+
+    Returns:
+        Node: The root AST node.
+
+    Raises:
+        ParseError: If the name cannot be parsed.
+    """
+    parser = ItaniumParser(mangled)
+    return parser.parse()

--- a/vivisect/demangle/itanium/parser.py
+++ b/vivisect/demangle/itanium/parser.py
@@ -154,7 +154,7 @@ class ItaniumParser:
             return self._parse_special_name()
 
         # It's a name, possibly followed by a bare-function-type
-        name = self._parse_name(substable=True)
+        name = self._parse_name(substable=False)
 
         # Check for bare-function-type (only if there's more input and it
         # looks like a type list)
@@ -189,7 +189,7 @@ class ItaniumParser:
         c = self._peek()
 
         if c == 'N':
-            return self._parse_nested_name()
+            return self._parse_nested_name(substable=substable)
 
         if c == 'Z':
             return self._parse_local_name()
@@ -247,8 +247,15 @@ class ItaniumParser:
 
         return unq
 
-    def _parse_nested_name(self):
-        """<nested-name> ::= N [<CV-qualifiers>] [<ref-qualifier>] <prefix> <unqualified-name> E"""
+    def _parse_nested_name(self, substable=False):
+        """<nested-name> ::= N [<CV-qualifiers>] [<ref-qualifier>] <prefix> <unqualified-name> E
+
+        The substable parameter controls whether the full nested name is added
+        to the substitution table. When called from _parse_name (encoding level),
+        it should be False — only intermediate prefixes are sub candidates, not
+        the top-level encoding name. When called from _parse_type (as a type),
+        it should be True.
+        """
         self._expect_char('N')
 
         # CV-qualifiers
@@ -277,8 +284,9 @@ class ItaniumParser:
 
         node = ast.NestedName(prefix_chain, unqualified, cv, ref)
 
-        # Add nested name to substitutions
-        self._add_substitution(node)
+        # Only add to substitution table when used as a type (not encoding name)
+        if substable:
+            self._add_substitution(node)
 
         return node
 
@@ -524,6 +532,24 @@ class ItaniumParser:
         if c == 'S':
             sub = self._parse_substitution(prefix=False)
             if sub is not None:
+                # St followed by a source name = std::<name> as a type
+                if isinstance(sub, ast.Substitution) and sub.std_sub == 't' and self._peek().isdigit():
+                    inner_name = self._parse_source_name()
+                    # Check for template args
+                    if self._peek() == 'I':
+                        targs = self._parse_template_args()
+                        result = ast.NestedName(
+                            [ast.SourceName('std'), ast.UnqualifiedName('source', inner_name)],
+                            ast.UnqualifiedName('template', targs)
+                        )
+                        self._add_substitution(result)
+                        return result
+                    result = ast.NestedName(
+                        [ast.SourceName('std')],
+                        ast.UnqualifiedName('source', inner_name)
+                    )
+                    self._add_substitution(result)
+                    return result
                 # Could be followed by template args (template-template-param)
                 if self._peek() == 'I':
                     targs = self._parse_template_args()
@@ -568,7 +594,7 @@ class ItaniumParser:
 
         # Nested name (class/enum type as a qualified name)
         if c == 'N':
-            return self._parse_nested_name()
+            return self._parse_nested_name(substable=True)
 
         # Source name as a class-enum-type (unqualified)
         if c.isdigit():
@@ -724,7 +750,28 @@ class ItaniumParser:
             type_node = self._parse_type()
             value = self._parse_until_char('E')
             self._expect_char('E')
-            return ast.TemplateArg('primary', '%s%s' % (type_node, value))
+            # Render the type properly and convert known value formats
+            if isinstance(type_node, ast.BuiltinType):
+                type_name = type_node.name
+                # For bool, convert 0->false, 1->true
+                if type_name == 'bool':
+                    if value == '0':
+                        value = 'false'
+                    elif value == '1':
+                        value = 'true'
+                # For integer types, render as the decimal value
+                # c++filt shows e.g. '42' for Li42E
+                elif value.isdigit() or (value.startswith('n') and value[1:].isdigit()):
+                    if value.startswith('n'):
+                        value = '-' + value[1:]
+                # For char, show the character
+                elif type_name == 'char' and len(value) <= 3:
+                    pass  # keep as-is
+                return ast.TemplateArg('primary', '%s' % value)
+            # Fallback: render as type+value
+            from vivisect.demangle.itanium.renderer import render as _render
+            type_str = _render(type_node)
+            return ast.TemplateArg('primary', '%s%s' % (type_str, value))
         # Default: it's a type
         type_node = self._parse_type()
         return ast.TemplateArg('type', type_node)

--- a/vivisect/demangle/itanium/renderer.py
+++ b/vivisect/demangle/itanium/renderer.py
@@ -1,0 +1,370 @@
+"""
+vivisect.demangle.itanium.renderer - Render Itanium AST nodes to demangled strings.
+
+Walks the AST produced by ``vivisect.demangle.itanium.parser`` and produces
+the human-readable demangled name string, matching the output format of
+``c++filt`` / ``__cxa_demangle``.
+"""
+
+import logging
+
+from vivisect.demangle.itanium import ast_nodes as ast
+from vivisect.demangle.itanium import grammar
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['render', 'Renderer']
+
+
+def render(node, subs=None, template_params=None):
+    """Render an AST node to a demangled string.
+
+    Args:
+        node: The root AST node.
+        subs: The substitution table from the parser (list of AST nodes).
+            Required to resolve substitution references.
+        template_params: Template parameter values (dict index -> AST node).
+    """
+    r = Renderer(subs=subs, template_params=template_params)
+    return r.render(node)
+
+
+class Renderer:
+    """
+    Render Itanium AST nodes to demangled strings.
+
+    The renderer maintains a context for:
+        - Substitution table (for S_, S0_, etc. references)
+        - Template parameter substitution (T_ values)
+    """
+
+    def __init__(self, subs=None, template_params=None):
+        self.subs = subs if subs is not None else []
+        self.template_params = template_params if template_params is not None else {}
+        self._in_template_args = False
+
+    def render(self, node):
+        """Dispatch to the appropriate render method based on node type."""
+        if node is None:
+            return ''
+        method = getattr(self, '_render_%s' % type(node).__name__, None)
+        if method is None:
+            logger.debug('no renderer for %s', type(node).__name__)
+            return repr(node)
+        return method(node)
+
+    def _render_Name(self, node):
+        name_str = self.render(node.qualified_name)
+        if node.is_function and node.bare_function:
+            func_str = self._render_function_signature(node)
+            return func_str
+        return name_str
+
+    def _render_function_signature(self, node):
+        """Render a Name node that has a bare_function (i.e. a function)."""
+        name_str = self.render(node.qualified_name)
+
+        if node.bare_function is None or not node.bare_function.types:
+            return name_str + '()'
+
+        # The bare function type contains return type + params (for functions
+        # that are not member functions) or just params (for member functions).
+        # At the top level, the return type is NOT included in cxxfilt output
+        # for regular functions.  It IS included for template specializations.
+        types = node.bare_function.types
+
+        # Check if the first type is a return type or a parameter.
+        # In the Itanium ABI, for a top-level function encoding, the first
+        # type is the return type ONLY if the function is a template
+        # specialization.  Otherwise, the bare-function-type is just the
+        # parameter list.
+        #
+        # Heuristic: if the name is a template, the first type is the return.
+        # Otherwise, all types are parameters.
+        is_template = self._is_template_name(node.qualified_name)
+
+        if is_template and len(types) > 1:
+            params = types[1:]  # skip return type
+        else:
+            params = types  # all are parameters
+
+        param_strs = [self.render(t) for t in params]
+        # Per cxxfilt convention: a single 'void' param = empty param list
+        if len(param_strs) == 1 and param_strs[0] == 'void':
+            param_strs = []
+        return '%s(%s)' % (name_str, ', '.join(param_strs))
+
+    def _is_template_name(self, node):
+        """Check if a name node is a template instantiation."""
+        if isinstance(node, ast.NestedName):
+            return self._is_template_unqualified(node.unqualified_name)
+        if isinstance(node, ast.UnqualifiedName):
+            return node.kind == 'template'
+        return False
+
+    def _is_template_unqualified(self, unq):
+        if isinstance(unq, ast.UnqualifiedName):
+            return unq.kind == 'template'
+        return False
+
+    def _render_SourceName(self, node):
+        return node.name
+
+    def _render_UnqualifiedName(self, node):
+        if node.kind == 'source':
+            return self.render(node.value)
+        if node.kind == 'operator':
+            return 'operator%s' % node.value.symbol
+        if node.kind == 'ctor':
+            return self._render_ctor_dtor(node.value, is_destructor=False)
+        if node.kind == 'dtor':
+            return self._render_ctor_dtor(node.value, is_destructor=True)
+        if node.kind == 'template':
+            # The value is a TemplateArgs node
+            return self.render(node.value)
+        return str(node.value)
+
+    def _render_ctor_dtor(self, node, is_destructor=False):
+        """Constructor/destructor uses the class name."""
+        # The class name is the last source name seen (self.last_name)
+        # For now, return a placeholder; the NestedName renderer handles this
+        if is_destructor:
+            return '~<dtor>'
+        return '<ctor>'
+
+    def _render_NestedName(self, node):
+        parts = []
+        i = 0
+        prefix = node.prefix
+        while i < len(prefix):
+            p = prefix[i]
+            if isinstance(p, ast.UnqualifiedName) and p.kind == 'template':
+                # Template: append args to the previous component
+                if parts:
+                    parts[-1] += self.render(p)
+                else:
+                    parts.append(self.render(p))
+            else:
+                parts.append(self.render(p))
+            i += 1
+
+        # Handle the unqualified name
+        unq = node.unqualified_name
+        if isinstance(unq, ast.UnqualifiedName) and unq.kind == 'template':
+            # The unqualified name is template args — append to last prefix
+            if parts:
+                parts[-1] += self.render(unq)
+            else:
+                parts.append(self.render(unq))
+        else:
+            unq_str = self.render(unq)
+            parts.append(unq_str)
+
+        # Handle constructor/destructor: replace the last component with
+        # the class name (which is the last prefix component that's a source name)
+        if isinstance(unq, ast.UnqualifiedName):
+            if unq.kind in ('ctor', 'dtor') and len(node.prefix) > 0:
+                class_name = self._get_class_name_from_prefix(prefix)
+                if class_name:
+                    if unq.kind == 'dtor':
+                        parts[-1] = '~' + class_name
+                    else:
+                        parts[-1] = class_name
+
+        result = '::'.join(parts)
+
+        # Apply CV-qualifiers and ref-qualifiers for member functions
+        suffix = ''
+        if node.cv_qualifiers:
+            suffix += ' ' + node.cv_qualifiers
+        if node.ref_qualifier:
+            suffix += node.ref_qualifier
+
+        return result + suffix
+
+    def _get_class_name_from_prefix(self, prefix):
+        """Get the unqualified class name from the prefix chain."""
+        if not prefix:
+            return ''
+        last = prefix[-1]
+        if isinstance(last, ast.SourceName):
+            return last.name
+        if isinstance(last, ast.UnqualifiedName):
+            if last.kind == 'source' and isinstance(last.value, ast.SourceName):
+                return last.value.name
+            # For template classes, use the base name (without args)
+            if last.kind == 'template':
+                # The class name is the source name before the template args
+                # which is the previous prefix element
+                if len(prefix) >= 2:
+                    prev = prefix[-2]
+                    if isinstance(prev, ast.SourceName):
+                        return prev.name
+                    if isinstance(prev, ast.UnqualifiedName) and isinstance(prev.value, ast.SourceName):
+                        return prev.value.name
+        return self.render(last)
+
+    def _render_OperatorName(self, node):
+        return node.symbol
+
+    def _render_CtorDtorName(self, node):
+        # Placeholder — handled by NestedName renderer
+        return ''
+
+    def _render_TemplateArgs(self, node):
+        args = [self.render(a) for a in node.args]
+        # cxxfilt puts a space before > when the last arg ends with >
+        # to avoid >> being confused with right-shift
+        result = '<%s>' % ', '.join(args)
+        if args and args[-1].rstrip().endswith('>'):
+            result = '<%s >' % ', '.join(args)
+        return result
+
+    def _render_TemplateArg(self, node):
+        if node.kind == 'type':
+            return self.render(node.value)
+        if node.kind == 'expression':
+            return str(node.value)
+        if node.kind == 'pack':
+            if isinstance(node.value, list):
+                return ', '.join(self.render(a) if isinstance(a, ast.Node) else str(a) for a in node.value)
+            return str(node.value)
+        if node.kind == 'primary':
+            return str(node.value)
+        return str(node.value)
+
+    def _render_BuiltinType(self, node):
+        return node.name
+
+    def _render_PointerType(self, node):
+        target = self.render(node.target)
+        # Pointer to function: special formatting
+        if isinstance(node.target, ast.FunctionType) or self._is_function_pointer(node.target):
+            return '%s (*)' % self._render_function_pointer_inner(node.target)
+        return '%s*' % target
+
+    def _is_function_pointer(self, node):
+        """Check if a node represents a function (for pointer formatting)."""
+        return isinstance(node, (ast.FunctionType, ast.BareFunctionType))
+
+    def _render_function_pointer_inner(self, node):
+        """Render the inner part of a function pointer."""
+        if isinstance(node, ast.FunctionType):
+            return self._render_FunctionType(node)
+        return self.render(node)
+
+    def _render_ReferenceType(self, node):
+        return '%s&' % self.render(node.target)
+
+    def _render_RvalueReferenceType(self, node):
+        return '%s&&' % self.render(node.target)
+
+    def _render_CVQualifiedType(self, node):
+        base = self.render(node.base)
+        # cxxfilt puts CV-qualifiers after the base type: "char const*" not "const char*"
+        return '%s %s' % (base, node.qualifiers)
+
+    def _render_FunctionType(self, node):
+        bare = node.bare_function
+        if bare is None or not bare.types:
+            return 'void ()'
+        ret = self.render(bare.types[0])
+        params = [self.render(t) for t in bare.types[1:]]
+        if len(params) == 1 and params[0] == 'void':
+            params = []
+        result = '%s (%s)' % (ret, ', '.join(params))
+        if node.cv:
+            result += ' ' + node.cv
+        if node.ref:
+            result += ' ' + node.ref
+        return result
+
+    def _render_BareFunctionType(self, node):
+        if not node.types:
+            return ''
+        return ', '.join(self.render(t) for t in node.types)
+
+    def _render_Substitution(self, node):
+        if node.std_sub:
+            return grammar.STD_SUBS.get(node.std_sub, 'std')
+        # Resolve indexed substitution from the table
+        if node.index is not None and node.index < len(self.subs):
+            target = self.subs[node.index]
+            return self.render(target)
+        return '/*sub%d*/' % node.index if node.index is not None else '/*sub*/'
+
+    def _render_TemplateParam(self, node):
+        return '/*T%d*/' % node.index
+
+    def _render_SpecialName(self, node):
+        kind = node.kind
+        target_str = self.render(node.target) if node.target else ''
+        if kind == 'vtable':
+            return 'vtable for %s' % target_str
+        if kind == 'VTT':
+            return 'VTT for %s' % target_str
+        if kind == 'typeinfo':
+            return 'typeinfo for %s' % target_str
+        if kind == 'typeinfo name':
+            return 'typeinfo name for %s' % target_str
+        if kind == 'guard variable':
+            return 'guard variable for %s' % target_str
+        if kind == 'reference temp':
+            return 'reference temporary for %s' % target_str
+        if kind == 'tls init':
+            return 'TLS init function for %s' % target_str
+        if kind == 'tls wrapper':
+            return 'TLS wrapper function for %s' % target_str
+        return '%s for %s' % (kind, target_str)
+
+    def _render_Array(self, node):
+        element = self.render(node.element_type)
+        return '%s [%s]' % (element, node.dimension)
+
+    def _render_PointerToMember(self, node):
+        # M <class-type> <member-type>
+        # If member-type is a function type (possibly CV-qualified),
+        # render as: ret (Class::*)(params) cv-quals ref-qual
+        class_str = self.render(node.class_type)
+        member = node.member_type
+
+        # Unwrap CV-qualifiers to find the underlying function type
+        cv = ''
+        ref = ''
+        func_type = member
+        if isinstance(func_type, ast.CVQualifiedType):
+            cv = func_type.qualifiers
+            func_type = func_type.base
+
+        if isinstance(func_type, ast.FunctionType):
+            bare = func_type.bare_function
+            if bare and bare.types:
+                ret = self.render(bare.types[0])
+                params = [self.render(t) for t in bare.types[1:]]
+                if len(params) == 1 and params[0] == 'void':
+                    params = []
+                # Merge cv/ref from outer CVQualified with any on FunctionType itself
+                cv = cv or func_type.cv
+                ref = ref or func_type.ref
+                result = '%s (%s::*)(%s)' % (ret, class_str, ', '.join(params))
+                if cv:
+                    result += ' ' + cv
+                if ref:
+                    result += ' ' + ref
+                return result
+            return 'void (%s::*)()' % class_str
+        # Non-function member
+        member_str = self.render(member)
+        return '%s %s::*' % (member_str, class_str)
+
+    def _render_VendorExtendedType(self, node):
+        return node.name
+
+    def _render_Decltype(self, node):
+        return 'decltype(%s)' % str(node.expression)
+
+    def _render_ModuleName(self, node):
+        return node.name
+
+    def _render_AbiTag(self, node):
+        return '[abi:%s]' % node.tag

--- a/vivisect/demangle/itanium/renderer.py
+++ b/vivisect/demangle/itanium/renderer.py
@@ -65,7 +65,15 @@ class Renderer:
         name_str = self.render(node.qualified_name)
 
         if node.bare_function is None or not node.bare_function.types:
-            return name_str + '()'
+            # For const member functions, cv-qualifiers are on the NestedName
+            # and should come AFTER the parens
+            cv_suffix = ''
+            if isinstance(node.qualified_name, ast.NestedName):
+                if node.qualified_name.cv_qualifiers:
+                    cv_suffix = ' ' + node.qualified_name.cv_qualifiers
+                if node.qualified_name.ref_qualifier:
+                    cv_suffix += node.qualified_name.ref_qualifier
+            return name_str + '()' + cv_suffix
 
         # The bare function type contains return type + params (for functions
         # that are not member functions) or just params (for member functions).
@@ -92,7 +100,25 @@ class Renderer:
         # Per cxxfilt convention: a single 'void' param = empty param list
         if len(param_strs) == 1 and param_strs[0] == 'void':
             param_strs = []
-        return '%s(%s)' % (name_str, ', '.join(param_strs))
+
+        # CV-qualifiers and ref-qualifiers go AFTER the parens for member functions
+        cv_suffix = ''
+        if isinstance(node.qualified_name, ast.NestedName):
+            if node.qualified_name.cv_qualifiers:
+                cv_suffix = ' ' + node.qualified_name.cv_qualifiers
+            if node.qualified_name.ref_qualifier:
+                cv_suffix += node.qualified_name.ref_qualifier
+
+        # Strip the cv-qualifiers from name_str since we're adding them after parens
+        # The NestedName renderer already appended them — we need to remove them
+        if cv_suffix:
+            # name_str already has cv appended by _render_NestedName
+            # Remove it and re-add after parens
+            stripped = cv_suffix.strip()
+            if name_str.endswith(stripped):
+                name_str = name_str[:-(len(stripped) + 1)]  # +1 for the space
+
+        return '%s(%s)%s' % (name_str, ', '.join(param_strs), cv_suffix)
 
     def _is_template_name(self, node):
         """Check if a name node is a template instantiation."""
@@ -114,7 +140,12 @@ class Renderer:
         if node.kind == 'source':
             return self.render(node.value)
         if node.kind == 'operator':
-            return 'operator%s' % node.value.symbol
+            sym = node.value.symbol
+            # Operators like "new", "delete", "sizeof", etc. get a space
+            # Binary/unary operator symbols like "+", "-", "<<" don't
+            if sym[0].isalpha():
+                return 'operator %s' % sym
+            return 'operator%s' % sym
         if node.kind == 'ctor':
             return self._render_ctor_dtor(node.value, is_destructor=False)
         if node.kind == 'dtor':
@@ -173,7 +204,11 @@ class Renderer:
 
         result = '::'.join(parts)
 
-        # Apply CV-qualifiers and ref-qualifiers for member functions
+        # NOTE: CV-qualifiers and ref-qualifiers are NOT appended here
+        # when this NestedName is part of a function signature. They are
+        # handled by _render_function_signature which places them after ().
+        # However, when this NestedName is used standalone (as a type),
+        # the cv-qualifiers should be appended.
         suffix = ''
         if node.cv_qualifiers:
             suffix += ' ' + node.cv_qualifiers
@@ -188,7 +223,14 @@ class Renderer:
             return ''
         last = prefix[-1]
         if isinstance(last, ast.SourceName):
-            return last.name
+            name = last.name
+            # Strip template args FIRST (they may contain ::)
+            if '<' in name:
+                name = name[:name.index('<')]
+            # Then strip namespace prefix
+            if '::' in name:
+                name = name.rsplit('::', 1)[-1]
+            return name
         if isinstance(last, ast.UnqualifiedName):
             if last.kind == 'source' and isinstance(last.value, ast.SourceName):
                 return last.value.name
@@ -202,6 +244,17 @@ class Renderer:
                         return prev.name
                     if isinstance(prev, ast.UnqualifiedName) and isinstance(prev.value, ast.SourceName):
                         return prev.value.name
+        if isinstance(last, ast.Substitution):
+            # For substitutions like Ss, extract the class name
+            # from the expanded form
+            rendered = self.render(last)
+            # Strip namespace prefix: take the last ::-separated component
+            # For template instantiations, take just the class name before <
+            name = rendered.rsplit('::', 1)[-1]
+            # If it's a template instantiation, take just the class name
+            if '<' in name:
+                name = name[:name.index('<')]
+            return name
         return self.render(last)
 
     def _render_OperatorName(self, node):

--- a/vivisect/demangle/jni/__init__.py
+++ b/vivisect/demangle/jni/__init__.py
@@ -1,0 +1,221 @@
+"""
+vivisect.demangle.jni - Java/JNI native method name demangling.
+
+JNI native methods are mangled according to the JNI specification:
+
+    Java_<mangled-class-name>_<mangled-method-name>
+    Java_<class>_<method>__<mangled-signature>   (for overloaded methods)
+
+Mangling rules:
+    - Class name: dots -> underscores, '/' stays
+    - '_' in original -> _1
+    - ';' -> _2
+    - '[' -> _3
+    - '$' -> _00024
+    - Non-ASCII -> _0xxxx (4 hex digits)
+
+Reference:
+    - JNI specification, "Resolving Native Method Names"
+    - https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html
+"""
+
+import logging
+
+from vivisect.demangle.common import DemangledSymbol
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['demangle_jni']
+
+_JNI_PREFIX = 'Java_'
+
+
+def demangle_jni(mangled, structured=False):
+    """
+    Demangle a Java/JNI native method name.
+
+    Args:
+        mangled (str): The mangled JNI method name (e.g.
+            ``Java_pkg_Cls_f__ILjava_lang_String_2``).
+        structured (bool): If True, return a DemangledSymbol.
+
+    Returns:
+        str or DemangledSymbol: The demangled method name (e.g.
+        ``pkg.Cls.f(int, String)``) or the original if it doesn't look
+        like a valid JNI mangled name.
+    """
+    original = mangled
+
+    if not mangled.startswith(_JNI_PREFIX):
+        if structured:
+            return DemangledSymbol(
+                format='jni',
+                full_name=original,
+                name=original,
+                original_mangled=original,
+                parse_warnings=['not a JNI mangled name'],
+            )
+        return original
+
+    body = mangled[len(_JNI_PREFIX):]
+
+    # Split on '__' to separate method name from signature (overloaded methods).
+    # But '__' could also appear as part of an escape sequence, so we need
+    # to be careful.  In practice, '__' as a separator appears between the
+    # method name and the overloaded signature.
+    sig_idx = body.find('__')
+    if sig_idx > -1:
+        name_part = body[:sig_idx]
+        sig_part = body[sig_idx + 2:]
+    else:
+        name_part = body
+        sig_part = ''
+
+    # Unmangle the class+method name (uses '.' as class separator)
+    demangled_name = _unmangle_jni_string(name_part, class_sep='.')
+
+    # Parse the signature if present (uses '/' as class separator)
+    params = []
+    if sig_part:
+        # First unmangle the signature, then parse the type descriptors.
+        # In the signature, '_' means '/' (Java package separator).
+        unmangled_sig = _unmangle_jni_string(sig_part, class_sep='/')
+        params = _parse_jni_signature(unmangled_sig)
+        # Format as: class.method(arg1, arg2)
+        last_dot = demangled_name.rfind('.')
+        if last_dot > -1:
+            class_name = demangled_name[:last_dot]
+            method = demangled_name[last_dot + 1:]
+            demangled_full = '%s.%s(%s)' % (class_name, method, ', '.join(params))
+        else:
+            demangled_full = '%s(%s)' % (demangled_name, ', '.join(params))
+    else:
+        demangled_full = demangled_name
+        # Try to split class.method
+        last_dot = demangled_name.rfind('.')
+        if last_dot > -1:
+            class_name = demangled_name[:last_dot]
+            method = demangled_name[last_dot + 1:]
+            demangled_full = '%s.%s' % (class_name, method)
+
+    if not structured:
+        return demangled_full
+
+    sym = DemangledSymbol(
+        format='jni',
+        full_name=demangled_full,
+        kind='function',
+        original_mangled=original,
+        parameters=params,
+    )
+    # Split scope and name
+    if '.' in demangled_name:
+        parts = demangled_name.split('.')
+        sym.scope = parts[:-1]
+        sym.name = parts[-1]
+    else:
+        sym.name = demangled_name
+    return sym
+
+
+def _unmangle_jni_string(s, class_sep='.'):
+    """
+    Unmangle a JNI class/method name string.
+
+    Handles:
+        _1 -> _
+        _2 -> ;
+        _3 -> [
+        _00024 -> $ (and _0xxxx for Unicode)
+        _ (other) -> class_sep (default '.')
+    """
+    result = []
+    i = 0
+    while i < len(s):
+        c = s[i]
+        if c == '_':
+            if i + 1 < len(s):
+                next_c = s[i + 1]
+                if next_c == '1':
+                    result.append('_')
+                    i += 2
+                elif next_c == '2':
+                    result.append(';')
+                    i += 2
+                elif next_c == '3':
+                    result.append('[')
+                    i += 2
+                elif next_c == '0' and i + 5 < len(s):
+                    # Unicode: _0xxxx (4 hex digits)
+                    hex_str = s[i + 2:i + 6]
+                    try:
+                        result.append(chr(int(hex_str, 16)))
+                        i += 6
+                    except ValueError:
+                        result.append(c)
+                        i += 1
+                else:
+                    # Treat _ as class separator
+                    result.append(class_sep)
+                    i += 1
+            else:
+                result.append(class_sep)
+                i += 1
+        else:
+            result.append(c)
+            i += 1
+    return ''.join(result)
+
+
+def _parse_jni_signature(sig):
+    """
+    Parse a JNI type signature string into a list of parameter type strings.
+
+    JNI type descriptors:
+        I=int, Z=boolean, B=byte, C=char, S=short, J=long, F=float, D=double
+        L<class>;  for objects
+        [          for arrays (prefix)
+        V          for void (return type, not param)
+    """
+    type_map = {
+        'I': 'int', 'Z': 'boolean', 'B': 'byte', 'C': 'char',
+        'S': 'short', 'J': 'long', 'F': 'float', 'D': 'double',
+        'V': 'void',
+    }
+
+    params = []
+    i = 0
+    while i < len(sig):
+        c = sig[i]
+        # Array dimensions
+        array_depth = 0
+        while c == '[':
+            array_depth += 1
+            i += 1
+            if i >= len(sig):
+                break
+            c = sig[i]
+
+        if c == 'L':
+            # Object type: L<class>;
+            end = sig.find(';', i)
+            if end > -1:
+                class_part = sig[i + 1:end].replace('/', '.')
+                # Unmangle JNI escapes in class names
+                class_part = _unmangle_jni_string(class_part)
+                type_str = class_part
+                i = end + 1
+            else:
+                type_str = 'object'
+                i += 1
+        elif c in type_map:
+            type_str = type_map[c]
+            i += 1
+        else:
+            type_str = c
+            i += 1
+
+        type_str += '[]' * array_depth
+        params.append(type_str)
+
+    return params

--- a/vivisect/demangle/msvc/__init__.py
+++ b/vivisect/demangle/msvc/__init__.py
@@ -1,0 +1,50 @@
+"""
+vivisect.demangle.msvc - Microsoft Visual C++ ABI demangling (? prefix).
+
+Phase 0: Stub that returns the original name.  The pure-Python parser
+will be implemented in Phase 3.
+
+The MSVC C++ ABI is used by Microsoft Visual C++ and ICC on Windows.
+Mangled symbols start with ``?`` and use ``@``-terminated scope chains.
+
+Reference:
+    - LLVM MicrosoftDemangle.cpp
+    - Microsoft undname.c documentation
+"""
+
+import logging
+
+from vivisect.demangle.common import DemangledSymbol, normalize_name
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['demangle_msvc']
+
+
+def demangle_msvc(mangled, structured=False):
+    """
+    Demangle an MSVC C++ ABI mangled symbol (? prefix).
+
+    Phase 0: Returns the original name unchanged.  Phase 3 will implement
+    the full MSVC demangler.
+
+    Args:
+        mangled (str): The mangled symbol string.
+        structured (bool): If True, return a DemangledSymbol object.
+
+    Returns:
+        str or DemangledSymbol: The original mangled name (Phase 0 stub).
+    """
+    original = mangled
+    mangled = normalize_name(mangled)
+
+    if not structured:
+        return original
+
+    return DemangledSymbol(
+        format='msvc',
+        full_name=original,
+        name=original,
+        original_mangled=original,
+        parse_warnings=['MSVC demangler not yet implemented (Phase 3)'],
+    )

--- a/vivisect/demangle/msvc/__init__.py
+++ b/vivisect/demangle/msvc/__init__.py
@@ -1,13 +1,14 @@
 """
 vivisect.demangle.msvc - Microsoft Visual C++ ABI demangling (? prefix).
 
-Phase 0: Stub that returns the original name.  The pure-Python parser
-will be implemented in Phase 3.
+Pure-Python recursive descent parser for MSVC mangled symbols.
+No external dependencies — works fully offline.
 
 The MSVC C++ ABI is used by Microsoft Visual C++ and ICC on Windows.
 Mangled symbols start with ``?`` and use ``@``-terminated scope chains.
 
 Reference:
+    - Ghidra MicrosoftDmang (mdemangler) package
     - LLVM MicrosoftDemangle.cpp
     - Microsoft undname.c documentation
 """
@@ -15,6 +16,8 @@ Reference:
 import logging
 
 from vivisect.demangle.common import DemangledSymbol, normalize_name
+from vivisect.demangle.msvc.parser import MSVCParser, ParseError
+from vivisect.demangle.msvc.renderer import render
 
 logger = logging.getLogger(__name__)
 
@@ -25,26 +28,162 @@ def demangle_msvc(mangled, structured=False):
     """
     Demangle an MSVC C++ ABI mangled symbol (? prefix).
 
-    Phase 0: Returns the original name unchanged.  Phase 3 will implement
-    the full MSVC demangler.
+    Uses the pure-Python recursive descent parser.
 
     Args:
         mangled (str): The mangled symbol string.
         structured (bool): If True, return a DemangledSymbol object.
 
     Returns:
-        str or DemangledSymbol: The original mangled name (Phase 0 stub).
+        str or DemangledSymbol: The demangled name, or the original if
+        demangling fails (graceful degradation).
     """
     original = mangled
     mangled = normalize_name(mangled)
 
-    if not structured:
+    demangled = None
+    parse_warnings = []
+
+    ast_root = None
+    try:
+        parser = MSVCParser(mangled)
+        ast_root = parser.parse()
+        demangled = render(ast_root)
+        parse_warnings = parser.warnings
+    except ParseError as e:
+        logger.debug('MSVC parser failed for %r: %r', mangled, e)
+        parse_warnings.append('parser error: %r' % e)
+    except Exception as e:
+        logger.debug('MSVC parser exception for %r: %r', mangled, e)
+        parse_warnings.append('parser exception: %r' % e)
+
+    if demangled is None or demangled == mangled or not demangled:
+        if structured:
+            return DemangledSymbol(
+                format='msvc',
+                full_name=original,
+                name=original,
+                original_mangled=original,
+                parse_warnings=parse_warnings or ['unable to demangle'],
+            )
         return original
 
-    return DemangledSymbol(
+    if not structured:
+        return demangled
+
+    # Build structured result
+    sym = _build_structured(demangled, original, parse_warnings, ast_root)
+    return sym
+
+
+def _build_structured(demangled, original, parse_warnings, ast_root=None):
+    """Build a DemangledSymbol from the demangled string and AST."""
+    sym = DemangledSymbol(
         format='msvc',
-        full_name=original,
-        name=original,
+        full_name=demangled,
         original_mangled=original,
-        parse_warnings=['MSVC demangler not yet implemented (Phase 3)'],
+        parse_warnings=parse_warnings,
     )
+
+    # Parse basic structure from the demangled string
+    _parse_basic_structure(sym, demangled)
+
+    # Populate from AST if available
+    if ast_root is not None:
+        _populate_from_ast(sym, ast_root)
+
+    return sym
+
+
+def _parse_basic_structure(sym, demangled):
+    """Best-effort extraction of basic structure from a demangled string."""
+    # Check for common MSVC patterns
+    if '`vftable\'' in demangled:
+        sym.kind = 'vtable'
+    elif '`vbtable\'' in demangled:
+        sym.kind = 'vbtable'
+    elif '`RTTI' in demangled:
+        sym.kind = 'rtti'
+    elif 'ctor' in demangled:
+        sym.kind = 'ctor'
+    elif 'dtor' in demangled or '~' in demangled:
+        sym.kind = 'dtor'
+    elif 'operator' in demangled:
+        sym.kind = 'operator'
+    elif '(' in demangled:
+        sym.kind = 'function'
+    else:
+        sym.kind = 'variable'
+
+    # Extract scope and name
+    if '::' in demangled:
+        depth = 0
+        split_pos = -1
+        for i in range(len(demangled) - 1):
+            c = demangled[i]
+            if c == '<':
+                depth += 1
+            elif c == '>':
+                depth -= 1
+            elif depth == 0 and c == ':' and demangled[i + 1] == ':':
+                split_pos = i
+
+        if split_pos > -1:
+            sym.scope = demangled[:split_pos].split('::')
+            sym.name = demangled[split_pos + 2:]
+        else:
+            sym.name = demangled
+    else:
+        sym.name = demangled
+
+    if '<' in sym.name:
+        sym.is_template = True
+
+
+def _populate_from_ast(sym, ast_root):
+    """Populate DemangledSymbol fields from the parsed AST."""
+    from vivisect.demangle.msvc import ast_nodes as ast
+
+    if ast_root.qualified_name:
+        qname = ast_root.qualified_name
+        if qname.scope:
+            sym.scope = [_render_name_part(s) for s in qname.scope]
+            sym.is_member = len(qname.scope) > 0
+        if qname.basic_name:
+            sym.name = _render_name_part(qname.basic_name)
+
+    if isinstance(ast_root.type_info, ast.FunctionType):
+        sym.kind = 'function' if sym.kind == 'unknown' else sym.kind
+        ti = ast_root.type_info
+        if ti.access:
+            sym.access = ti.access
+        if ti.calling_convention:
+            sym.calling_convention = ti.calling_convention
+        if ti.is_static:
+            sym.is_static = True
+        if ti.is_virtual:
+            sym.is_virtual = True
+        if ti.return_type and ti.return_type != 'void':
+            sym.return_type = ti.return_type
+        sym.parameters = [p for p in ti.parameters if p and p != 'void']
+        if ti.cv_modifiers:
+            sym.cv_qualifiers = ti.cv_modifiers
+    elif isinstance(ast_root.type_info, ast.VariableInfo):
+        sym.kind = 'variable' if sym.kind == 'unknown' else sym.kind
+        ti = ast_root.type_info
+        if ti.access:
+            sym.access = ti.access
+        if ti.is_static:
+            sym.is_static = True
+        if ti.var_type:
+            sym.return_type = ti.var_type
+
+
+def _render_name_part(part):
+    """Render a name part to string."""
+    from vivisect.demangle.msvc import ast_nodes as ast
+    if isinstance(part, ast.FragmentName):
+        return part.name
+    if hasattr(part, 'name'):
+        return part.name
+    return str(part)

--- a/vivisect/demangle/msvc/ast_nodes.py
+++ b/vivisect/demangle/msvc/ast_nodes.py
@@ -1,0 +1,187 @@
+"""
+AST node classes for MSVC C++ demangling.
+
+These nodes represent the parsed structure of a Microsoft Visual C++
+mangled symbol.  The renderer converts them to demangled strings.
+"""
+
+
+# ---- Name nodes ----
+
+class FragmentName:
+    """A simple name fragment (e.g. 'foo' in ?foo@@YA...)."""
+    __slots__ = ('name',)
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return 'FragmentName(%r)' % self.name
+
+
+class SpecialName:
+    """A special name: constructor, destructor, operator, RTTI, etc."""
+    __slots__ = ('name', 'kind', 'is_ctor', 'is_dtor', 'is_operator', 'is_type_cast',
+                 'rtti_number')
+    def __init__(self, name, kind='special', is_ctor=False, is_dtor=False,
+                 is_operator=False, is_type_cast=False, rtti_number=-1):
+        self.name = name
+        self.kind = kind
+        self.is_ctor = is_ctor
+        self.is_dtor = is_dtor
+        self.is_operator = is_operator
+        self.is_type_cast = is_type_cast
+        self.rtti_number = rtti_number
+
+    def __repr__(self):
+        return 'SpecialName(%r, kind=%r)' % (self.name, self.kind)
+
+
+class TemplateName:
+    """A template name with arguments: ?$name@@..."""
+    __slots__ = ('base_name', 'args')
+    def __init__(self, base_name, args):
+        self.base_name = base_name  # FragmentName or SpecialName
+        self.args = args  # list of type strings
+
+    def __repr__(self):
+        return 'TemplateName(%r, args=%r)' % (self.base_name, self.args)
+
+
+class QualifiedName:
+    """A qualified name: scope chain + basic name."""
+    __slots__ = ('scope', 'basic_name')
+    def __init__(self, scope, basic_name):
+        self.scope = scope  # list of FragmentName/TemplateName strings
+        self.basic_name = basic_name  # FragmentName, SpecialName, or TemplateName
+
+    def __repr__(self):
+        return 'QualifiedName(scope=%r, basic=%r)' % (self.scope, self.basic_name)
+
+
+class AnonymousNamespace:
+    """Anonymous namespace marker (?A@)."""
+    __slots__ = ()
+    def __repr__(self):
+        return 'AnonymousNamespace()'
+
+
+# ---- Type nodes ----
+
+class PrimitiveType:
+    """A primitive type (int, char, void, etc.)."""
+    __slots__ = ('name',)
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return 'PrimitiveType(%r)' % self.name
+
+
+class PointerType:
+    """A pointer type."""
+    __slots__ = ('pointee', 'is_const', 'is_volatile', 'is_far')
+    def __init__(self, pointee, is_const=False, is_volatile=False, is_far=False):
+        self.pointee = pointee
+        self.is_const = is_const
+        self.is_volatile = is_volatile
+        self.is_far = is_far
+
+    def __repr__(self):
+        return 'PointerType(%r, const=%r, volatile=%r, far=%r)' % (
+            self.pointee, self.is_const, self.is_volatile, self.is_far)
+
+
+class ReferenceType:
+    """An lvalue reference type."""
+    __slots__ = ('referent',)
+    def __init__(self, referent):
+        self.referent = referent
+
+    def __repr__(self):
+        return 'ReferenceType(%r)' % self.referent
+
+
+class RvalueReferenceType:
+    """An rvalue reference type (&&)."""
+    __slots__ = ('referent',)
+    def __init__(self, referent):
+        self.referent = referent
+
+    def __repr__(self):
+        return 'RvalueReferenceType(%r)' % self.referent
+
+
+class UserDefinedType:
+    """A user-defined type (class, struct, union, enum)."""
+    __slots__ = ('kind', 'qualified_name')
+    def __init__(self, kind, qualified_name):
+        self.kind = kind  # 'class', 'struct', 'union', 'enum'
+        self.qualified_name = qualified_name
+
+    def __repr__(self):
+        return 'UserDefinedType(%r, %r)' % (self.kind, self.qualified_name)
+
+
+class FunctionType:
+    """A function type: calling convention, return type, args, CV modifiers."""
+    __slots__ = ('calling_convention', 'return_type', 'parameters',
+                 'is_member', 'cv_modifiers', 'is_static', 'is_virtual',
+                 'access', 'is_thunk', 'thunk_adjustment')
+    def __init__(self, calling_convention=None, return_type=None, parameters=None,
+                 is_member=False, cv_modifiers='', is_static=False, is_virtual=False,
+                 access=None, is_thunk=False, thunk_adjustment=None):
+        self.calling_convention = calling_convention
+        self.return_type = return_type
+        self.parameters = parameters if parameters is not None else []
+        self.is_member = is_member
+        self.cv_modifiers = cv_modifiers
+        self.is_static = is_static
+        self.is_virtual = is_virtual
+        self.access = access  # 'private', 'protected', 'public', None
+        self.is_thunk = is_thunk
+        self.thunk_adjustment = thunk_adjustment
+
+    def __repr__(self):
+        return 'FunctionType(cc=%r, ret=%r, params=%r, member=%r)' % (
+            self.calling_convention, self.return_type, self.parameters, self.is_member)
+
+
+class VariableInfo:
+    """A variable (data) symbol: storage class, access, type."""
+    __slots__ = ('access', 'is_static', 'var_type', 'is_guard')
+    def __init__(self, access=None, is_static=False, var_type=None, is_guard=False):
+        self.access = access
+        self.is_static = is_static
+        self.var_type = var_type
+        self.is_guard = is_guard
+
+    def __repr__(self):
+        return 'VariableInfo(access=%r, static=%r, type=%r)' % (
+            self.access, self.is_static, self.var_type)
+
+
+class VFTable:
+    """Virtual function table."""
+    __slots__ = ('scope', 'parents')
+    def __init__(self, scope, parents=None):
+        self.scope = scope
+        self.parents = parents if parents is not None else []
+
+    def __repr__(self):
+        return 'VFTable(scope=%r)' % (self.scope,)
+
+
+# ---- Top-level symbol ----
+
+class MSVCSymbol:
+    """Top-level parsed MSVC symbol."""
+    __slots__ = ('qualified_name', 'type_info', 'is_embedded', 'kind')
+    def __init__(self, qualified_name=None, type_info=None, is_embedded=False, kind='unknown'):
+        self.qualified_name = qualified_name
+        self.type_info = type_info  # FunctionType, VariableInfo, VFTable, etc.
+        self.is_embedded = is_embedded
+        self.kind = kind
+
+    def __repr__(self):
+        return 'MSVCSymbol(name=%r, type=%r, kind=%r)' % (
+            self.qualified_name, self.type_info, self.kind)

--- a/vivisect/demangle/msvc/parser.py
+++ b/vivisect/demangle/msvc/parser.py
@@ -1,0 +1,1012 @@
+"""
+MSVC C++ ABI demangling parser.
+
+Recursive descent parser for Microsoft Visual C++ mangled symbols.
+Symbols start with '?' and use '@'-terminated scope chains.
+
+Reference:
+    - Ghidra MicrosoftDmang (mdemangler) package
+    - LLVM MicrosoftDemangle.cpp
+    - Microsoft undname.c documentation
+    - http://www.geoffchappell.com/studies/msvc/language/decoration/name.htm
+"""
+
+import logging
+from vivisect.demangle.msvc import ast_nodes as ast
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['MSVCParser', 'ParseError']
+
+
+class ParseError(Exception):
+    pass
+
+
+class MSVCParser:
+    """Recursive descent parser for MSVC mangled symbols."""
+
+    # --- Operator name lookup tables ---
+
+    # Single-char operator codes (after ?)
+    OPERATORS = {
+        '0': ('constructor', True, False),
+        '1': ('destructor', False, True),
+        '2': 'operator new',
+        '3': 'operator delete',
+        '4': 'operator=',
+        '5': 'operator>>',
+        '6': 'operator<<',
+        '7': 'operator!',
+        '8': 'operator==',
+        '9': 'operator!=',
+        'A': 'operator[]',
+        # B = operator [type cast] — handled specially
+        'C': 'operator->',
+        'D': 'operator*',
+        'E': 'operator++',
+        'F': 'operator--',
+        'G': 'operator-',
+        'H': 'operator+',
+        'I': 'operator&',
+        'J': 'operator->*',
+        'K': 'operator/',
+        'L': 'operator%',
+        'M': 'operator<',
+        'N': 'operator<=',
+        'O': 'operator>',
+        'P': 'operator>=',
+        'Q': 'operator,',
+        'R': 'operator()',
+        'S': 'operator~',
+        'T': 'operator^',
+        'U': 'operator|',
+        'V': 'operator&&',
+        'W': 'operator||',
+        'X': 'operator*=',
+        'Y': 'operator+=',
+        'Z': 'operator-=',
+    }
+
+    # Two-char operator codes (after ?_)
+    OPERATORS_EXT = {
+        '0': 'operator/=',
+        '1': 'operator%=',
+        '2': 'operator>>=',
+        '3': 'operator<<=',
+        '4': 'operator&=',
+        '5': 'operator|=',
+        '6': 'operator^=',
+        '7': '`vftable\'',
+        '8': '`vbtable\'',
+        '9': '`vcall\'',
+        'A': '`typeof\'',
+        'B': '`local static guard\'',
+        # C = string — handled specially
+        'D': '`vbase destructor\'',
+        'E': '`vector deleting destructor\'',
+        'F': '`default constructor closure\'',
+        'G': '`scalar deleting destructor\'',
+        'H': '`vector constructor iterator\'',
+        'I': '`vector destructor iterator\'',
+        'J': '`vector vbase constructor iterator\'',
+        'K': '`virtual displacement map\'',
+        'L': '`eh vector constructor iterator\'',
+        'M': '`eh vector destructor iterator\'',
+        'N': '`eh vector vbase constructor iterator\'',
+        'O': '`copy constructor closure\'',
+        'S': '`local vftable\'',
+        'T': '`local vftable constructor closure\'',
+        'U': 'operator new[]',
+        'V': 'operator delete[]',
+        'W': '`omni callsig\'',
+        'X': '`placement delete closure\'',
+        'Y': '`placement delete[] closure\'',
+    }
+
+    # Three-char operator codes (after ?__)
+    OPERATORS_EXT3 = {
+        'A': '`managed vector constructor iterator\'',
+        'B': '`managed vector destructor iterator\'',
+        'C': '`eh vector copy constructor iterator\'',
+        'D': '`eh vector vbase copy constructor iterator\'',
+        'E': '`dynamic initializer for \'',  # needs object name appended
+        'F': '`dynamic atexit destructor for \'',
+        'G': '`vector copy constructor iterator\'',
+        'H': '`vector vbase copy constructor iterator\'',
+        'I': '`managed vector copy constructor iterator\'',
+        'J': '`local static thread guard\'',
+        'K': 'operator "" ',  # UDL — needs fragment name
+    }
+
+    # RTTI names (after ?_R)
+    RTTI_NAMES = {
+        '0': '`RTTI Type Descriptor\'',
+        '2': '`RTTI Base Class Array\'',
+        '3': '`RTTI Class Hierarchy Descriptor\'',
+        '4': '`RTTI Complete Object Locator\'',
+    }
+
+    # Primitive type codes → type name
+    PRIMITIVES = {
+        'C': 'char',
+        'D': 'char',
+        'E': 'unsigned char',
+        'F': 'short',
+        'G': 'unsigned short',
+        'H': 'int',
+        'I': 'unsigned int',
+        'J': 'long',
+        'K': 'unsigned long',
+        'M': 'float',
+        'N': 'double',
+        'O': 'long double',
+        'X': 'void',
+        'Z': '...',
+    }
+
+    # Extended primitive types (after _)
+    EXTENDED_PRIMITIVES = {
+        'D': 'signed char',
+        'E': 'unsigned char',
+        'F': 'short',
+        'G': 'unsigned short',
+        'H': 'int',
+        'I': 'unsigned int',
+        'J': '__int64',
+        'K': 'unsigned __int64',
+        'L': '__int128',
+        'M': 'unsigned __int128',
+        'N': 'bool',
+        'Q': 'char8_t',
+        'S': 'char16_t',
+        'U': 'char32_t',
+        'W': 'wchar_t',
+    }
+
+    # Calling convention codes → name
+    CALLING_CONVENTIONS = {
+        'A': '__cdecl', 'B': '__cdecl',
+        'C': '__pascal', 'D': '__pascal',
+        'E': '__thiscall', 'F': '__thiscall',
+        'G': '__stdcall', 'H': '__stdcall',
+        'I': '__fastcall', 'J': '__fastcall',
+        'K': '', 'L': '',
+        'M': '__clrcall', 'N': '__clrcall',
+    }
+
+    def __init__(self, mangled):
+        self.mangled = mangled
+        self.pos = 0
+        self.warnings = []
+        self._backrefs = []  # Type back-reference table
+        self._name_backrefs = []  # Name back-reference table
+
+    # --- Low-level cursor ---
+
+    def _peek(self, offset=0):
+        idx = self.pos + offset
+        if idx >= len(self.mangled):
+            return '\x00'  # DONE
+        return self.mangled[idx]
+
+    def _next(self):
+        if self.pos >= len(self.mangled):
+            raise ParseError('unexpected end of input at pos %d' % self.pos)
+        ch = self.mangled[self.pos]
+        self.pos += 1
+        return ch
+
+    def _expect(self, ch):
+        c = self._next()
+        if c != ch:
+            raise ParseError('expected %r, got %r at pos %d' % (ch, c, self.pos - 1))
+        return c
+
+    def _at_end(self):
+        return self.pos >= len(self.mangled)
+
+    # --- Public entry point ---
+
+    def parse(self):
+        """Parse the mangled symbol and return an MSVCSymbol AST."""
+        if self._peek() != '?':
+            raise ParseError('MSVC symbols must start with ?')
+
+        self._next()  # consume '?'
+
+        # Check for special prefixes
+        # ??@ = hashed object (MD5-based)
+        if self._peek() == '@':
+            # Hashed object — can't demangle, return as-is
+            raise ParseError('hashed object (??@) cannot be demangled')
+
+        # ?? = could be embedded object, RTTI, or special name (ctor/dtor/operator)
+        if self._peek() == '?':
+            # Check what follows the second ?
+            next2 = self._peek(1)
+            if next2 == '_' or next2 == '?':
+                # ??_X (RTTI/vtable) or ??? (embedded)
+                return self._parse_double_question()
+            # ??0, ??1, ??B, etc. = special name (constructor, destructor, operator)
+            # Fall through to normal C++ symbol parsing
+            pass
+
+        # ?$ = template
+        if self._peek() == '$':
+            return self._parse_template_symbol()
+
+        # Standard ?name@@typeinfo pattern
+        return self._parse_cpp_symbol()
+
+    # --- Double-question symbols (??, ??_) ---
+
+    def _parse_double_question(self):
+        """Parse symbols starting with ?? (second ? consumed)."""
+        self._next()  # consume second '?'
+
+        # ??_7Foo@@6B = vtable for Foo
+        # ??_8Foo@@6B = vbtable for Foo
+        # ??_0 through ??_4 = RTTI
+        if self._peek() == '_':
+            self._next()  # consume '_'
+            code = self._next()
+
+            if code == '7':
+                # vtable: ??_7Class@@6B
+                qname = self._parse_qualified_name()
+                return ast.MSVCSymbol(
+                    qualified_name=qname,
+                    type_info=ast.VFTable(scope=qname),
+                    kind='vtable',
+                )
+            elif code == '8':
+                # vbtable
+                qname = self._parse_qualified_name()
+                return ast.MSVCSymbol(
+                    qualified_name=qname,
+                    type_info=ast.VFTable(scope=qname),
+                    kind='vbtable',
+                )
+            elif code in self.RTTI_NAMES:
+                rtti_name = self.RTTI_NAMES[code]
+                # RTTI 0 has a type
+                if code == '0':
+                    type_str = self._parse_data_type()
+                    name = '%s `RTTI Type Descriptor\'' % type_str
+                elif code == '1':
+                    # RTTI Base Class Descriptor — has 4 numbers
+                    a = self._parse_encoded_number()
+                    b = self._parse_encoded_number()
+                    c = self._parse_encoded_number()
+                    d = self._parse_encoded_number()
+                    name = '`RTTI Base Class Descriptor at (%s,%s,%s,%s)\'' % (a, b, c, d)
+                else:
+                    name = rtti_name
+                return ast.MSVCSymbol(
+                    qualified_name=ast.QualifiedName([], ast.SpecialName(name, kind='rtti')),
+                    type_info=None,
+                    kind='rtti',
+                )
+            else:
+                raise ParseError('unknown ??_%s symbol' % code)
+
+        # ??? prefix = embedded object
+        if self._peek() == '?':
+            # Embedded — parse the inner symbol
+            inner = self._parse_embedded_name()
+            return ast.MSVCSymbol(
+                qualified_name=inner,
+                type_info=None,
+                is_embedded=True,
+                kind='embedded',
+            )
+
+        # ??B, ??C, etc. — might be other special forms
+        # Try parsing as a regular C++ symbol with extra ? prefix
+        raise ParseError('unknown ?? prefix: %r' % self._peek())
+
+    # --- Template symbol ($ prefix) ---
+
+    def _parse_template_symbol(self):
+        """Parse a top-level ?$ template symbol."""
+        self._next()  # consume '$'
+        template = self._parse_template_name()
+        # After the template name, there may be type info
+        type_info = None
+        if not self._at_end():
+            type_info = self._parse_type_info(-1)
+
+        return ast.MSVCSymbol(
+            qualified_name=template,
+            type_info=type_info,
+            kind='template',
+        )
+
+    # --- Standard C++ symbol ---
+
+    def _parse_cpp_symbol(self):
+        """Parse a standard ?name@@typeinfo C++ symbol."""
+        qname = self._parse_qualified_name()
+        rtti_num = -1
+        if isinstance(qname.basic_name, ast.SpecialName):
+            rtti_num = qname.basic_name.rtti_number
+
+        type_info = None
+        if not self._at_end():
+            type_info = self._parse_type_info(rtti_num)
+
+        return ast.MSVCSymbol(
+            qualified_name=qname,
+            type_info=type_info,
+            kind='function' if isinstance(type_info, ast.FunctionType) else 'variable',
+        )
+
+    # --- Name parsing ---
+
+    def _parse_qualified_name(self):
+        """Parse a qualified name: name@scope1@scope2@@ or name@@.
+
+        In MSVC mangling, the basic name comes first, then scope fragments
+        as @-terminated strings, and the whole qualified name ends with @@.
+        The pattern is: name@scope1@scope2@...@@
+        A single @@ after the name means no scope.
+        """
+        scope = []
+        basic_name = None
+
+        # Check for ? prefix (special name or template)
+        if self._peek() == '?':
+            self._next()  # consume '?'
+            basic_name = self._parse_special_name()
+        elif self._peek() == '$':
+            self._next()  # consume '$'
+            basic_name = self._parse_template_name()
+        else:
+            # Plain name fragment
+            basic_name = self._parse_fragment_name()
+
+        # Now parse scope fragments. Each @ after the name either:
+        # - starts a scope fragment (name@MyClass@...)
+        # - ends the qualified name (name@@ or operator@@)
+        # For special names (constructor/destructor), the scope follows
+        # directly without an @ separator: ?0MyClass@@
+        # For operators, a single @ means end of name (global scope)
+        is_special = isinstance(basic_name, ast.SpecialName)
+        is_operator = is_special and basic_name.is_operator
+
+        while True:
+            ch = self._peek()
+            if ch == '@':
+                self._next()  # consume @
+                if self._peek() == '@':
+                    # @@ = end of qualified name
+                    self._next()
+                    break
+                if self._peek() == '\x00':
+                    break
+                # For operators, a single @ means end of name (global scope)
+                if is_operator:
+                    break
+                # Parse scope fragment (goes before the basic name in scope chain)
+                frag = self._parse_scope_fragment_or_name()
+                if frag is not None:
+                    scope.insert(0, frag)
+            elif is_special and not is_operator and ch != '\x00':
+                # Special names (ctor/dtor) have scope directly after, no @ separator
+                frag = self._parse_scope_fragment_or_name()
+                if frag is not None:
+                    scope.insert(0, frag)
+            else:
+                # No more @ — end of qualified name
+                break
+
+        # For constructor/destructor, the name is the class name from scope
+        if isinstance(basic_name, ast.SpecialName):
+            if basic_name.is_ctor and scope:
+                cls_name = scope[-1].name if hasattr(scope[-1], 'name') else str(scope[-1])
+                basic_name.name = cls_name
+            elif basic_name.is_dtor and scope:
+                base = scope[-1].name if hasattr(scope[-1], 'name') else str(scope[-1])
+                basic_name.name = '~' + base
+
+        return ast.QualifiedName(scope, basic_name)
+
+    def _parse_scope_fragment_or_name(self):
+        """Parse a scope fragment (handles ?, $, or plain name)."""
+        if self._peek() == '?':
+            return self._parse_scope_fragment()
+        elif self._peek() == '$':
+            self._next()
+            return self._parse_template_name()
+        else:
+            return self._parse_fragment_name()
+
+    def _parse_scope_fragment(self):
+        """Parse a scope fragment that starts with ?."""
+        if self._peek() == '?':
+            # Check for ?A (anonymous namespace)
+            if self._peek(1) == 'A':
+                self._next()  # ?
+                self._next()  # A
+                if self._peek() == '@':
+                    self._next()
+                return ast.AnonymousNamespace()
+            # Check for ?$ (template in scope)
+            if self._peek(1) == '$':
+                self._next()  # ?
+                self._next()  # $
+                tmpl = self._parse_template_name()
+                return tmpl
+            # Numeric back-reference (?0, ?1, ...)
+            if self._peek(1).isdigit():
+                self._next()  # ?
+                idx = self._next()
+                # TODO: resolve back-reference
+                return None  # skip for now
+            # Unknown ? in scope
+            self._next()
+            return None
+        return self._parse_fragment_name()
+
+    def _parse_fragment_name(self):
+        """Parse a simple name fragment terminated by @."""
+        chars = []
+        while True:
+            ch = self._peek()
+            if ch == '@' or ch == '\x00':
+                break
+            chars.append(ch)
+            self.pos += 1
+        name = ''.join(chars)
+        if not name:
+            raise ParseError('empty fragment name at pos %d' % self.pos)
+        frag = ast.FragmentName(name)
+        self._name_backrefs.append(frag)
+        return frag
+
+    def _parse_template_name(self):
+        """Parse a template name: name@@template-args."""
+        # The base name fragment
+        base = self._parse_fragment_name()
+        # Consume @ separator (template names end with @@)
+        if self._peek() == '@':
+            self._next()
+            if self._peek() == '@':
+                self._next()
+
+        # Parse template arguments
+        args = self._parse_template_args()
+
+        tmpl = ast.TemplateName(base, args)
+        self._name_backrefs.append(tmpl)
+        return tmpl
+
+    def _parse_template_args(self):
+        """Parse template arguments until we hit a non-type boundary."""
+        args = []
+        # Template args are types or values, terminated implicitly
+        while not self._at_end() and self._peek() != '@':
+            try:
+                arg = self._parse_template_arg()
+                args.append(arg)
+            except ParseError:
+                break
+        # Consume trailing @ if present
+        if self._peek() == '@':
+            self._next()
+        return args
+
+    def _parse_template_arg(self):
+        """Parse a single template argument (type or value)."""
+        # Template args can be:
+        # - A type (starts with a type code)
+        # - A numeric value (digits)
+        # - A named value (?$ + name)
+        ch = self._peek()
+        if ch == '?':
+            # Could be a nested template or special
+            self._next()
+            if self._peek() == '$':
+                self._next()
+                tmpl = self._parse_template_name()
+                return tmpl
+            # Try as type
+            return '?' + self._parse_type_string()
+        if ch.isdigit():
+            # Integer value
+            num = ''
+            while self._peek().isdigit():
+                num += self._next()
+            if self._peek() == '@':
+                self._next()
+            return num
+        # Parse as type
+        return self._parse_data_type()
+
+    def _parse_special_name(self):
+        """Parse a special name following the ? prefix."""
+        code = self._next()
+
+        if code in self.OPERATORS:
+            info = self.OPERATORS[code]
+            if isinstance(info, tuple):
+                name, is_ctor, is_dtor = info
+                return ast.SpecialName('', kind='ctor' if is_ctor else 'dtor',
+                                       is_ctor=is_ctor, is_dtor=is_dtor)
+            return ast.SpecialName(info, kind='operator', is_operator=True)
+
+        if code == 'B':
+            # Type cast operator — type determined later from return type
+            return ast.SpecialName('operator', kind='operator', is_type_cast=True)
+
+        if code == '_':
+            code2 = self._next()
+            if code2 in self.OPERATORS_EXT:
+                name = self.OPERATORS_EXT[code2]
+                if code2 == 'B':
+                    # local static guard — may have a number
+                    pass
+                if code2 == 'C':
+                    # string — parse MDString
+                    return ast.SpecialName(self._parse_md_string(), kind='string')
+                return ast.SpecialName(name, kind='special')
+
+            if code2 == 'R':
+                # RTTI
+                rtti_code = self._next()
+                rtti_num = int(rtti_code) if rtti_code.isdigit() else -1
+                if rtti_code in self.RTTI_NAMES:
+                    return ast.SpecialName(self.RTTI_NAMES[rtti_code],
+                                          kind='rtti', rtti_number=rtti_num)
+                if rtti_code == '1':
+                    # RTTI Base Class Descriptor — has 4 encoded numbers
+                    a = self._parse_encoded_number()
+                    b = self._parse_encoded_number()
+                    c = self._parse_encoded_number()
+                    d = self._parse_encoded_number()
+                    return ast.SpecialName(
+                        '`RTTI Base Class Descriptor at (%s,%s,%s,%s)\'' % (a, b, c, d),
+                        kind='rtti', rtti_number=1)
+
+            if code2 == '_':
+                code3 = self._next()
+                if code3 in self.OPERATORS_EXT3:
+                    name = self.OPERATORS_EXT3[code3]
+                    if code3 in ('E', 'F'):
+                        # dynamic initializer/destructor for — needs object
+                        obj = self._parse_fragment_name()
+                        name = '%s%s\'' % (name, obj.name)
+                    if code3 == 'K':
+                        # UDL operator — needs fragment name
+                        frag = self._parse_fragment_name()
+                        name = 'operator "" %s' % frag.name
+                    return ast.SpecialName(name, kind='special')
+
+            raise ParseError('unknown operator code ?_%s' % code2)
+
+        raise ParseError('unknown special name code %r' % code)
+
+    def _parse_md_string(self):
+        """Parse an MDString (embedded string data)."""
+        # MDString format: length@@data
+        # For now, return a placeholder
+        chars = []
+        while self._peek() != '@' and self._peek() != '\x00':
+            chars.append(self._next())
+        if self._peek() == '@':
+            self._next()
+        return ''.join(chars)
+
+    # --- Type info parsing ---
+
+    def _parse_type_info(self, rtti_num):
+        """Parse the type info section (access, storage, function/variable type)."""
+        is_based = False
+        if self._peek() == '_':
+            is_based = True
+            self._next()
+
+        code = self._peek()
+
+        # $ prefix = special handling function
+        if code == '$':
+            self._next()
+            return self._parse_special_handling_function(rtti_num)
+
+        # Variable info (data)
+        if code in '01234':
+            self._next()
+            access_map = {'0': 'private', '1': 'protected', '2': 'public'}
+            access = access_map.get(code)
+            is_static = code in '012'
+            if code in '01234':
+                var_type = None
+                if not self._at_end():
+                    var_type = self._parse_data_type()
+                return ast.VariableInfo(access=access, is_static=is_static,
+                                        var_type=var_type)
+
+        if code == '5':
+            self._next()
+            return ast.VariableInfo(is_guard=True)
+
+        if code == '6':
+            self._next()
+            # VFTable or RTTI4
+            if rtti_num == 4:
+                return ast.VFTable(scope=None)
+            return ast.VFTable(scope=None)
+
+        if code == '7':
+            self._next()
+            return ast.VFTable(scope=None)  # VBTable
+
+        # Member function access codes
+        # A-Z encode: access × (static/virtual/thunk) × (near/far)
+        access_map = {
+            'A': 'private', 'B': 'private',
+            'C': 'private', 'D': 'private',
+            'E': 'private', 'F': 'private',
+            'G': 'private', 'H': 'private',
+            'I': 'protected', 'J': 'protected',
+            'K': 'protected', 'L': 'protected',
+            'M': 'protected', 'N': 'protected',
+            'O': 'protected', 'P': 'protected',
+            'Q': 'public', 'R': 'public',
+            'S': 'public', 'T': 'public',
+            'U': 'public', 'V': 'public',
+            'W': 'public', 'X': 'public',
+        }
+
+        if code in access_map:
+            self._next()
+            access = access_map[code]
+            idx = ord(code) - ord('A')
+
+            is_static = code in 'CDKLST'
+            is_virtual = code in 'EFMNUV'
+            is_thunk = code in 'GHWXOP'
+            is_member = True
+
+            # Parse function type — CV modifier only for non-static member functions
+            has_cv = not is_static
+            func = self._parse_function_type(is_member=True, has_cv_mod=has_cv)
+            func.access = access
+            func.is_static = is_static
+            func.is_virtual = is_virtual
+            if is_thunk:
+                func.is_thunk = True
+            return func
+
+        if code in 'YZ':
+            self._next()
+            # Non-member function
+            func = self._parse_function_type(is_member=False, has_cv_mod=False)
+            return func
+
+        raise ParseError('unknown type info code %r at pos %d' % (code, self.pos))
+
+    def _parse_special_handling_function(self, rtti_num):
+        """Parse $-prefixed special function type."""
+        code = self._next()
+        # Vtordisp, vcall, etc.
+        if code in '012345':
+            access_map = {'0': 'private', '1': 'private',
+                          '2': 'protected', '3': 'protected',
+                          '4': 'public', '5': 'public'}
+            access = access_map.get(code, 'private')
+            func = self._parse_function_type(is_member=True, has_cv_mod=True)
+            func.access = access
+            return func
+
+        if code == '$':
+            code2 = self._next()
+            if code2 in 'JNO':
+                # extern "C" — skip count then recurse
+                cnt_ch = self._next()
+                if cnt_ch.isdigit():
+                    cnt = int(cnt_ch)
+                    for _ in range(cnt):
+                        self._next()
+                inner = self._parse_type_info(rtti_num)
+                return inner
+            if code2 in 'FHLMQ':
+                inner = self._parse_type_info(rtti_num)
+                return inner
+            if code2 == 'R':
+                # vtordispex
+                access_code = self._next()
+                access_map = {'0': 'private', '1': 'private',
+                              '2': 'protected', '3': 'protected',
+                              '4': 'public', '5': 'public'}
+                func = self._parse_function_type(is_member=True, has_cv_mod=True)
+                func.access = access_map.get(access_code, 'private')
+                return func
+            if code2 == 'B':
+                # vcall
+                return ast.FunctionType(is_member=False)
+
+        raise ParseError('unknown special handling function %r' % code)
+
+    # --- Function type ---
+
+    def _parse_function_type(self, is_member, has_cv_mod):
+        """Parse a function type: calling convention, return type, args."""
+        func = ast.FunctionType(is_member=is_member)
+
+        # CV modifier for this pointer (member functions, non-static only)
+        if has_cv_mod:
+            func.cv_modifiers = self._parse_cv_mod()
+
+        # Calling convention
+        cc_code = self._next()
+        func.calling_convention = self.CALLING_CONVENTIONS.get(cc_code, '')
+
+        # Return type: @ means no return type (constructors/destructors)
+        if self._peek() == '@':
+            self._next()
+            func.return_type = ''  # No return type for structors
+        else:
+            func.return_type = self._parse_data_type()
+
+        # Arguments
+        func.parameters = self._parse_arguments()
+
+        # Throw attribute (optional, ends with Z or @)
+        if self._peek() == 'Z':
+            self._next()
+        elif self._peek() == '@':
+            self._next()
+
+        return func
+
+    def _parse_cv_mod(self):
+        """Parse CV modifier for this pointer."""
+        # CV modifier format: [E/F/N/O] qualifiers
+        # E = __ptr32, F = __ptr32 __ptr64, etc.
+        # Simpler: read until we hit a calling convention letter
+        modifiers = []
+        code = self._next()
+
+        # CV modifier encoding:
+        # A = none, B = const, C = volatile, D = const volatile
+        # E = far, F = const far, G = volatile far, H = const volatile far
+        # I = based(0), ...
+        # N = __ptr64, O = const __ptr64, P = volatile __ptr64, Q = const volatile __ptr64
+        cv_map = {
+            'A': '', 'B': 'const', 'C': 'volatile', 'D': 'const volatile',
+            'E': '', 'F': 'const', 'G': 'volatile', 'H': 'const volatile',
+            'I': '', 'J': 'const', 'K': 'volatile', 'L': 'const volatile',
+            'M': '', 'N': '', 'O': 'const', 'P': 'volatile', 'Q': 'const volatile',
+        }
+
+        result = cv_map.get(code, '')
+        if not result and code not in cv_map:
+            self.warnings.append('unknown CV modifier code %r' % code)
+        return result
+
+    def _parse_arguments(self):
+        """Parse function argument list."""
+        args = []
+        while True:
+            ch = self._peek()
+            if ch == '\x00':
+                break
+            if ch == 'X':
+                self._next()
+                # void = end of arguments (either no args or void param)
+                break
+            if ch == 'Z':
+                self._next()
+                break
+            if ch == '@':
+                self._next()
+                break
+            try:
+                arg_type = self._parse_data_type()
+                if arg_type and arg_type != 'void':
+                    args.append(arg_type)
+            except ParseError:
+                break
+        return args
+
+    # --- Data type parsing ---
+
+    def _parse_data_type(self):
+        """Parse a data type and return its string representation."""
+        ch = self._peek()
+
+        if ch == '\x00':
+            raise ParseError('unexpected end of input parsing type')
+
+        if ch == '?':
+            self._next()
+            # Custom type or question modifier
+            return '?'
+
+        if ch == 'X':
+            self._next()
+            return 'void'
+
+        if ch == 'A':
+            # Reference type: A = reference, then CV modifier, then referent
+            self._next()
+            cv_code = self._next()
+            # For references, CV modifier is usually ignored in output (refs are always const)
+            ref = self._parse_data_type()
+            return ref + '&'
+
+        if ch == 'B':
+            # B = far reference variant (same as A for output)
+            self._next()
+            cv_code = self._next()
+            ref = self._parse_data_type()
+            return ref + '&'
+
+        # Extended types ($)
+        if ch == '$':
+            self._next()
+            ext_code = self._next()
+            if ext_code == 'A':
+                return self._parse_function_indirect_type()
+            if ext_code == 'T':
+                return 'std::nullptr_t'
+            if ext_code == 'V':
+                return ''
+            if ext_code == 'Z':
+                return '...'
+            if ext_code == 'C':
+                ref = self._parse_data_type()
+                return ref + '&'
+            if ext_code == 'Q':
+                ref = self._parse_data_type()
+                return ref + '&&'
+            if ext_code == 'R':
+                ref = self._parse_data_type()
+                return ref + '&&'
+            if ext_code == 'B':
+                ref = self._parse_data_type()
+                return ref + '*'
+            self.warnings.append('unknown $ type code %r' % ext_code)
+            return '$' + ext_code
+
+        # Pointer types: P/Q/R/S followed by CV modifier code, then pointee
+        if ch in 'PQRS':
+            self._next()
+            # Read the pointer's CV modifier
+            ptr_cv = self._next()
+            cv_map = {
+                'A': '', 'B': 'const ', 'C': 'volatile ', 'D': 'const volatile ',
+                'E': '', 'F': 'const ', 'G': 'volatile ', 'H': 'const volatile ',
+            }
+            cv = cv_map.get(ptr_cv, '')
+            # Check if next is a function type (function pointer)
+            pointee = self._parse_data_type()
+            return '%s%s*' % (cv, pointee)
+
+        # User-defined types
+        if ch == 'T':
+            self._next()
+            qname = self._parse_qualified_name_type()
+            return 'union ' + qname
+        if ch == 'U':
+            self._next()
+            qname = self._parse_qualified_name_type()
+            return 'struct ' + qname
+        if ch == 'V':
+            self._next()
+            qname = self._parse_qualified_name_type()
+            return 'class ' + qname
+        if ch == 'W':
+            self._next()
+            # W4 prefix for enum — consume the '4'
+            if self._peek() == '4':
+                self._next()
+            qname = self._parse_qualified_name_type()
+            return 'enum ' + qname
+
+        # Extended primitives (_ prefix)
+        if ch == '_':
+            self._next()
+            ext_code = self._next()
+            if ext_code == '$':
+                inner = self._parse_data_type()
+                return inner
+            if ext_code in self.EXTENDED_PRIMITIVES:
+                return self.EXTENDED_PRIMITIVES[ext_code]
+            self.warnings.append('unknown extended type _%r' % ext_code)
+            return '_' + ext_code
+
+        # Primitive types
+        if ch in self.PRIMITIVES:
+            self._next()
+            return self.PRIMITIVES[ch]
+
+        raise ParseError('unknown type code %r at pos %d' % (ch, self.pos))
+
+    def _parse_qualified_name_type(self):
+        """Parse a qualified name used as a type (UDT name)."""
+        parts = []
+        while True:
+            if self._peek() == '@':
+                self._next()
+                if self._peek() == '@':
+                    self._next()
+                break
+            if self._peek() == '\x00':
+                break
+            if self._peek() == '?':
+                # ?0 backref or ?A anonymous
+                self._next()
+                if self._peek() == 'A':
+                    self._next()
+                    parts.insert(0, '`anonymous namespace\'')
+                else:
+                    idx = self._next()
+                    # Back-reference — TODO: resolve
+                continue
+            if self._peek() == '$':
+                self._next()
+                tmpl = self._parse_template_name()
+                parts.insert(0, self._render_template(tmpl))
+                continue
+            frag = self._parse_fragment_name()
+            parts.insert(0, frag.name)
+
+        return '::'.join(parts)
+
+    def _parse_function_indirect_type(self):
+        """Parse a function indirect type ($A)."""
+        func = self._parse_function_type(is_member=False, has_cv_mod=False)
+        # Render as function pointer
+        ret = func.return_type or 'void'
+        params = ', '.join(func.parameters) if func.parameters else 'void'
+        cc = func.calling_convention
+        if cc:
+            return '%s (%s*)(%s)' % (ret, cc, params)
+        return '%s (*)(%s)' % (ret, params)
+
+    def _parse_type_string(self):
+        """Parse a type string (for template args)."""
+        return self._parse_data_type()
+
+    # --- Number parsing ---
+
+    def _parse_encoded_number(self):
+        """Parse an encoded number (used in RTTI, thunks)."""
+        ch = self._next()
+        if ch == '?':
+            # Negative: next char + 1
+            sign = self._next()
+            return str(-ord(sign) + ord('A') - 1)
+        if ch == '@':
+            return '0'
+        if ch == '$':
+            # Hex encoding
+            high = self._next()
+            low = self._next()
+            return str(int(high + low, 16))
+        # Direct digit
+        result = 0
+        while ch != '@' and ch != '\x00':
+            if ch.isdigit():
+                result = result * 10 + int(ch)
+            ch = self._next()
+        return str(result)
+
+    # --- Rendering helpers (for inline type strings) ---
+
+    def _render_template(self, tmpl):
+        """Render a template name as a string."""
+        base = tmpl.base_name.name if hasattr(tmpl.base_name, 'name') else str(tmpl.base_name)
+        args_str = ','.join(str(a) for a in tmpl.args)
+        return '%s<%s>' % (base, args_str)
+
+    # --- Embedded name ---
+
+    def _parse_embedded_name(self):
+        """Parse an embedded object name (??? prefix)."""
+        # The third ? starts another symbol
+        # For now, parse as qualified name
+        return self._parse_qualified_name()

--- a/vivisect/demangle/msvc/renderer.py
+++ b/vivisect/demangle/msvc/renderer.py
@@ -1,0 +1,176 @@
+"""
+Renderer for MSVC C++ demangled AST nodes.
+
+Converts the parsed AST into a demangled string representation
+matching Microsoft's undname output format.
+"""
+
+import logging
+from vivisect.demangle.msvc import ast_nodes as ast
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['render']
+
+
+def render(symbol):
+    """Render an MSVCSymbol AST into a demangled string."""
+    if symbol is None:
+        return ''
+
+    parts = []
+
+    # Render type info (access modifiers, function/variable type)
+    type_info = symbol.type_info
+
+    # Build access/storage prefix
+    prefix = _build_prefix(type_info)
+    if prefix:
+        parts.append(prefix)
+
+    # Render the qualified name
+    name_str = _render_qualified_name(symbol.qualified_name)
+    if name_str:
+        parts.append(name_str)
+
+    # Render function signature or variable type
+    if isinstance(type_info, ast.FunctionType):
+        sig = _render_function_signature(type_info, name_str)
+        # Replace the name with the full signature
+        if parts and parts[-1] == name_str:
+            parts[-1] = sig
+        else:
+            parts.append(sig)
+    elif isinstance(type_info, ast.VariableInfo):
+        var_str = _render_variable(type_info, name_str)
+        if parts and parts[-1] == name_str:
+            parts[-1] = var_str
+        else:
+            parts.append(var_str)
+    elif isinstance(type_info, ast.VFTable):
+        vft_str = _render_vftable(type_info, name_str)
+        if parts and parts[-1] == name_str:
+            parts[-1] = vft_str
+        else:
+            parts.append(vft_str)
+
+    result = ' '.join(parts)
+    return result.strip()
+
+
+def _build_prefix(type_info):
+    """Build the access/storage modifier prefix."""
+    if type_info is None:
+        return ''
+
+    prefix_parts = []
+
+    if isinstance(type_info, ast.FunctionType):
+        if type_info.is_thunk:
+            prefix_parts.append('[thunk]:')
+        if type_info.access:
+            prefix_parts.append(type_info.access + ':')
+        if type_info.is_virtual:
+            prefix_parts.append('virtual')
+        if type_info.is_static:
+            prefix_parts.append('static')
+    elif isinstance(type_info, ast.VariableInfo):
+        if type_info.access:
+            prefix_parts.append(type_info.access + ':')
+        if type_info.is_static:
+            prefix_parts.append('static')
+
+    return ' '.join(prefix_parts)
+
+
+def _render_qualified_name(qname):
+    """Render a QualifiedName to string."""
+    if qname is None:
+        return ''
+
+    parts = []
+
+    # Scope
+    if qname.scope:
+        for s in qname.scope:
+            parts.append(_render_name_component(s))
+
+    # Basic name
+    parts.append(_render_name_component(qname.basic_name))
+
+    return '::'.join(parts)
+
+
+def _render_name_component(component):
+    """Render a single name component (FragmentName, SpecialName, TemplateName, etc.)."""
+    if isinstance(component, ast.FragmentName):
+        return component.name
+    elif isinstance(component, ast.SpecialName):
+        return component.name
+    elif isinstance(component, ast.TemplateName):
+        base = _render_name_component(component.base_name)
+        args = ','.join(str(a) for a in component.args)
+        return '%s<%s>' % (base, args)
+    elif isinstance(component, ast.AnonymousNamespace):
+        return '`anonymous-namespace\''
+    elif isinstance(component, str):
+        return component
+    else:
+        return str(component)
+
+
+def _render_function_signature(func, name_str):
+    """Render a function type as: ret_type calling_conv name(params) cv_modifiers."""
+    parts = []
+
+    # Return type — always show it, including void (matches MSVC undname output)
+    ret = func.return_type or ''
+    if ret:
+        parts.append(ret)
+
+    # Calling convention
+    cc = func.calling_convention or ''
+    if cc:
+        parts.append(cc)
+
+    # Function name (already rendered)
+    parts.append(name_str)
+
+    result = ' '.join(parts)
+
+    # Parameters
+    params = func.parameters
+    if not params:
+        params_str = 'void'
+    else:
+        param_strs = [p for p in params if p and p != 'void']
+        if not param_strs:
+            params_str = 'void'
+        else:
+            params_str = ', '.join(param_strs)
+
+    result += '(%s)' % params_str
+
+    # CV modifiers (const/volatile on this pointer)
+    if func.cv_modifiers:
+        result += ' ' + func.cv_modifiers
+
+    return result
+
+
+def _render_variable(var, name_str):
+    """Render a variable: type name."""
+    if var.is_guard:
+        return '`local static guard\'' if not name_str else name_str
+    var_type = var.var_type or ''
+    if var_type:
+        return '%s %s' % (var_type, name_str)
+    return name_str
+
+
+def _render_vftable(vft, name_str):
+    """Render a vtable/vbtable."""
+    if vft.scope is not None:
+        # VFTable with explicit scope
+        return 'const %s::`vftable\'' % _render_qualified_name(vft.scope)
+    return 'const %s::`vftable\'' % name_str

--- a/vivisect/demangle/objc/__init__.py
+++ b/vivisect/demangle/objc/__init__.py
@@ -1,0 +1,93 @@
+"""
+vivisect.demangle.objc - Objective-C symbol demangling.
+
+Objective-C symbols in Mach-O binaries use special prefixes:
+
+    _OBJC_CLASS_$_ClassName        - class reference
+    _OBJC_METACLASS_$_ClassName    - metaclass reference
+    _OBJC_IVAR_$_ClassName.ivar    - instance variable
+    _OBJC_EHTYPE_$_ClassName       - exception type
+    +[ClassName method]            - class method (already human-readable)
+    -[ClassName method]            - instance method (already human-readable)
+
+The ``_OBJC_*`` symbols are mostly already readable and just need the
+prefix stripped.  The ``+[``/``-[`` method syntax is not really mangled
+but is included here for completeness.
+"""
+
+import logging
+
+from vivisect.demangle.common import DemangledSymbol
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['demangle_objc']
+
+_OBJC_PREFIXES = (
+    ('_OBJC_CLASS_$_', 'class_ref'),
+    ('_OBJC_METACLASS_$_', 'metaclass_ref'),
+    ('_OBJC_IVAR_$_', 'ivar'),
+    ('_OBJC_EHTYPE_$_', 'exception_type'),
+    ('_OBJC_CLASSLIST_IMAGES_$_', 'classlist_images'),
+    ('_OBJC_CATEGORY_CLASS_$_', 'category_class'),
+    ('_OBJC_CATEGORY_$_', 'category'),
+)
+
+
+def demangle_objc(mangled, structured=False):
+    """
+    Demangle an Objective-C symbol.
+
+    Args:
+        mangled (str): The mangled ObjC symbol.
+        structured (bool): If True, return a DemangledSymbol.
+
+    Returns:
+        str or DemangledSymbol: The demangled symbol.
+    """
+    original = mangled
+
+    # Handle +[ClassName method] / -[ClassName method] syntax
+    # These are already human-readable; just return them
+    if mangled.startswith('+[') or mangled.startswith('-['):
+        if not structured:
+            return mangled
+        return DemangledSymbol(
+            format='objc',
+            full_name=mangled,
+            kind='method',
+            name=mangled,
+            original_mangled=original,
+        )
+
+    # Handle _OBJC_* prefixed symbols
+    for prefix, kind in _OBJC_PREFIXES:
+        if mangled.startswith(prefix):
+            name = mangled[len(prefix):]
+            if not structured:
+                return name
+            sym = DemangledSymbol(
+                format='objc',
+                full_name=name,
+                kind=kind,
+                name=name,
+                original_mangled=original,
+            )
+            # For ivar symbols, split on '.'
+            if '.' in name:
+                parts = name.split('.')
+                sym.scope = [parts[0]]
+                sym.name = parts[1] if len(parts) > 1 else name
+            return sym
+
+    # Not a recognized ObjC symbol — return as-is
+    if not structured:
+        return original
+
+    return DemangledSymbol(
+        format='objc',
+        full_name=original,
+        name=original,
+        original_mangled=original,
+        parse_warnings=['not a recognized Objective-C mangled symbol'],
+    )

--- a/vivisect/demangle/rust/__init__.py
+++ b/vivisect/demangle/rust/__init__.py
@@ -1,0 +1,40 @@
+"""
+vivisect.demangle.rust - Rust symbol demangling.
+
+Phase 0: Stub.  Phase 4 will implement both legacy (_Z) and v0 (_R) Rust
+mangling.
+
+Reference:
+    - RFC 2603 (Rust v0 mangling)
+    - rustc-demangle crate
+"""
+
+import logging
+
+from vivisect.demangle.common import DemangledSymbol, normalize_name
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['demangle_rust']
+
+
+def demangle_rust(mangled, structured=False):
+    """
+    Demangle a Rust mangled symbol.
+
+    Phase 0: Returns the original name.  Phase 4 will implement legacy
+    (_Z prefix, with $ escape decoding) and v0 (_R prefix, RFC 2603).
+    """
+    original = mangled
+    mangled = normalize_name(mangled)
+
+    if not structured:
+        return original
+
+    return DemangledSymbol(
+        format='rust',
+        full_name=original,
+        name=original,
+        original_mangled=original,
+        parse_warnings=['Rust demangler not yet implemented (Phase 4)'],
+    )

--- a/vivisect/demangle/rust/__init__.py
+++ b/vivisect/demangle/rust/__init__.py
@@ -1,8 +1,8 @@
 """
 vivisect.demangle.rust - Rust symbol demangling.
 
-Phase 0: Stub.  Phase 4 will implement both legacy (_Z) and v0 (_R) Rust
-mangling.
+Implements both legacy (_Z prefix, with $ escape decoding) and v0
+(_R prefix, RFC 2603) Rust mangling schemes.
 
 Reference:
     - RFC 2603 (Rust v0 mangling)
@@ -10,6 +10,7 @@ Reference:
 """
 
 import logging
+import re
 
 from vivisect.demangle.common import DemangledSymbol, normalize_name
 
@@ -22,19 +23,300 @@ def demangle_rust(mangled, structured=False):
     """
     Demangle a Rust mangled symbol.
 
-    Phase 0: Returns the original name.  Phase 4 will implement legacy
-    (_Z prefix, with $ escape decoding) and v0 (_R prefix, RFC 2603).
+    Handles both v0 (_R prefix, RFC 2603) and legacy (_Z prefix with
+    Rust-specific $ escape sequences).
     """
     original = mangled
     mangled = normalize_name(mangled)
 
-    if not structured:
+    demangled = None
+    parse_warnings = []
+
+    if mangled.startswith('_R'):
+        try:
+            demangled = _demangle_rust_v0(mangled)
+        except Exception as e:
+            logger.debug('Rust v0 parser failed for %r: %r', mangled, e)
+            parse_warnings.append('v0 parser error: %r' % e)
+    elif mangled.startswith('_Z') or mangled.startswith('__Z'):
+        try:
+            demangled = _demangle_rust_legacy(mangled)
+        except Exception as e:
+            logger.debug('Rust legacy parser failed for %r: %r', mangled, e)
+            parse_warnings.append('legacy parser error: %r' % e)
+
+    if demangled is None or demangled == mangled or not demangled:
+        if structured:
+            return DemangledSymbol(
+                format='rust',
+                full_name=original,
+                name=original,
+                original_mangled=original,
+                parse_warnings=parse_warnings or ['unable to demangle'],
+            )
         return original
 
-    return DemangledSymbol(
+    if not structured:
+        return demangled
+
+    sym = DemangledSymbol(
         format='rust',
-        full_name=original,
-        name=original,
+        full_name=demangled,
         original_mangled=original,
-        parse_warnings=['Rust demangler not yet implemented (Phase 4)'],
+        parse_warnings=parse_warnings,
     )
+    _parse_basic_structure(sym, demangled)
+    return sym
+
+
+# --- Rust v0 demangling (RFC 2603) ---
+
+def _demangle_rust_v0(mangled):
+    """Demangle a Rust v0 symbol (_R prefix)."""
+    s = mangled[2:]  # skip _R
+    dot_pos = s.find('.')
+    if dot_pos > 0:
+        s = s[:dot_pos]
+    parser = _RustV0Parser(s)
+    return parser.parse()
+
+
+class _RustV0Parser:
+    """Recursive descent parser for Rust v0 mangling (RFC 2603)."""
+
+    BASIC_TYPES = {
+        'a': 'i8', 'b': 'bool', 'c': 'char', 'd': 'f64',
+        'e': 'str', 'f': 'f32', 'h': 'u8', 'i': 'isize',
+        'j': 'usize', 'l': 'i32', 'm': 'u32', 'n': 'i128',
+        'o': 'u128', 's': 'i16', 't': 'u16', 'u': '()',
+        'v': '...', 'x': 'i64', 'y': 'u64', 'z': '!',
+        'p': '_',
+    }
+
+    def __init__(self, s):
+        self.s = s
+        self.pos = 0
+        self.warnings = []
+        self._substs = []
+
+    def _peek(self, offset=0):
+        idx = self.pos + offset
+        if idx >= len(self.s):
+            return '\x00'
+        return self.s[idx]
+
+    def _next(self):
+        if self.pos >= len(self.s):
+            raise ValueError('unexpected end of input')
+        ch = self.s[self.pos]
+        self.pos += 1
+        return ch
+
+    def parse(self):
+        result = self._parse_path()
+        return result
+
+    def _parse_path(self):
+        ch = self._peek()
+
+        if ch == 'N':
+            self._next()
+            ns = self._next()
+            self._parse_disambiguator()
+            path = self._parse_path()
+            name = self._parse_ident()
+            return '%s::%s' % (path, name)
+
+        if ch == 'I':
+            self._next()
+            path = self._parse_path()
+            args = self._parse_generic_args()
+            return '%s<%s>' % (path, args)
+
+        if ch == 'B':
+            self._next()
+            idx = self._parse_base62()
+            if idx < len(self._substs):
+                return self._substs[idx]
+            return '<backref:%d>' % idx
+
+        if ch == 'C':
+            self._next()
+            self._parse_disambiguator()
+            name = self._parse_ident()
+            return name
+
+        if ch == 'M':
+            self._next()
+            self._parse_disambiguator()
+            ty = self._parse_type()
+            return '<impl %s>' % ty
+
+        name = self._parse_ident()
+        return name
+
+    def _parse_ident(self):
+        length = self._parse_number()
+        if length == 0:
+            return ''
+        if self._peek() == '_':
+            self._next()
+        if self.pos + length > len(self.s):
+            raise ValueError('ident length exceeds input')
+        name = self.s[self.pos:self.pos + length]
+        self.pos += length
+
+        # Decode $ escape sequences
+        name = name.replace('$SP$', '@')
+        name = name.replace('$BP$', '*')
+        name = name.replace('$RF$', '&')
+        name = name.replace('$LT$', '<')
+        name = name.replace('$GT$', '>')
+        name = name.replace('$LP$', '(')
+        name = name.replace('$RP$', ')')
+        name = name.replace('$C$', ',')
+        name = re.sub(r'\$u([0-9a-fA-F]{2})\$',
+                       lambda m: chr(int(m.group(1), 16)), name)
+        return name
+
+    def _parse_number(self):
+        result = 0
+        while self._peek().isdigit():
+            result = result * 10 + int(self._next())
+        return result
+
+    def _parse_base62(self):
+        chars = []
+        while self._peek() != '_' and self._peek() != '\x00':
+            chars.append(self._next())
+        if self._peek() == '_':
+            self._next()
+        if not chars:
+            return 0
+        result = 0
+        for c in chars:
+            if c.isdigit():
+                v = int(c) + 1
+            elif c.islower():
+                v = ord(c) - ord('a') + 11
+            else:
+                v = ord(c) - ord('A') + 37
+            result = result * 62 + v
+        return result - 1
+
+    def _parse_disambiguator(self):
+        if self._peek() == 's':
+            self._next()
+            return self._parse_number()
+        return 0
+
+    def _parse_generic_args(self):
+        args = []
+        while self._peek() != 'E' and self._peek() != '\x00':
+            ty = self._parse_type()
+            args.append(ty)
+        if self._peek() == 'E':
+            self._next()
+        return ', '.join(args)
+
+    def _parse_type(self):
+        ch = self._peek()
+
+        if ch in self.BASIC_TYPES:
+            self._next()
+            return self.BASIC_TYPES[ch]
+
+        if ch == 'A':
+            self._next()
+            ty = self._parse_type()
+            n = self._parse_number()
+            return '[%s; %d]' % (ty, n)
+
+        if ch == 'S':
+            self._next()
+            ty = self._parse_type()
+            return '[%s]' % ty
+
+        if ch == 'R':
+            self._next()
+            ty = self._parse_type()
+            return '&%s' % ty
+
+        if ch == 'Q':
+            self._next()
+            ty = self._parse_type()
+            return '&mut %s' % ty
+
+        if ch == 'P':
+            self._next()
+            ty = self._parse_type()
+            return '*const %s' % ty
+
+        if ch == 'O':
+            self._next()
+            ty = self._parse_type()
+            return '*mut %s' % ty
+
+        if ch == 'T':
+            self._next()
+            args = []
+            while self._peek() != 'E' and self._peek() != '\x00':
+                args.append(self._parse_type())
+            if self._peek() == 'E':
+                self._next()
+            return '(%s)' % ', '.join(args)
+
+        if ch in ('C', 'N', 'M', 'I', 'B'):
+            return self._parse_path()
+
+        self._next()
+        return '?%s' % ch
+
+
+# --- Rust legacy demangling ---
+
+def _demangle_rust_legacy(mangled):
+    """Demangle a legacy Rust symbol (_Z prefix with $ escapes)."""
+    try:
+        from vivisect.demangle.itanium import demangle_itanium
+        result = demangle_itanium(mangled)
+        if result and result != mangled:
+            result = _decode_rust_escapes(result)
+            result = re.sub(r'\.h[0-9a-f]+$', '', result)
+            return result
+    except Exception as e:
+        logger.debug('Rust legacy Itanium fallback failed: %r', e)
+
+    s = mangled
+    if s.startswith('_Z'):
+        s = s[2:]
+    elif s.startswith('__Z'):
+        s = s[3:]
+    s = _decode_rust_escapes(s)
+    return s
+
+
+def _decode_rust_escapes(s):
+    s = s.replace('$SP$', '@')
+    s = s.replace('$BP$', '*')
+    s = s.replace('$RF$', '&')
+    s = s.replace('$LT$', '<')
+    s = s.replace('$GT$', '>')
+    s = s.replace('$LP$', '(')
+    s = s.replace('$RP$', ')')
+    s = s.replace('$C$', ',')
+    s = re.sub(r'\$u([0-9a-fA-F]{2})\$',
+               lambda m: chr(int(m.group(1), 16)), s)
+    return s
+
+
+def _parse_basic_structure(sym, demangled):
+    if '::' in demangled:
+        parts = demangled.rsplit('::', 1)
+        sym.scope = parts[0].split('::')
+        sym.name = parts[1]
+    else:
+        sym.name = demangled
+    if '<' in sym.name:
+        sym.is_template = True
+    sym.kind = 'function'

--- a/vivisect/demangle/rust/__init__.py
+++ b/vivisect/demangle/rust/__init__.py
@@ -4,9 +4,27 @@ vivisect.demangle.rust - Rust symbol demangling.
 Implements both legacy (_Z prefix, with $ escape decoding) and v0
 (_R prefix, RFC 2603) Rust mangling schemes.
 
-Reference:
+Full RFC 2603 v0 support includes:
+    - Crate paths (C), nested paths (N), impl paths (M, X, Y)
+    - Generic arguments (I) with lifetimes (L), const generics (K), types
+    - Function types (F) with binders (G), unsafe (U), ABI (K/C), params, return
+    - Dyn types (D) with trait bounds, associated types (p), lifetime
+    - References (R, Q) with lifetimes
+    - Pointers (P, O) - const/mut
+    - Arrays (A) with const length, slices (S)
+    - Tuples (T) with single-element trailing comma
+    - Back-references (B) with byte-offset resolution
+    - Lifetimes with depth tracking and for<> binders
+    - Const generics: bool, char, signed/unsigned integers, placeholder
+    - Punycode (RFC 3492) identifier decoding
+    - Namespace rendering: closures (::C), shims (::S), etc.
+    - Vendor suffix stripping (.llvm.<hash>, etc.)
+    - Instantiating crate suffix
+
+References:
     - RFC 2603 (Rust v0 mangling)
     - rustc-demangle crate
+    - LLVM RustDemangle.cpp
 """
 
 import logging
@@ -69,35 +87,71 @@ def demangle_rust(mangled, structured=False):
     return sym
 
 
-# --- Rust v0 demangling (RFC 2603) ---
+# ---------------------------------------------------------------------------
+# Rust v0 demangling (RFC 2603) - Full implementation
+# ---------------------------------------------------------------------------
+
+# Basic type tags -> Rust type names (RFC 2603 §2.3)
+_BASIC_TYPES = {
+    'a': 'i8', 'b': 'bool', 'c': 'char', 'd': 'f64',
+    'e': 'str', 'f': 'f32', 'h': 'u8', 'i': 'isize',
+    'j': 'usize', 'l': 'i32', 'm': 'u32', 'n': 'i128',
+    'o': 'u128', 's': 'i16', 't': 'u16', 'u': '()',
+    'v': '...', 'x': 'i64', 'y': 'u64', 'z': '!',
+    'p': '_',
+}
+
+# Unsigned integer type tags for const generics
+_CONST_UINT_TYPES = {'h', 't', 'm', 'y', 'o', 'j'}
+# Signed integer type tags for const generics
+_CONST_INT_TYPES = {'a', 's', 'l', 'x', 'n', 'i'}
+
+# Namespace special names (uppercase only)
+_NS_NAMES = {
+    'C': 'closure',
+    'S': 'shim',
+}
+
 
 def _demangle_rust_v0(mangled):
     """Demangle a Rust v0 symbol (_R prefix)."""
     s = mangled[2:]  # skip _R
+
+    # Strip vendor suffix (e.g. .llvm.<hash>)
     dot_pos = s.find('.')
     if dot_pos > 0:
         s = s[:dot_pos]
+
     parser = _RustV0Parser(s)
-    return parser.parse()
+    result = parser._parse_path(in_value=True)
+
+    # Check for instantiating crate suffix (another path starting with uppercase)
+    # This is a second path that follows the main path — we skip it
+    # (it's the crate that instantiated the symbol, not part of the name)
+    if parser.pos < len(s) and s[parser.pos].isupper():
+        try:
+            parser._parse_path(in_value=False)
+        except Exception:
+            pass
+
+    return result
 
 
 class _RustV0Parser:
-    """Recursive descent parser for Rust v0 mangling (RFC 2603)."""
+    """Recursive descent parser for Rust v0 mangling (RFC 2603).
 
-    BASIC_TYPES = {
-        'a': 'i8', 'b': 'bool', 'c': 'char', 'd': 'f64',
-        'e': 'str', 'f': 'f32', 'h': 'u8', 'i': 'isize',
-        'j': 'usize', 'l': 'i32', 'm': 'u32', 'n': 'i128',
-        'o': 'u128', 's': 'i16', 't': 'u16', 'u': '()',
-        'v': '...', 'x': 'i64', 'y': 'u64', 'z': '!',
-        'p': '_',
-    }
+    Implements the full grammar: paths, types, generic args, lifetimes,
+    const generics, function types, dyn types, back-references, and
+    Punycode identifier decoding.
+    """
 
     def __init__(self, s):
         self.s = s
         self.pos = 0
         self.warnings = []
-        self._substs = []
+        self._bound_lifetime_depth = 0
+
+    # --- Low-level helpers ---
 
     def _peek(self, offset=0):
         idx = self.pos + offset
@@ -107,173 +161,619 @@ class _RustV0Parser:
 
     def _next(self):
         if self.pos >= len(self.s):
-            raise ValueError('unexpected end of input')
+            raise ValueError('unexpected end of input at pos %d' % self.pos)
         ch = self.s[self.pos]
         self.pos += 1
         return ch
 
-    def parse(self):
-        result = self._parse_path()
-        return result
+    def _eat(self, ch):
+        """Consume a single character if it matches. Returns True/False."""
+        if self._peek() == ch:
+            self.pos += 1
+            return True
+        return False
 
-    def _parse_path(self):
-        ch = self._peek()
+    # --- Number parsing ---
 
-        if ch == 'N':
-            self._next()
-            ns = self._next()
-            self._parse_disambiguator()
-            path = self._parse_path()
-            name = self._parse_ident()
-            return '%s::%s' % (path, name)
-
-        if ch == 'I':
-            self._next()
-            path = self._parse_path()
-            args = self._parse_generic_args()
-            return '%s<%s>' % (path, args)
-
-        if ch == 'B':
-            self._next()
-            idx = self._parse_base62()
-            if idx < len(self._substs):
-                return self._substs[idx]
-            return '<backref:%d>' % idx
-
-        if ch == 'C':
-            self._next()
-            self._parse_disambiguator()
-            name = self._parse_ident()
-            return name
-
-        if ch == 'M':
-            self._next()
-            self._parse_disambiguator()
-            ty = self._parse_type()
-            return '<impl %s>' % ty
-
-        name = self._parse_ident()
-        return name
-
-    def _parse_ident(self):
-        length = self._parse_number()
-        if length == 0:
-            return ''
-        if self._peek() == '_':
-            self._next()
-        if self.pos + length > len(self.s):
-            raise ValueError('ident length exceeds input')
-        name = self.s[self.pos:self.pos + length]
-        self.pos += length
-
-        # Decode $ escape sequences
-        name = name.replace('$SP$', '@')
-        name = name.replace('$BP$', '*')
-        name = name.replace('$RF$', '&')
-        name = name.replace('$LT$', '<')
-        name = name.replace('$GT$', '>')
-        name = name.replace('$LP$', '(')
-        name = name.replace('$RP$', ')')
-        name = name.replace('$C$', ',')
-        name = re.sub(r'\$u([0-9a-fA-F]{2})\$',
-                       lambda m: chr(int(m.group(1), 16)), name)
-        return name
-
-    def _parse_number(self):
+    def _parse_decimal(self):
+        """Parse a decimal number (for ident lengths)."""
         result = 0
         while self._peek().isdigit():
             result = result * 10 + int(self._next())
         return result
 
-    def _parse_base62(self):
-        chars = []
-        while self._peek() != '_' and self._peek() != '\x00':
-            chars.append(self._next())
-        if self._peek() == '_':
-            self._next()
-        if not chars:
+    def _parse_digit_62(self):
+        """Parse a single base-62 digit. Returns int value.
+
+        0-9 = 0-9, a-z = 10-35, A-Z = 36-61
+        """
+        ch = self._next()
+        if ch.isdigit():
+            return int(ch)
+        elif ch.islower():
+            return 10 + (ord(ch) - ord('a'))
+        elif ch.isupper():
+            return 10 + 26 + (ord(ch) - ord('A'))
+        else:
+            raise ValueError('invalid base-62 digit: %r' % ch)
+
+    def _parse_integer_62(self):
+        """Parse a base-62 integer terminated by '_'.
+
+        Returns the decoded value. A lone '_' means 0.
+        Otherwise the value is (decoded) + 1.
+        """
+        if self._eat('_'):
             return 0
-        result = 0
-        for c in chars:
-            if c.isdigit():
-                v = int(c) + 1
-            elif c.islower():
-                v = ord(c) - ord('a') + 11
-            else:
-                v = ord(c) - ord('A') + 37
-            result = result * 62 + v
-        return result - 1
+        x = 0
+        while not self._eat('_'):
+            d = self._parse_digit_62()
+            x = x * 62 + d
+        return x + 1
+
+    def _parse_opt_integer_62(self, tag):
+        """Parse an optional base-62 integer prefixed by a tag character.
+
+        If tag is present, returns (value + 1). If not, returns 0.
+        """
+        if not self._eat(tag):
+            return 0
+        return self._parse_integer_62() + 1
 
     def _parse_disambiguator(self):
-        if self._peek() == 's':
-            self._next()
-            return self._parse_number()
-        return 0
+        """Parse an optional disambiguator (s prefix + base-62 number)."""
+        return self._parse_opt_integer_62('s')
+
+    def _parse_hex_nibbles(self):
+        """Parse hex nibbles terminated by '_'. Returns the hex string."""
+        start = self.pos
+        while True:
+            ch = self._next()
+            if ch in '0123456789abcdef':
+                continue
+            elif ch == '_':
+                break
+            else:
+                raise ValueError('invalid hex nibble: %r' % ch)
+        return self.s[start:self.pos - 1]
+
+    # --- Identifier parsing (with Punycode support) ---
+
+    def _parse_ident(self):
+        """Parse an identifier with optional Punycode encoding.
+
+        Grammar: [u] <decimal-number> [_] <bytes>
+        If 'u' prefix is present, the identifier is Punycode-encoded (RFC 3492).
+        """
+        is_punycode = self._eat('u')
+
+        length = self._parse_decimal()
+        if length == 0:
+            return ''
+
+        # Optional underscore separator after length
+        self._eat('_')
+
+        if self.pos + length > len(self.s):
+            raise ValueError('ident length %d exceeds input at pos %d' % (length, self.pos))
+
+        name = self.s[self.pos:self.pos + length]
+        self.pos += length
+
+        if is_punycode:
+            name = _punycode_decode_ident(name)
+
+        # Decode $ escape sequences (shouldn't appear in v0 but be safe)
+        name = _decode_rust_escapes(name)
+
+        return name
+
+    # --- Path parsing ---
+
+    def _parse_path(self, in_value=False):
+        """Parse a path (RFC 2603 §2.1).
+
+        Grammar:
+            C = crate          -> C <disambiguator> <ident>
+            N = nested         -> N <namespace> <path> <disambiguator> <ident>
+            M = impl           -> M <disambiguator> <path> <type>
+            X = impl-trait     -> X <disambiguator> <path> <type> <path>
+            Y = trait-def      -> Y <type> <path>
+            I = generic        -> I <path> {<generic-arg>} E
+            B = backref        -> B <base-62-number>
+
+        The in_value parameter controls whether `::` is inserted before
+        generic angle brackets. Top-level paths use in_value=True.
+        """
+        ch = self._next()
+
+        if ch == 'C':
+            self._parse_disambiguator()
+            return self._parse_ident()
+
+        if ch == 'N':
+            ns = self._next()
+            if not ns.isalpha():
+                raise ValueError('invalid namespace: %r' % ns)
+            path = self._parse_path(in_value=in_value)
+            dis = self._parse_disambiguator()
+            name = self._parse_ident()
+
+            if ns.islower():
+                # Type namespace: just path::name (no decoration)
+                if name:
+                    return '%s::%s' % (path, name)
+                return path
+            else:
+                # Value namespace: path::{ns_name:name#dis} or path::{ns_name#dis}
+                ns_name = _NS_NAMES.get(ns, ns)
+                if name:
+                    return '%s::{%s:%s#%d}' % (path, ns_name, name, dis)
+                else:
+                    return '%s::{%s#%d}' % (path, ns_name, dis)
+
+        if ch == 'M':
+            self._parse_disambiguator()
+            impl_path = self._parse_path()
+            ty = self._parse_type()
+            return '<%s>' % ty
+
+        if ch == 'X':
+            self._parse_disambiguator()
+            impl_path = self._parse_path()
+            ty = self._parse_type()
+            trait_path = self._parse_path()
+            return '<%s as %s>' % (ty, trait_path)
+
+        if ch == 'Y':
+            ty = self._parse_type()
+            trait_path = self._parse_path()
+            return '<%s as %s>' % (ty, trait_path)
+
+        if ch == 'I':
+            path = self._parse_path(in_value=in_value)
+            args = self._parse_generic_args()
+            # Top-level (in_value=True) gets `::` before `<` per RFC 2603
+            sep = '::' if in_value else ''
+            return '%s%s<%s>' % (path, sep, args)
+
+        if ch == 'B':
+            idx = self._parse_integer_62()
+            # Back-reference: save and restore position
+            # The backref index is a byte offset (0-based from start of path)
+            save_pos = self.pos
+            self.pos = idx
+            result = self._parse_path(in_value=in_value)
+            self.pos = save_pos
+            return result
+
+        raise ValueError('invalid path tag: %r at pos %d' % (ch, self.pos - 1))
 
     def _parse_generic_args(self):
+        """Parse generic arguments (RFC 2603 §2.2).
+
+        Grammar: {<generic-arg>} E
+        Generic arg = L <lifetime> | K <const> | <type>
+        """
         args = []
-        while self._peek() != 'E' and self._peek() != '\x00':
-            ty = self._parse_type()
-            args.append(ty)
-        if self._peek() == 'E':
-            self._next()
+        while not self._eat('E'):
+            if self.pos >= len(self.s):
+                raise ValueError('unexpected end of input in generic args')
+            arg = self._parse_generic_arg()
+            args.append(arg)
         return ', '.join(args)
 
+    def _parse_generic_arg(self):
+        """Parse a single generic argument."""
+        if self._eat('L'):
+            lt = self._parse_integer_62()
+            return self._format_lifetime(lt)
+        if self._eat('K'):
+            return self._parse_const()
+        return self._parse_type()
+
+    # --- Type parsing ---
+
     def _parse_type(self):
-        ch = self._peek()
+        """Parse a type (RFC 2603 §2.3).
 
-        if ch in self.BASIC_TYPES:
-            self._next()
-            return self.BASIC_TYPES[ch]
+        Grammar:
+            Basic types (single char)
+            R = &<type>         (shared reference, optional lifetime)
+            Q = &mut <type>     (mutable reference, optional lifetime)
+            P = *const <type>   (const pointer)
+            O = *mut <type>     (mut pointer)
+            A = [<type>; <const>]
+            S = [<type>]        (slice)
+            T = ({<type>}+) E   (tuple)
+            F = fn(...) -> ...  (function type)
+            D = dyn ...         (dyn trait type)
+            B = backref
+            Path types (C, N, M, X, Y, I)
+        """
+        ch = self._next()
 
-        if ch == 'A':
-            self._next()
-            ty = self._parse_type()
-            n = self._parse_number()
-            return '[%s; %d]' % (ty, n)
+        # Basic types
+        if ch in _BASIC_TYPES:
+            return _BASIC_TYPES[ch]
 
-        if ch == 'S':
-            self._next()
-            ty = self._parse_type()
-            return '[%s]' % ty
-
+        # References
         if ch == 'R':
-            self._next()
+            lifetime = ''
+            if self._eat('L'):
+                lt = self._parse_integer_62()
+                if lt != 0:
+                    lifetime = self._format_lifetime(lt) + ' '
             ty = self._parse_type()
-            return '&%s' % ty
+            return '&%s%s' % (lifetime, ty)
 
         if ch == 'Q':
-            self._next()
+            lifetime = ''
+            if self._eat('L'):
+                lt = self._parse_integer_62()
+                if lt != 0:
+                    lifetime = self._format_lifetime(lt) + ' '
             ty = self._parse_type()
-            return '&mut %s' % ty
+            return '&mut %s%s' % (lifetime, ty)
 
+        # Pointers
         if ch == 'P':
-            self._next()
             ty = self._parse_type()
             return '*const %s' % ty
 
         if ch == 'O':
-            self._next()
             ty = self._parse_type()
             return '*mut %s' % ty
 
+        # Arrays and slices
+        if ch == 'A':
+            ty = self._parse_type()
+            const = self._parse_const()
+            return '[%s; %s]' % (ty, const)
+
+        if ch == 'S':
+            ty = self._parse_type()
+            return '[%s]' % ty
+
+        # Tuples
         if ch == 'T':
-            self._next()
             args = []
-            while self._peek() != 'E' and self._peek() != '\x00':
+            while not self._eat('E'):
+                if self.pos >= len(self.s):
+                    raise ValueError('unexpected end of input in tuple')
                 args.append(self._parse_type())
-            if self._peek() == 'E':
-                self._next()
+            if len(args) == 1:
+                return '(%s,)' % args[0]
             return '(%s)' % ', '.join(args)
 
-        if ch in ('C', 'N', 'M', 'I', 'B'):
-            return self._parse_path()
+        # Function types
+        if ch == 'F':
+            return self._parse_fn_type()
 
-        self._next()
-        return '?%s' % ch
+        # Dyn trait types
+        if ch == 'D':
+            return self._parse_dyn_type()
+
+        # Back-reference
+        if ch == 'B':
+            idx = self._parse_integer_62()
+            save_pos = self.pos
+            self.pos = idx
+            result = self._parse_type()
+            self.pos = save_pos
+            return result
+
+        # Path types - back up and parse as path
+        self.pos -= 1
+        return self._parse_path()
+
+    def _parse_fn_type(self):
+        """Parse a function type (RFC 2603 §2.3.F).
+
+        Grammar: F [G <bound-lifetimes>] [U] [K <abi>] {<type>} E <type>
+        The return type is omitted if it's the unit type 'u'.
+        """
+        # Optional binder (G prefix + base-62 count of bound lifetimes)
+        bound_lifetimes = self._parse_opt_integer_62('G')
+
+        prefix = ''
+        if bound_lifetimes > 0:
+            lts = []
+            for i in range(bound_lifetimes):
+                self._bound_lifetime_depth += 1
+                lts.append(self._format_lifetime(1))
+            prefix = 'for<%s> ' % ', '.join(lts)
+            # Note: bound_lifetime_depth stays incremented during type parsing,
+            # then we decrement after the fn type is fully parsed
+
+        # Optional unsafe
+        is_unsafe = self._eat('U')
+
+        # Optional ABI
+        abi = ''
+        if self._eat('K'):
+            if self._eat('C'):
+                abi = 'extern "C" '
+            else:
+                # Custom ABI - read as ident
+                abi_ident = self._parse_ident()
+                if abi_ident:
+                    abi = 'extern "%s" ' % abi_ident
+
+        fn_prefix = prefix
+        if is_unsafe:
+            fn_prefix += 'unsafe '
+        fn_prefix += abi
+        fn_prefix += 'fn('
+
+        # Parameters
+        params = []
+        while not self._eat('E'):
+            if self.pos >= len(self.s):
+                raise ValueError('unexpected end of input in fn params')
+            params.append(self._parse_type())
+
+        # Return type
+        ret = self._parse_type()
+        # Decrement bound lifetime depth after the fn type is parsed
+        self._bound_lifetime_depth -= bound_lifetimes
+
+        if ret == '()':
+            return '%s%s)' % (fn_prefix, ', '.join(params))
+        return '%s%s) -> %s' % (fn_prefix, ', '.join(params), ret)
+
+    def _parse_dyn_type(self):
+        """Parse a dyn trait type (RFC 2603 §2.3.D).
+
+        Grammar: D [G <bound-lifetimes>] {<dyn-trait>} E L <lifetime>
+        dyn-trait = <path> {p <ident> <type>}
+        """
+        # Optional binder
+        bound_lifetimes = self._parse_opt_integer_62('G')
+
+        prefix = 'dyn '
+        if bound_lifetimes > 0:
+            lts = []
+            for i in range(bound_lifetimes):
+                self._bound_lifetime_depth += 1
+                lts.append(self._format_lifetime(1))
+            prefix = 'for<%s> dyn ' % ', '.join(lts)
+            # bound_lifetime_depth stays incremented during trait parsing
+
+        # Parse dyn traits
+        traits = []
+        while not self._eat('E'):
+            if self.pos >= len(self.s):
+                raise ValueError('unexpected end of input in dyn traits')
+            traits.append(self._parse_dyn_trait())
+
+        # Lifetime
+        lifetime = ''
+        if self._eat('L'):
+            lt = self._parse_integer_62()
+            if lt != 0:
+                lifetime = ' + ' + self._format_lifetime(lt)
+
+        # Decrement bound lifetime depth after dyn type is parsed
+        self._bound_lifetime_depth -= bound_lifetimes
+
+        return '%s%s%s' % (prefix, ' + '.join(traits), lifetime)
+
+    def _parse_dyn_trait(self):
+        """Parse a single dyn trait (RFC 2603 §2.3.D).
+
+        Grammar: <path> {p <ident> <type>}
+        The path may have open generics.
+        """
+        path = self._parse_path()
+
+        # Parse associated type bindings (p prefix)
+        bindings = []
+        while self._eat('p'):
+            name = self._parse_ident()
+            ty = self._parse_type()
+            bindings.append('%s = %s' % (name, ty))
+
+        if bindings:
+            return '%s<%s>' % (path, ', '.join(bindings))
+        return path
+
+    # --- Const parsing ---
+
+    def _parse_const(self):
+        """Parse a const generic value (RFC 2603 §2.2.K).
+
+        Grammar: K <const>
+        const = B <backref> | <type-tag> [n] <hex-nibbles>_
+                p = placeholder (_)
+        """
+        if self._eat('B'):
+            idx = self._parse_integer_62()
+            save_pos = self.pos
+            self.pos = idx
+            result = self._parse_const()
+            self.pos = save_pos
+            return result
+
+        ty_tag = self._next()
+
+        if ty_tag == 'p':
+            return '_'
+
+        if ty_tag == 'b':
+            # bool
+            hex_val = self._parse_hex_nibbles()
+            if hex_val == '0':
+                return 'false'
+            elif hex_val == '1':
+                return 'true'
+            else:
+                raise ValueError('invalid bool const: 0x%s' % hex_val)
+
+        if ty_tag == 'c':
+            # char
+            hex_val = self._parse_hex_nibbles()
+            if len(hex_val) > 8:
+                raise ValueError('char const too long: 0x%s' % hex_val)
+            char_val = int(hex_val, 16)
+            return repr(chr(char_val))
+
+        if ty_tag in _CONST_UINT_TYPES:
+            # Unsigned integer
+            hex_val = self._parse_hex_nibbles()
+            if len(hex_val) > 16:
+                return '0x%s' % hex_val
+            return str(int(hex_val, 16))
+
+        if ty_tag in _CONST_INT_TYPES:
+            # Signed integer
+            negative = self._eat('n')
+            hex_val = self._parse_hex_nibbles()
+            if len(hex_val) > 16:
+                val = '0x%s' % hex_val
+            else:
+                val = str(int(hex_val, 16))
+            return '-%s' % val if negative else val
+
+        raise ValueError('invalid const type tag: %r' % ty_tag)
+
+    # --- Lifetime formatting ---
+
+    def _format_lifetime(self, index):
+        """Format a lifetime from a de Bruijn index.
+
+        RFC 2603 uses de Bruijn indexing for lifetimes:
+            - index 0 = anonymous lifetime ('_)
+            - index N > 0 = the Nth bound lifetime, counting from the
+              innermost binder outward
+
+        The bound_lifetime_depth tracks how many binders we're inside.
+        At depth D, lifetime index K (K > 0) refers to the binder at
+        level D - K. If D - K == 0, it's the innermost -> 'a.
+        If D - K == 1, it's the next outer -> 'b, etc.
+        """
+        if index == 0:
+            return "'_"
+
+        depth = self._bound_lifetime_depth - index
+        if depth < 0:
+            # Lifetime references outside any binder — graceful fallback
+            return "'_"
+        if depth < 26:
+            return "'%s" % chr(ord('a') + depth)
+        return "'_%d" % depth
 
 
-# --- Rust legacy demangling ---
+# ---------------------------------------------------------------------------
+# Punycode decoding (RFC 3492)
+# ---------------------------------------------------------------------------
+
+def _punycode_decode_ident(encoded):
+    """Decode a Punycode-encoded Rust identifier.
+
+    The identifier may contain a '_' separator between the ASCII prefix
+    and the Punycode suffix. If there's no '_', the entire string is
+    Punycode.
+    """
+    # Split on the last underscore
+    if '_' in encoded:
+        idx = encoded.rfind('_')
+        ascii_part = encoded[:idx]
+        punycode_part = encoded[idx + 1:]
+    else:
+        ascii_part = ''
+        punycode_part = encoded
+
+    if not punycode_part:
+        return ascii_part
+
+    try:
+        decoded = _punycode_decode(ascii_part, punycode_part)
+        return decoded
+    except Exception:
+        # Fallback: show as punycode{...}
+        if ascii_part:
+            return 'punycode{%s-%s}' % (ascii_part, punycode_part)
+        return 'punycode{%s}' % punycode_part
+
+
+def _punycode_decode(ascii_prefix, punycode_str):
+    """Decode a Punycode string (RFC 3492).
+
+    Parameters:
+        ascii_prefix: the basic (ASCII) code points that appear before
+                      the Punycode suffix
+        punycode_str: the Punycode-encoded suffix (base-36 variable-length
+                      integers)
+    """
+    output = list(ascii_prefix)
+    base = 36
+    t_min = 1
+    t_max = 26
+    skew = 38
+    damp = 700
+    bias = 72
+    n = 0x80  # initial value for code point
+    i = 0
+    idx = 0  # position in punycode_str
+
+    output_len = len(output)
+
+    while idx < len(punycode_str):
+        old_i = i
+        w = 1
+        k = base
+        while True:
+            if idx >= len(punycode_str):
+                raise ValueError('punycode: premature end of input')
+            ch = punycode_str[idx]
+            idx += 1
+
+            # In standard Punycode, digits are a-z=0-25, 0-5=26-35
+            if 'a' <= ch <= 'z':
+                digit = ord(ch) - ord('a')
+            elif '0' <= ch <= '9':
+                digit = 26 + (ord(ch) - ord('0'))
+            else:
+                raise ValueError('punycode: invalid char %r' % ch)
+
+            i += digit * w
+            t = min(max(k - bias, t_min), t_max)
+            if digit < t:
+                break
+            w *= (base - t)
+            k += base
+
+        output_len += 1
+        delta = i - old_i
+        delta = delta // output_len if output_len > 0 else delta
+
+        # Bias adaptation
+        if old_i == 0:
+            delta //= damp
+        else:
+            delta //= 2
+
+        delta += delta // output_len
+        k = 0
+        while delta > ((base - t_min) * t_max) // 2:
+            delta = delta // (base - t_min)
+            k += base
+        bias = k + ((base - t_min + 1) * delta) // (delta + skew)
+
+        n += i // output_len
+        i = i % output_len
+
+        # Insert code point n at position i
+        output.insert(i, chr(n))
+        i += 1
+
+    return ''.join(output)
+
+
+# ---------------------------------------------------------------------------
+# Rust legacy demangling
+# ---------------------------------------------------------------------------
 
 def _demangle_rust_legacy(mangled):
     """Demangle a legacy Rust symbol (_Z prefix with $ escapes)."""
@@ -297,6 +797,7 @@ def _demangle_rust_legacy(mangled):
 
 
 def _decode_rust_escapes(s):
+    """Decode Rust-specific $ escape sequences."""
     s = s.replace('$SP$', '@')
     s = s.replace('$BP$', '*')
     s = s.replace('$RF$', '&')
@@ -305,12 +806,51 @@ def _decode_rust_escapes(s):
     s = s.replace('$LP$', '(')
     s = s.replace('$RP$', ')')
     s = s.replace('$C$', ',')
+    s = s.replace('$u7e$', '~')
+    s = s.replace('$u20$', ' ')
+    s = s.replace('$u27$', "'")
+    s = s.replace('$u3d$', '=')
+    s = s.replace('$u5b$', '[')
+    s = s.replace('$u5d$', ']')
+    s = s.replace('$u7b$', '{')
+    s = s.replace('$u7d$', '}')
+    s = s.replace('$u22$', '"')
+    s = s.replace('$u3c$', '<')
+    s = s.replace('$u3e$', '>')
+    s = s.replace('$u3b$', ';')
+    s = s.replace('$u2e$', '.')
+    s = s.replace('$u2d$', '-')
+    s = s.replace('$u2b$', '+')
+    s = s.replace('$u2f$', '/')
+    s = s.replace('$u5f$', '_')
+    s = s.replace('$u21$', '!')
+    s = s.replace('$u23$', '#')
+    s = s.replace('$u24$', '$')
+    s = s.replace('$u25$', '%')
+    s = s.replace('$u26$', '&')
+    s = s.replace('$u28$', '(')
+    s = s.replace('$u29$', ')')
+    s = s.replace('$u2a$', '*')
+    s = s.replace('$u2c$', ',')
+    s = s.replace('$u3a$', ':')
+    s = s.replace('$u3f$', '?')
+    s = s.replace('$u40$', '@')
+    s = s.replace('$u5c$', '\\\\')
+    s = s.replace('$u7c$', '|')
+    s = s.replace('$u60$', '`')
+    s = s.replace('$u5e$', '^')
+    # Generic $uXX$ hex escape (must be last)
     s = re.sub(r'\$u([0-9a-fA-F]{2})\$',
                lambda m: chr(int(m.group(1), 16)), s)
     return s
 
 
+# ---------------------------------------------------------------------------
+# Structured output helper
+# ---------------------------------------------------------------------------
+
 def _parse_basic_structure(sym, demangled):
+    """Parse basic structure from a demangled Rust name."""
     if '::' in demangled:
         parts = demangled.rsplit('::', 1)
         sym.scope = parts[0].split('::')

--- a/vivisect/demangle/swift/__init__.py
+++ b/vivisect/demangle/swift/__init__.py
@@ -1,0 +1,37 @@
+"""
+vivisect.demangle.swift - Swift symbol demangling ($s / _T0 / $S prefix).
+
+Phase 0: Stub.  Phase 5 will implement the Swift demangler.
+
+Reference:
+    - Swift mangling specification (swift-mangling.rst)
+"""
+
+import logging
+
+from vivisect.demangle.common import DemangledSymbol, normalize_name
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['demangle_swift']
+
+
+def demangle_swift(mangled, structured=False):
+    """
+    Demangle a Swift mangled symbol ($s / _T0 / $S prefix).
+
+    Phase 0: Returns the original name.
+    """
+    original = mangled
+    mangled = normalize_name(mangled)
+
+    if not structured:
+        return original
+
+    return DemangledSymbol(
+        format='swift',
+        full_name=original,
+        name=original,
+        original_mangled=original,
+        parse_warnings=['Swift demangler not yet implemented (Phase 5)'],
+    )

--- a/vivisect/demangle/swift/__init__.py
+++ b/vivisect/demangle/swift/__init__.py
@@ -1,13 +1,16 @@
 """
 vivisect.demangle.swift - Swift symbol demangling ($s / _T0 / $S prefix).
 
-Phase 0: Stub.  Phase 5 will implement the Swift demangler.
+Swift mangling is complex. This implementation handles common patterns
+and falls back gracefully for unsupported symbols.
 
 Reference:
     - Swift mangling specification (swift-mangling.rst)
+    - LLVM SwiftDemangle.cpp
 """
 
 import logging
+import re
 
 from vivisect.demangle.common import DemangledSymbol, normalize_name
 
@@ -17,21 +20,103 @@ __all__ = ['demangle_swift']
 
 
 def demangle_swift(mangled, structured=False):
-    """
-    Demangle a Swift mangled symbol ($s / _T0 / $S prefix).
-
-    Phase 0: Returns the original name.
-    """
+    """Demangle a Swift mangled symbol ($s / _T0 / $S prefix)."""
     original = mangled
     mangled = normalize_name(mangled)
 
-    if not structured:
+    demangled = None
+    parse_warnings = []
+
+    try:
+        demangled = _demangle_swift_basic(mangled)
+        if demangled and demangled != mangled:
+            parse_warnings = ['basic Swift demangling (not full parser)']
+        else:
+            demangled = None
+    except Exception as e:
+        logger.debug('Swift parser failed for %r: %r', mangled, e)
+        parse_warnings.append('parser error: %r' % e)
+
+    if demangled is None or not demangled:
+        if structured:
+            return DemangledSymbol(
+                format='swift',
+                full_name=original,
+                name=original,
+                original_mangled=original,
+                parse_warnings=parse_warnings or ['unable to demangle'],
+            )
         return original
 
-    return DemangledSymbol(
+    if not structured:
+        return demangled
+
+    sym = DemangledSymbol(
         format='swift',
-        full_name=original,
-        name=original,
+        full_name=demangled,
         original_mangled=original,
-        parse_warnings=['Swift demangler not yet implemented (Phase 5)'],
+        parse_warnings=parse_warnings,
     )
+    _parse_basic_structure(sym, demangled)
+    return sym
+
+
+def _demangle_swift_basic(mangled):
+    """Basic Swift symbol demangling.
+
+    Swift symbols use length-prefixed names for modules and functions.
+    Pattern: $s<module_length><module><func_length><func>...
+    """
+    if mangled.startswith('$s'):
+        s = mangled[2:]
+    elif mangled.startswith('$S'):
+        s = mangled[2:]
+    elif mangled.startswith('_T0'):
+        s = mangled[3:]
+    else:
+        return None
+
+    parts = []
+    pos = 0
+
+    while pos < len(s):
+        # Parse length-prefixed name
+        length = 0
+        while pos < len(s) and s[pos].isdigit():
+            length = length * 10 + int(s[pos])
+            pos += 1
+
+        if length == 0 or pos + length > len(s):
+            break
+
+        name = s[pos:pos + length]
+        pos += length
+
+        name = _decode_swift_escapes(name)
+        parts.append(name)
+
+        # Skip type encoding (non-digit characters between names)
+        while pos < len(s) and not s[pos].isdigit():
+            pos += 1
+
+    if parts:
+        return '.'.join(parts)
+
+    return None
+
+
+def _decode_swift_escapes(s):
+    """Decode Swift-specific escape sequences in names."""
+    s = re.sub(r'\$([0-9A-Fa-f]{2})\$',
+               lambda m: chr(int(m.group(1), 16)), s)
+    return s
+
+
+def _parse_basic_structure(sym, demangled):
+    if '.' in demangled:
+        parts = demangled.rsplit('.', 1)
+        sym.scope = parts[0].split('.')
+        sym.name = parts[1]
+    else:
+        sym.name = demangled
+    sym.kind = 'function'

--- a/vivisect/demangle/swift/__init__.py
+++ b/vivisect/demangle/swift/__init__.py
@@ -1,12 +1,35 @@
 """
 vivisect.demangle.swift - Swift symbol demangling ($s / _T0 / $S prefix).
 
-Swift mangling is complex. This implementation handles common patterns
-and falls back gracefully for unsupported symbols.
+Swift mangling is a postfix-operator language with 800+ grammar productions.
+This implementation handles the common cases found in real-world binaries:
 
-Reference:
+    - Module + entity names (length-prefixed identifiers)
+    - Function/entity kinds (v=variable, F=function, etc.)
+    - Basic type operators (i=int, d=double, y=void, etc.)
+    - Class/struct/enum types (C, V, O prefixes)
+    - Protocol types (P prefix)
+    - Generic substitutions (G prefix)
+    - Type lists and function signatures
+    - Protocol conformance (Hp/HpX)
+    - Opaque return types (Qo)
+    - Back-references (A prefix)
+    - Substitutions (standard substitutions for common Swift types)
+    - Mangling version prefixes ($s, $S, _T0, $e)
+
+Not yet implemented:
+    - Full postfix operator stack machine
+    - All 800+ grammar productions
+    - Closure types (K)
+    - Associated types (Q)
+    - Symbolic references (binary control chars)
+    - Full generic signature parsing
+    - Accessor kinds (getter/setter/willSet/didSet)
+
+References:
     - Swift mangling specification (swift-mangling.rst)
     - LLVM SwiftDemangle.cpp
+    - swift/lib/Demangling/Demangler.cpp
 """
 
 import logging
@@ -20,7 +43,15 @@ __all__ = ['demangle_swift']
 
 
 def demangle_swift(mangled, structured=False):
-    """Demangle a Swift mangled symbol ($s / _T0 / $S prefix)."""
+    """Demangle a Swift mangled symbol ($s / _T0 / $S prefix).
+
+    Args:
+        mangled: The mangled symbol string.
+        structured: If True, return a DemangledSymbol object.
+
+    Returns:
+        The demangled name string, or DemangledSymbol if structured=True.
+    """
     original = mangled
     mangled = normalize_name(mangled)
 
@@ -28,16 +59,26 @@ def demangle_swift(mangled, structured=False):
     parse_warnings = []
 
     try:
-        demangled = _demangle_swift_basic(mangled)
-        if demangled and demangled != mangled:
-            parse_warnings = ['basic Swift demangling (not full parser)']
-        else:
-            demangled = None
+        parser = _SwiftParser(mangled)
+        demangled = parser.parse()
+        parse_warnings = parser.warnings
     except Exception as e:
         logger.debug('Swift parser failed for %r: %r', mangled, e)
         parse_warnings.append('parser error: %r' % e)
 
-    if demangled is None or not demangled:
+    if demangled is None or not demangled or demangled == mangled:
+        # Fallback to basic extraction
+        try:
+            demangled = _demangle_swift_basic(mangled)
+            if demangled and demangled != mangled:
+                parse_warnings = parse_warnings or ['basic extraction fallback']
+            else:
+                demangled = None
+        except Exception as e:
+            logger.debug('Swift basic fallback failed for %r: %r', mangled, e)
+            parse_warnings.append('basic fallback error: %r' % e)
+
+    if demangled is None or not demangled or demangled == mangled:
         if structured:
             return DemangledSymbol(
                 format='swift',
@@ -61,11 +102,433 @@ def demangle_swift(mangled, structured=False):
     return sym
 
 
-def _demangle_swift_basic(mangled):
-    """Basic Swift symbol demangling.
+# Swift basic type operators (postfix)
+_SWIFT_TYPES = {
+    'b': 'Builtin.BridgeObject',
+    'B': 'Builtin.BridgeObject',
+    'c': 'Builtin.BridgeObject',
+    'd': 'Double',
+    'f': 'Float',
+    'i': 'Int',
+    'h': 'Builtin.Word',
+    'l': 'Builtin.IntLiteral',
+    'n': 'Builtin.UnknownPointer',
+    'p': 'Builtin.RawPointer',
+    'q': 'Builtin.UnknownPointer',
+    'r': 'Builtin.UnknownPointer',
+    's': 'String',
+    't': 'Builtin.BridgeObject',
+    'u': 'UInt',
+    'v': 'Builtin.BridgeObject',
+    'w': 'Builtin.Word',
+    'x': 'Builtin.Int64',
+    'y': 'Void',  # also used as empty type list
+    'z': 'Builtin.UnknownPointer',
+    'A': 'Builtin.BridgeObject',
+    'C': 'Builtin.BridgeObject',
+    'D': 'Builtin.BridgeObject',
+    'E': 'Builtin.BridgeObject',
+    'F': 'Builtin.BridgeObject',
+    'G': 'Builtin.BridgeObject',
+    'H': 'Builtin.BridgeObject',
+    'I': 'Builtin.BridgeObject',
+    'J': 'Builtin.BridgeObject',
+    'K': 'Builtin.BridgeObject',
+    'L': 'Builtin.BridgeObject',
+    'M': 'Builtin.BridgeObject',
+    'N': 'Builtin.BridgeObject',
+    'O': 'Builtin.BridgeObject',
+    'P': 'Builtin.BridgeObject',
+    'Q': 'Builtin.BridgeObject',
+    'R': 'Builtin.BridgeObject',
+    'S': 'Builtin.BridgeObject',
+    'T': 'Builtin.BridgeObject',
+    'U': 'Builtin.BridgeObject',
+    'V': 'Builtin.BridgeObject',
+    'W': 'Builtin.BridgeObject',
+    'X': 'Builtin.BridgeObject',
+    'Y': 'Builtin.BridgeObject',
+    'Z': 'Builtin.BridgeObject',
+}
 
-    Swift symbols use length-prefixed names for modules and functions.
-    Pattern: $s<module_length><module><func_length><func>...
+# Standard substitutions
+_SWIFT_SUBS = {
+    'S_': 'Swift',  # The Swift module itself
+    'SQ': 'Swift.Optional',
+    'Sg': 'Swift.Optional<...>',
+    'Sb': 'Swift.Bool',
+    'Si': 'Swift.Int',
+    'Sd': 'Swift.Double',
+    'Ss': 'Swift.String',
+    'Sf': 'Swift.Float',
+    'Su': 'Swift.UInt',
+    'SS': 'Swift.String',
+    'Sa': 'Swift.Array',
+    'SD': 'Swift.Dictionary',
+    'SN': 'Swift.Int',
+    'Sx': 'Swift.Int',
+    'Sy': 'Void',
+}
+
+
+class _SwiftParser:
+    """Parser for Swift mangled symbols.
+
+    Implements a subset of the Swift mangling grammar sufficient for
+    common symbols found in real-world binaries. The parser uses a
+    recursive descent approach for the most common productions.
+    """
+
+    def __init__(self, mangled):
+        self.s = mangled
+        self.pos = 0
+        self.warnings = []
+        self._subs = []  # Substitution table
+        self._depth = 0  # Recursion depth guard
+
+    def _peek(self, offset=0):
+        idx = self.pos + offset
+        if idx >= len(self.s):
+            return '\x00'
+        return self.s[idx]
+
+    def _next(self):
+        if self.pos >= len(self.s):
+            raise ValueError('unexpected end of input at pos %d' % self.pos)
+        ch = self.s[self.pos]
+        self.pos += 1
+        return ch
+
+    def _eat(self, ch):
+        if self._peek() == ch:
+            self.pos += 1
+            return True
+        return False
+
+    def _at_end(self):
+        return self.pos >= len(self.s)
+
+    def _parse_number(self):
+        """Parse a decimal number (for ident lengths)."""
+        result = 0
+        while self._peek().isdigit():
+            result = result * 10 + int(self._next())
+        return result
+
+    def parse(self):
+        """Entry point: parse a Swift mangled symbol."""
+        # Determine mangling prefix
+        if self.s.startswith('$s'):
+            self.pos = 2
+        elif self.s.startswith('$S'):
+            self.pos = 2
+        elif self.s.startswith('_T0'):
+            self.pos = 3
+        elif self.s.startswith('$e'):
+            self.pos = 2
+        else:
+            return None
+
+        # Parse the main entity
+        result = self._parse_entity()
+        return result
+
+    def _parse_entity(self):
+        """Parse a Swift entity (function, variable, type, etc.).
+
+        The entity starts with a module name (length-prefixed) followed
+        by a kind-specific suffix.
+        """
+        if self._depth > 50:
+            raise ValueError('recursion too deep')
+
+        self._depth += 1
+        try:
+            result = self._parse_context_or_entity()
+        finally:
+            self._depth -= 1
+
+        return result
+
+    def _parse_context_or_entity(self):
+        """Parse a context (module/class/struct) or entity name.
+
+        Swift mangling uses length-prefixed identifiers for names.
+        After a module name, the next identifier is the entity name,
+        optionally followed by type encoding.
+        """
+        # Check for standard substitution
+        if self._peek() == 'S':
+            sub = self._parse_substitution()
+            if sub:
+                return sub
+
+        # Check for back-reference
+        if self._peek() == 'A':
+            return self._parse_backref()
+
+        # Parse module name (length-prefixed)
+        if not self._peek().isdigit():
+            # Could be an operator or special encoding
+            ch = self._peek()
+            if ch.isalpha() and ch.isupper():
+                # Type operator (C=class, V=struct, O=enum, P=protocol)
+                return self._parse_type()
+            return None
+
+        module = self._parse_ident()
+        if not module:
+            return None
+
+        # Add to substitution table
+        self._subs.append(module)
+
+        parts = [module]
+
+        # Parse additional context names (class, struct, etc.)
+        while self._peek().isdigit():
+            name = self._parse_ident()
+            if not name:
+                break
+            self._subs.append('.'.join(parts + [name]))
+            parts.append(name)
+
+        # Now we have: module.class.function (or just module.function)
+        qualified = '.'.join(parts)
+
+        # Check for type suffix (function parameters/return type)
+        # The type suffix starts with a non-digit character
+        if not self._at_end() and not self._peek().isdigit():
+            type_suffix = self._parse_type_suffix()
+            if type_suffix:
+                # Format: Module.func(params) -> ReturnType
+                # Or just the qualified name with type info
+                if '(' in type_suffix:
+                    return '%s%s' % (qualified, type_suffix)
+                else:
+                    return '%s -> %s' % (qualified, type_suffix)
+
+        return qualified
+
+    def _parse_ident(self):
+        """Parse a length-prefixed identifier."""
+        length = self._parse_number()
+        if length == 0 or self.pos + length > len(self.s):
+            return None
+
+        name = self.s[self.pos:self.pos + length]
+        self.pos += length
+
+        # Decode escape sequences
+        name = _decode_swift_escapes(name)
+
+        return name
+
+    def _parse_type(self):
+        """Parse a Swift type encoding (simplified).
+
+        Swift uses postfix operators for types. This is a simplified
+        version that handles the most common cases.
+        """
+        ch = self._peek()
+
+        # Type operators (postfix)
+        if ch == 'C':
+            self._next()
+            # Class type: C <module> <name>
+            module = self._parse_ident()
+            name = self._parse_ident()
+            return '%s.%s' % (module, name)
+
+        if ch == 'V':
+            self._next()
+            # Struct type: V <module> <name>
+            module = self._parse_ident()
+            name = self._parse_ident()
+            return '%s.%s' % (module, name)
+
+        if ch == 'O':
+            self._next()
+            # Enum type: O <module> <name>
+            module = self._parse_ident()
+            name = self._parse_ident()
+            return '%s.%s' % (module, name)
+
+        if ch == 'P':
+            self._next()
+            # Protocol type: P <module> <name>
+            module = self._parse_ident()
+            name = self._parse_ident()
+            return '%s.%s' % (module, name)
+
+        # Basic types (single char)
+        if ch in ('i', 'd', 'f', 's', 'u', 'y', 'b', 'h'):
+            self._next()
+            type_map = {
+                'i': 'Int', 'd': 'Double', 'f': 'Float',
+                's': 'String', 'u': 'UInt', 'y': 'Void',
+                'b': 'Bool', 'h': 'Builtin.Word',
+            }
+            return type_map.get(ch, '?%s' % ch)
+
+        # Function type: F <params> <return>
+        if ch == 'F':
+            self._next()
+            params = self._parse_type_list()
+            ret = self._parse_type()
+            return '(%s) -> %s' % (params, ret)
+
+        # Generic type: G <count> <args>
+        if ch == 'G':
+            self._next()
+            return '<generic>'
+
+        # Opaque return type: Qo
+        if ch == 'Q':
+            self._next()
+            if self._eat('o'):
+                return 'some'
+            return '<opaque>'
+
+        # Optional: u (suffix) or Sg (substitution)
+        if ch == 'u':
+            self._next()
+            return 'Optional'
+
+        # Unknown — consume and return placeholder
+        self._next()
+        return '?%s' % ch
+
+    def _parse_type_list(self):
+        """Parse a type list: y <type>* t (or _T0 format)"""
+        # y = start of type list, t = end
+        if self._eat('y'):
+            types = []
+            while not self._at_end() and self._peek() != 't':
+                ty = self._parse_type()
+                if ty:
+                    types.append(ty)
+                else:
+                    break
+            self._eat('t')
+            return ', '.join(types)
+        return ''
+
+    def _parse_type_suffix(self):
+        """Parse the type suffix after an entity name.
+
+        In Swift mangling, after the entity name comes:
+        - F <type-list> <return-type>  (function)
+        - v <type>                      (variable)
+        - Other entity kind characters
+        """
+        ch = self._peek()
+
+        # Function: F<params><return>
+        if ch == 'F':
+            self._next()
+            params = self._parse_type_list()
+            ret = self._parse_type()
+            if ret and ret != 'Void':
+                return '(%s) -> %s' % (params, ret)
+            return '(%s)' % params
+
+        # Variable: v<type>
+        if ch == 'v':
+            self._next()
+            ty = self._parse_type()
+            return ''  # Variables don't have () suffix
+
+        # Initializer: fc
+        if ch == 'f':
+            self._next()
+            if self._eat('c'):
+                return '(init)'
+
+        # Deinitializer: fd
+        if ch == 'f':
+            self._next()
+            if self._eat('d'):
+                return '(deinit)'
+
+        # Getter: g<type>
+        if ch == 'g':
+            self._next()
+            self._parse_type()
+            return ''
+
+        # Setter: s<type>
+        if ch == 's':
+            self._next()
+            self._parse_type()
+            return ''
+
+        # Subscript: i
+        if ch == 'i':
+            self._next()
+            params = self._parse_type_list()
+            ret = self._parse_type()
+            return '[%s] -> %s' % (params, ret)
+
+        # Protocol conformance descriptor: Hp
+        if ch == 'H':
+            self._next()
+            if self._eat('p'):
+                # Parse protocol conformance
+                proto = self._parse_type()
+                return ' protocol conformance %s' % proto
+
+        # Metadata accessor: Ma
+        if ch == 'M':
+            self._next()
+            self._eat('a')
+            return ' (metadata accessor)'
+
+        # Type metadata: Mn
+        if ch == 'M':
+            self._next()
+            self._eat('n')
+            return ' (type metadata)'
+
+        # Unknown suffix — don't consume, let caller handle
+        return ''
+
+    def _parse_substitution(self):
+        """Parse a standard substitution (S prefix)."""
+        if self._peek() != 'S':
+            return None
+
+        # Check two-char substitutions
+        two = self.s[self.pos:self.pos + 2]
+        if two in _SWIFT_SUBS:
+            self.pos += 2
+            return _SWIFT_SUBS[two]
+
+        # S_ = Swift module
+        if self._eat('S'):
+            if self._eat('_'):
+                return 'Swift'
+            # Other S<letter> combinations
+            ch = self._next()
+            return 'S%c' % ch
+
+        return None
+
+    def _parse_backref(self):
+        """Parse a back-reference (A prefix)."""
+        self._eat('A')
+        # Back-references in Swift are complex — skip for now
+        idx = self._parse_number()
+        if idx < len(self._subs):
+            return self._subs[idx]
+        return '<backref:%d>' % idx
+
+
+def _demangle_swift_basic(mangled):
+    """Basic Swift symbol demangling — fallback.
+
+    Extracts length-prefixed names for module and function names.
+    This is a simplified extraction that doesn't parse types.
     """
     if mangled.startswith('$s'):
         s = mangled[2:]
@@ -106,17 +569,29 @@ def _demangle_swift_basic(mangled):
 
 
 def _decode_swift_escapes(s):
-    """Decode Swift-specific escape sequences in names."""
+    """Decode Swift-specific escape sequences in names.
+
+    Swift uses $HH$ (where HH is hex) for non-ASCII characters in identifiers.
+    """
+    # $HH$ hex escapes
     s = re.sub(r'\$([0-9A-Fa-f]{2})\$',
                lambda m: chr(int(m.group(1), 16)), s)
     return s
 
 
 def _parse_basic_structure(sym, demangled):
+    """Parse basic structure from a demangled Swift name."""
     if '.' in demangled:
         parts = demangled.rsplit('.', 1)
         sym.scope = parts[0].split('.')
         sym.name = parts[1]
     else:
         sym.name = demangled
-    sym.kind = 'function'
+
+    if '(' in sym.name:
+        sym.kind = 'function'
+    else:
+        sym.kind = 'variable'
+
+    if '<' in sym.name:
+        sym.is_template = True

--- a/vivisect/demangle/symbol.py
+++ b/vivisect/demangle/symbol.py
@@ -1,0 +1,168 @@
+"""
+vivisect.demangle.symbol - The Symbol class for demangled symbol representation.
+
+A Symbol holds:
+    - original:    The original mangled name (exact input, no normalization)
+    - demangled:   The fully demangled name string
+    - stripped:    Extra metadata (e.g. stripped @@VERSION suffixes, comments)
+    - structured:  Parsed components (scope, name, kind, template_args,
+                   return_type, parameters, calling_convention, etc.)
+
+For functions that contain type, return, and argument data, all of that
+information is available as structured fields.  The Symbol class is the
+canonical object that parsers, the workspace, and downstream analysis
+tools pass around.
+"""
+
+from vivisect.demangle.common import DemangledSymbol, normalize_name
+
+__all__ = ['Symbol']
+
+
+class Symbol:
+    """
+    Canonical symbol object holding original, demangled, stripped, and
+    structured data for a (potentially mangled) symbol name.
+
+    Attributes:
+        original (str):    The exact original input (mangled or plain).
+                           Never modified — preserves provenance.
+        demangled (str):    The demangled name string.  If demangling
+                           failed, equals the normalized original.
+        stripped (dict):    Extra data stripped during normalization
+                           (e.g. ``{'version_suffix': '@@GLIBC_2.4'}``).
+        format (str):       The mangling format ('itanium', 'msvc', etc.)
+                           or 'unknown'.
+        kind (str):         Symbol kind: 'function', 'variable', 'vtable',
+                           'typeinfo', 'ctor', 'dtor', 'thunk', 'guard',
+                           'template', etc.
+        scope (list[str]):  Namespace/class path (e.g.
+                           ['std', '__cxx11', 'string']).
+        name (str):         The unqualified name.
+        is_template (bool): True if this is a template instantiation.
+        template_args (list[str]): Template parameter type strings.
+        is_member (bool):   True if this is a class member.
+        is_static (bool):   True if static (mainly MSVC).
+        is_virtual (bool):  True if virtual (mainly MSVC).
+        access (str):       'public', 'private', 'protected', or None.
+        calling_convention (str): 'cdecl', 'stdcall', etc.
+        return_type (str or None): Return type string, if known.
+        parameters (list[str]):   Parameter type strings.
+        cv_qualifiers (str):  'const', 'volatile', 'const volatile', ''.
+        ref_qualifier (str):   '', '&', or '&&'.
+        abi_tags (list[str]):  ABI tag names (Itanium).
+        parse_warnings (list[str]): Non-fatal parse issues.
+
+    The ``structured`` property returns a DemangledSymbol for backward
+    compatibility with the Phase 0 API.
+    """
+
+    __slots__ = (
+        'original', 'demangled', 'stripped', 'format', 'kind',
+        'scope', 'name', 'is_template', 'template_args',
+        'is_member', 'is_static', 'is_virtual', 'access',
+        'calling_convention', 'return_type', 'parameters',
+        'cv_qualifiers', 'ref_qualifier', 'abi_tags',
+        'parse_warnings',
+    )
+
+    def __init__(self, original='', demangled=None, format='unknown',
+                 kind='unknown', scope=None, name='', is_template=False,
+                 template_args=None, is_member=False, is_static=False,
+                 is_virtual=False, access=None, calling_convention=None,
+                 return_type=None, parameters=None, cv_qualifiers='',
+                 ref_qualifier='', abi_tags=None, stripped=None,
+                 parse_warnings=None):
+        self.original = original
+        self.demangled = demangled if demangled is not None else original
+        self.stripped = stripped if stripped is not None else {}
+        self.format = format
+        self.kind = kind
+        self.scope = scope if scope is not None else []
+        self.name = name
+        self.is_template = is_template
+        self.template_args = template_args if template_args is not None else []
+        self.is_member = is_member
+        self.is_static = is_static
+        self.is_virtual = is_virtual
+        self.access = access
+        self.calling_convention = calling_convention
+        self.return_type = return_type
+        self.parameters = parameters if parameters is not None else []
+        self.cv_qualifiers = cv_qualifiers
+        self.ref_qualifier = ref_qualifier
+        self.abi_tags = abi_tags if abi_tags is not None else []
+        self.parse_warnings = parse_warnings if parse_warnings is not None else []
+
+    @property
+    def structured(self):
+        """Return a DemangledSymbol for backward compat with Phase 0 API."""
+        sym = DemangledSymbol(
+            format=self.format,
+            full_name=self.demangled,
+            kind=self.kind,
+            scope=list(self.scope),
+            name=self.name,
+            is_template=self.is_template,
+            template_args=list(self.template_args),
+            is_member=self.is_member,
+            is_static=self.is_static,
+            is_virtual=self.is_virtual,
+            access=self.access,
+            calling_convention=self.calling_convention,
+            return_type=self.return_type,
+            parameters=list(self.parameters),
+            cv_qualifiers=self.cv_qualifiers,
+            ref_qualifier=self.ref_qualifier,
+            this_adjustment=0,
+            abi_tags=list(self.abi_tags),
+            storage_class=None,
+            original_mangled=self.original,
+            parse_warnings=list(self.parse_warnings),
+        )
+        return sym
+
+    @classmethod
+    def from_demangled_symbol(cls, dsym, original=None, stripped=None):
+        """Build a Symbol from a DemangledSymbol (Phase 0 compat)."""
+        return cls(
+            original=original if original is not None else dsym.original_mangled,
+            demangled=dsym.full_name,
+            format=dsym.format,
+            kind=dsym.kind,
+            scope=list(dsym.scope),
+            name=dsym.name,
+            is_template=dsym.is_template,
+            template_args=list(dsym.template_args),
+            is_member=dsym.is_member,
+            is_static=dsym.is_static,
+            is_virtual=dsym.is_virtual,
+            access=dsym.access,
+            calling_convention=dsym.calling_convention,
+            return_type=dsym.return_type,
+            parameters=list(dsym.parameters),
+            cv_qualifiers=dsym.cv_qualifiers,
+            ref_qualifier=dsym.ref_qualifier,
+            abi_tags=list(dsym.abi_tags),
+            stripped=stripped,
+            parse_warnings=list(dsym.parse_warnings),
+        )
+
+    def __str__(self):
+        return self.demangled
+
+    def __repr__(self):
+        return '<Symbol format=%r kind=%r demangled=%r>' % (
+            self.format, self.kind, self.demangled)
+
+    def __eq__(self, other):
+        if not isinstance(other, Symbol):
+            return NotImplemented
+        return self.demangled == other.demangled and self.format == other.format
+
+    def __hash__(self):
+        return hash((self.format, self.demangled))
+
+    def to_dict(self):
+        """Return a dict representation suitable for JSON serialization."""
+        return {k: getattr(self, k) for k in self.__slots__}

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -1215,21 +1215,15 @@ def demangle(name):
 
     Uses the vivisect.demangle library which supports Itanium (GCC/Clang),
     MSVC, Rust, D, Swift, JNI, and Objective-C mangling formats.  Falls back
-    to cxxfilt for Itanium if the pure-Python parser is not yet implemented.
+    to cxxfilt if the new library is unavailable (import failure only).
     '''
     try:
         from vivisect.demangle import demangle as _demangle
-        result = _demangle(name)
-        if result and result != normName(name):
-            return result
-        # If demangle returned the original, still try cxxfilt for backward compat
-        # (the new library's Itanium handler already tries cxxfilt, so this is
-        # just a safety net)
-        return result
+        return _demangle(name)
     except Exception as e:
         logger.debug('vivisect.demangle failed for %r: %r', name, e)
 
-    # Fallback to cxxfilt if the new library is unavailable
+    # Fallback to cxxfilt if the new library is unavailable (import failure)
     name = normName(name)
     try:
         import cxxfilt

--- a/vivisect/parsers/elf.py
+++ b/vivisect/parsers/elf.py
@@ -1212,9 +1212,25 @@ def normName(name):
 def demangle(name):
     '''
     Translate C++ mangled name back into the verbose C++ symbol name (with helpful type info)
-    '''
-    name = normName(name)
 
+    Uses the vivisect.demangle library which supports Itanium (GCC/Clang),
+    MSVC, Rust, D, Swift, JNI, and Objective-C mangling formats.  Falls back
+    to cxxfilt for Itanium if the pure-Python parser is not yet implemented.
+    '''
+    try:
+        from vivisect.demangle import demangle as _demangle
+        result = _demangle(name)
+        if result and result != normName(name):
+            return result
+        # If demangle returned the original, still try cxxfilt for backward compat
+        # (the new library's Itanium handler already tries cxxfilt, so this is
+        # just a safety net)
+        return result
+    except Exception as e:
+        logger.debug('vivisect.demangle failed for %r: %r', name, e)
+
+    # Fallback to cxxfilt if the new library is unavailable
+    name = normName(name)
     try:
         import cxxfilt
         name = cxxfilt.demangle(name)

--- a/vivisect/parsers/macho.py
+++ b/vivisect/parsers/macho.py
@@ -8,6 +8,8 @@ import vstruct.defs.macho as vs_macho
 import vstruct.defs.macho.fat as vsm_fat
 import vstruct.defs.macho.const as vsm_const
 
+from vivisect.demangle import demangle
+
 logger = logging.getLogger(__name__)
 
 
@@ -173,6 +175,46 @@ def _loadMacho(vw, filebytes, filename=None, baseaddr=None):
         ptr = baseaddr + soff
         logger.debug("adding entrypoint: 0x%x (off: 0x%x/0x%x)", va, ptr, soff)
         vw.makePointer(ptr, follow=False)
+
+    # Apply symbols from the symbol table and demangle C++ names.
+    # This was previously missing entirely — Mach-O symbols were never
+    # applied to the workspace.
+    try:
+        symbols = macho.getSymbols()
+    except Exception as e:
+        logger.warning('Error parsing Mach-O symbols: %r', e)
+        symbols = []
+
+    for symname, symval, symtype, symsect, symdesc in symbols:
+        # Skip stab/debug symbols (N_STAB mask)
+        if symtype & 0xe0:
+            continue
+
+        # Skip undefined symbols (n_value == 0, N_UNDF type)
+        if symval == 0:
+            continue
+
+        va = symval + offset
+        if not vw.isValidPointer(va):
+            continue
+
+        # Skip symbols with empty names
+        if not symname:
+            continue
+
+        # Demangle C++ symbols (Itanium _Z prefix, ObjC _OBJC_ prefix, etc.)
+        dmglname = demangle(symname)
+        if dmglname != symname:
+            # Preserve original mangled name as a comment
+            vw.setComment(va, symname)
+            name_to_apply = dmglname
+        else:
+            name_to_apply = symname
+
+        try:
+            vw.makeName(va, name_to_apply, filelocal=True, makeuniq=True)
+        except Exception as e:
+            logger.debug('macho makeName failed for %r: %r', name_to_apply, e)
 
     return fname
 

--- a/vivisect/parsers/pe.py
+++ b/vivisect/parsers/pe.py
@@ -18,6 +18,9 @@ import envi.bits as e_bits
 import envi.const as e_const
 import envi.symstore.symcache as e_symcache
 
+from vivisect.const import *
+from vivisect.demangle import demangle
+
 logger = logging.getLogger(__name__)
 
 for mod in (PE, vtrace):
@@ -441,6 +444,14 @@ def loadPeIntoWorkspace(vw, pe, filename=None, baseaddr=None):
         # Functions exported by ordinal only have no name
         if not name:
             name = "Ordinal_" + str(ord)
+
+        # Demangle C++ symbols (MSVC ? prefix, Itanium _Z prefix, etc.)
+        # This was previously missing — MSVC-mangled names passed through raw.
+        dmglname = demangle(name)
+        if dmglname != name:
+            # Preserve the original mangled name as a comment
+            vw.setComment(eva, name)
+            name = dmglname
 
         try:
             vw.setVaSetRow('pe:ordinals', (eva, ord))

--- a/vivisect/tests/test_demangle.py
+++ b/vivisect/tests/test_demangle.py
@@ -116,14 +116,15 @@ class TestDispatch(unittest.TestCase):
         self.assertIsInstance(result, str)
         self.assertEqual(result, 'foo::bar()')
 
-    def test_msvc_dispatch_stub(self):
-        """MSVC is a stub in Phase 0 — should return original."""
-        result = demangle('?foo@@YAXXZ')
-        self.assertEqual(result, '?foo@@YAXXZ')
+    def test_msvc_dispatch(self):
+        """MSVC demangling is now implemented."""
+        result = demangle('?foo@@YAXH@Z')
+        self.assertEqual(result, 'void __cdecl foo(int)')
 
-    def test_rust_dispatch_stub(self):
-        result = demangle('_RNvNtCs1234_7mycrate3foo3bar')
-        self.assertEqual(result, '_RNvNtCs1234_7mycrate3foo3bar')
+    def test_rust_dispatch(self):
+        """Rust v0 demangling is now implemented."""
+        result = demangle('_RNvCs1234_4test3foo')
+        self.assertIsInstance(result, str)
 
     def test_jni_dispatch(self):
         result = demangle('Java_pkg_Cls_f__ILjava_lang_String_2')
@@ -202,11 +203,11 @@ class TestStructuredOutput(unittest.TestCase):
         self.assertEqual(sym.kind, 'class_ref')
         self.assertEqual(sym.name, 'NSObject')
 
-    def test_msvc_structured_stub(self):
-        sym = demangle('?foo@@YAXXZ', structured=True)
+    def test_msvc_structured(self):
+        sym = demangle('?foo@@YAXH@Z', structured=True)
         self.assertIsInstance(sym, DemangledSymbol)
         self.assertEqual(sym.format, FORMAT_MSVC)
-        self.assertTrue(sym.parse_warnings)  # should have "not yet implemented"
+        self.assertEqual(sym.full_name, 'void __cdecl foo(int)')
 
     def test_unknown_structured(self):
         sym = demangle('plain_symbol', structured=True)

--- a/vivisect/tests/test_demangle.py
+++ b/vivisect/tests/test_demangle.py
@@ -1,0 +1,291 @@
+"""
+Tests for the vivisect.demangle library.
+
+These tests verify:
+    1. Format detection (detect_format)
+    2. Dispatch to the correct format handler
+    3. Graceful degradation (never crash on bad input)
+    4. Structured output (DemangledSymbol)
+    5. Normalization (@@VERSION suffixes, trailing NUL)
+    6. Each format handler individually
+"""
+
+import unittest
+
+from vivisect.demangle import (
+    demangle, detect_format,
+    DemangledSymbol, DemangleError,
+    FORMAT_ITANIUM, FORMAT_MSVC, FORMAT_RUST, FORMAT_D,
+    FORMAT_SWIFT, FORMAT_JNI, FORMAT_OBJC, FORMAT_UNKNOWN,
+)
+from vivisect.demangle.common import normalize_name
+
+
+class TestDetectFormat(unittest.TestCase):
+    """Test format auto-detection from symbol prefix."""
+
+    def test_itanium_prefix(self):
+        self.assertEqual(detect_format('_Z3foov'), FORMAT_ITANIUM)
+        self.assertEqual(detect_format('_ZN3foo3barEv'), FORMAT_ITANIUM)
+        self.assertEqual(detect_format('__Z3foov'), FORMAT_ITANIUM)
+        self.assertEqual(detect_format('_ZTV1A'), FORMAT_ITANIUM)
+
+    def test_msvc_prefix(self):
+        self.assertEqual(detect_format('?foo@@YAXXZ'), FORMAT_MSVC)
+        self.assertEqual(detect_format('??0MyClass@@QAE@H@Z'), FORMAT_MSVC)
+        self.assertEqual(detect_format('??_7MyClass@@6B@'), FORMAT_MSVC)
+
+    def test_rust_v0_prefix(self):
+        self.assertEqual(detect_format('_RNvNtCs1234_7mycrate3foo3bar'), FORMAT_RUST)
+        self.assertEqual(detect_format('_RNvCs1234_7mycrate3foo'), FORMAT_RUST)
+
+    def test_d_prefix(self):
+        self.assertEqual(detect_format('_Dmain'), FORMAT_D)
+        self.assertEqual(detect_format('_D3foo3barFiZv'), FORMAT_D)
+
+    def test_swift_prefix(self):
+        self.assertEqual(detect_format('$s4Test3FooC'), FORMAT_SWIFT)
+        self.assertEqual(detect_format('$S4Test3FooC'), FORMAT_SWIFT)
+        self.assertEqual(detect_format('_T04Test3FooC'), FORMAT_SWIFT)
+
+    def test_jni_prefix(self):
+        self.assertEqual(detect_format('Java_pkg_Cls_f'), FORMAT_JNI)
+        self.assertEqual(detect_format('Java_pkg_Cls_f__ILjava_lang_String_2'), FORMAT_JNI)
+
+    def test_objc_prefix(self):
+        self.assertEqual(detect_format('_OBJC_CLASS_$_NSObject'), FORMAT_OBJC)
+        self.assertEqual(detect_format('_OBJC_METACLASS_$_NSObject'), FORMAT_OBJC)
+        self.assertEqual(detect_format('_OBJC_IVAR_$_NSObject._isa'), FORMAT_OBJC)
+        self.assertEqual(detect_format('+[NSObject alloc]'), FORMAT_OBJC)
+        self.assertEqual(detect_format('-[NSObject init]'), FORMAT_OBJC)
+
+    def test_unknown(self):
+        self.assertEqual(detect_format('plain_symbol'), FORMAT_UNKNOWN)
+        self.assertEqual(detect_format('main'), FORMAT_UNKNOWN)
+        self.assertEqual(detect_format(''), FORMAT_UNKNOWN)
+        self.assertEqual(detect_format('_start'), FORMAT_UNKNOWN)
+
+    def test_global_not_d(self):
+        """_GLOBAL_ symbols should not be detected as D format."""
+        self.assertNotEqual(detect_format('_GLOBAL__sub_I_some_file.cpp'), FORMAT_D)
+
+
+class TestNormalizeName(unittest.TestCase):
+    """Test name normalization."""
+
+    def test_strip_version_suffix(self):
+        self.assertEqual(normalize_name('foo@@GLIBC_2.4'), 'foo')
+        self.assertEqual(normalize_name('foo@@GLIBC_2.17'), 'foo')
+        self.assertEqual(normalize_name('_Z3foo@@GLIBC_2.4'), '_Z3foo')
+
+    def test_msvc_atat_preserved(self):
+        """MSVC symbols use @@ as scope terminator, not version suffix."""
+        self.assertEqual(normalize_name('?foo@@YAXXZ'), '?foo@@YAXXZ')
+        self.assertEqual(normalize_name('??0MyClass@@QAE@H@Z'), '??0MyClass@@QAE@H@Z')
+
+    def test_trailing_nul(self):
+        self.assertEqual(normalize_name('foo\x00'), 'foo')
+
+    def test_empty(self):
+        self.assertEqual(normalize_name(''), '')
+        self.assertIsNone(normalize_name(None))
+
+    def test_no_change(self):
+        self.assertEqual(normalize_name('plain_name'), 'plain_name')
+        self.assertEqual(normalize_name('_Z3foov'), '_Z3foov')
+
+
+class TestDispatch(unittest.TestCase):
+    """Test the main demangle() dispatch."""
+
+    def test_itanium_dispatch(self):
+        result = demangle('_ZN3foo3barEv')
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, 'foo::bar()')
+
+    def test_msvc_dispatch_stub(self):
+        """MSVC is a stub in Phase 0 — should return original."""
+        result = demangle('?foo@@YAXXZ')
+        self.assertEqual(result, '?foo@@YAXXZ')
+
+    def test_rust_dispatch_stub(self):
+        result = demangle('_RNvNtCs1234_7mycrate3foo3bar')
+        self.assertEqual(result, '_RNvNtCs1234_7mycrate3foo3bar')
+
+    def test_jni_dispatch(self):
+        result = demangle('Java_pkg_Cls_f__ILjava_lang_String_2')
+        self.assertIsInstance(result, str)
+        self.assertIn('pkg', result)
+
+    def test_objc_dispatch(self):
+        result = demangle('_OBJC_CLASS_$_NSObject')
+        self.assertEqual(result, 'NSObject')
+        result = demangle('+[NSObject alloc]')
+        self.assertEqual(result, '+[NSObject alloc]')
+
+    def test_unknown_returns_original(self):
+        result = demangle('plain_symbol')
+        self.assertEqual(result, 'plain_symbol')
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(demangle(''), '')
+
+    def test_force_format(self):
+        """Test forcing a specific format."""
+        result = demangle('_Z3foov', fmt=FORMAT_ITANIUM)
+        self.assertEqual(result, 'foo()')
+
+    def test_graceful_degradation(self):
+        """demangle() should never raise on bad input."""
+        bad_inputs = [
+            '_Z',  # truncated
+            '_Z!',  # invalid char
+            '?',  # truncated MSVC
+            '???',  # invalid MSVC
+            '\x00\x01\x02',  # binary garbage
+            'a' * 1000,  # very long
+        ]
+        for inp in bad_inputs:
+            result = demangle(inp)
+            self.assertIsInstance(result, str, 'demangle(%r) returned non-str' % inp)
+
+    def test_version_suffix_stripped(self):
+        """@@VERSION suffixes should be stripped."""
+        result = demangle('foo@@GLIBC_2.4')
+        self.assertEqual(result, 'foo')
+
+
+class TestStructuredOutput(unittest.TestCase):
+    """Test structured DemangledSymbol output."""
+
+    def test_itanium_structured(self):
+        sym = demangle('_ZN3foo3barEv', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, FORMAT_ITANIUM)
+        self.assertEqual(sym.full_name, 'foo::bar()')
+        self.assertEqual(sym.scope, ['foo'])
+        self.assertEqual(sym.name, 'bar()')
+        self.assertEqual(sym.kind, 'function')
+        self.assertEqual(sym.original_mangled, '_ZN3foo3barEv')
+
+    def test_itanium_vtable_structured(self):
+        sym = demangle('_ZTV1A', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.kind, 'vtable')
+        self.assertEqual(sym.name, 'A')
+
+    def test_jni_structured(self):
+        sym = demangle('Java_pkg_Cls_f__ILjava_lang_String_2', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, FORMAT_JNI)
+        self.assertEqual(sym.kind, 'function')
+        self.assertIn('int', sym.parameters)
+        self.assertIn('java.lang.String', sym.parameters)
+
+    def test_objc_structured(self):
+        sym = demangle('_OBJC_CLASS_$_NSObject', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, FORMAT_OBJC)
+        self.assertEqual(sym.kind, 'class_ref')
+        self.assertEqual(sym.name, 'NSObject')
+
+    def test_msvc_structured_stub(self):
+        sym = demangle('?foo@@YAXXZ', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, FORMAT_MSVC)
+        self.assertTrue(sym.parse_warnings)  # should have "not yet implemented"
+
+    def test_unknown_structured(self):
+        sym = demangle('plain_symbol', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, FORMAT_UNKNOWN)
+        self.assertEqual(sym.full_name, 'plain_symbol')
+
+    def test_demangled_symbol_str(self):
+        """DemangledSymbol.__str__ should return full_name."""
+        sym = DemangledSymbol(full_name='foo::bar()')
+        self.assertEqual(str(sym), 'foo::bar()')
+
+    def test_demangled_symbol_to_dict(self):
+        """DemangledSymbol.to_dict should return all slots."""
+        sym = DemangledSymbol(format='itanium', full_name='foo()')
+        d = sym.to_dict()
+        self.assertEqual(d['format'], 'itanium')
+        self.assertEqual(d['full_name'], 'foo()')
+        self.assertIn('original_mangled', d)
+        self.assertIn('parse_warnings', d)
+
+
+class TestItaniumDemangle(unittest.TestCase):
+    """Test Itanium ABI demangling (via cxxfilt fallback in Phase 0)."""
+
+    def test_simple_function(self):
+        self.assertEqual(demangle('_Z3foov'), 'foo()')
+
+    def test_nested_name(self):
+        self.assertEqual(demangle('_ZN3foo3barEv'), 'foo::bar()')
+
+    def test_std_namespace(self):
+        self.assertEqual(demangle('_ZSt5state'), 'std::state')
+
+    def test_vtable(self):
+        self.assertEqual(demangle('_ZTV1A'), 'vtable for A')
+
+    def test_typeinfo(self):
+        self.assertEqual(demangle('_ZTI1A'), 'typeinfo for A')
+
+    def test_typeinfo_name(self):
+        self.assertEqual(demangle('_ZTS1A'), 'typeinfo name for A')
+
+    def test_template(self):
+        result = demangle('_ZN1N1TIiiE2mfES0_IddE')
+        self.assertIn('N::T', result)
+
+    def test_version_suffix(self):
+        """Itanium symbols with @@VERSION should be demangled after stripping."""
+        # _Z3foo is a data name (no bare-function-type), so demangles to 'foo'
+        self.assertEqual(demangle('_Z3foo@@GLIBC_2.4'), 'foo')
+        # _Z3foov is a function (v = void params), demangles to 'foo()'
+        self.assertEqual(demangle('_Z3foov@@GLIBC_2.4'), 'foo()')
+
+
+class TestJNIDemangle(unittest.TestCase):
+    """Test JNI native method name demangling."""
+
+    def test_simple_method(self):
+        result = demangle('Java_pkg_Cls_f')
+        self.assertIn('pkg', result)
+        self.assertIn('Cls', result)
+        self.assertIn('f', result)
+
+    def test_overloaded_method(self):
+        result = demangle('Java_pkg_Cls_f__ILjava_lang_String_2')
+        self.assertIn('int', result)
+        self.assertIn('java.lang.String', result)
+
+    def test_structured(self):
+        sym = demangle('Java_pkg_Cls_f__ILjava_lang_String_2', structured=True)
+        self.assertEqual(sym.kind, 'function')
+        self.assertIn('int', sym.parameters)
+
+
+class TestObjCDemangle(unittest.TestCase):
+    """Test Objective-C symbol demangling."""
+
+    def test_class_ref(self):
+        self.assertEqual(demangle('_OBJC_CLASS_$_NSObject'), 'NSObject')
+
+    def test_metaclass_ref(self):
+        self.assertEqual(demangle('_OBJC_METACLASS_$_NSObject'), 'NSObject')
+
+    def test_ivar(self):
+        result = demangle('_OBJC_IVAR_$_NSObject._isa')
+        self.assertIn('NSObject', result)
+
+    def test_method_syntax(self):
+        self.assertEqual(demangle('+[NSObject alloc]'), '+[NSObject alloc]')
+        self.assertEqual(demangle('-[NSObject init]'), '-[NSObject init]')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivisect/tests/test_demangle.py
+++ b/vivisect/tests/test_demangle.py
@@ -299,6 +299,32 @@ class TestItaniumDemangle(unittest.TestCase):
         # _Z3foov is a function (v = void params), demangles to 'foo()'
         self.assertEqual(demangle('_Z3foov@@GLIBC_2.4'), 'foo()')
 
+    def test_pointer_to_member_function(self):
+        """Pointer-to-member function types with CV/ref qualifiers."""
+        # const & ref-qualifier
+        self.assertEqual(demangle('_Z1fM1AKFvvRE'),
+                         'f(void (A::*)() const &)')
+        # const only, no ref
+        self.assertEqual(demangle('_Z1fM1AKFvvE'),
+                         'f(void (A::*)() const)')
+        # no CV, no ref
+        self.assertEqual(demangle('_Z1fM1AFvvE'),
+                         'f(void (A::*)())')
+        # ref only, no const
+        self.assertEqual(demangle('_Z1fM1AFvvRE'),
+                         'f(void (A::*)() &)')
+        # const && (rvalue ref)
+        self.assertEqual(demangle('_Z1fM1AKFvvOE'),
+                         'f(void (A::*)() const &&)')
+
+    def test_pointer_to_member_data(self):
+        """Pointer-to-member data (non-function member type)."""
+        # M <class> <type> where type is not a function
+        # _Z1fM1Ai => f(int A::*)
+        result = demangle('_Z1fM1Ai')
+        self.assertIn('A::*', result)
+        self.assertIn('int', result)
+
 
 class TestJNIDemangle(unittest.TestCase):
     """Test JNI native method name demangling."""

--- a/vivisect/tests/test_demangle.py
+++ b/vivisect/tests/test_demangle.py
@@ -69,6 +69,19 @@ class TestDetectFormat(unittest.TestCase):
         """_GLOBAL_ symbols should not be detected as D format."""
         self.assertNotEqual(detect_format('_GLOBAL__sub_I_some_file.cpp'), FORMAT_D)
 
+    def test_common_elf_symbols_not_d(self):
+        """Common ELF symbols starting with _D must not be detected as D format."""
+        # These are real ELF symbol names that must NOT route to D
+        self.assertEqual(detect_format('_DYNAMIC'), FORMAT_UNKNOWN)
+        self.assertEqual(detect_format('_DATA'), FORMAT_UNKNOWN)
+        self.assertEqual(detect_format('_DWARF'), FORMAT_UNKNOWN)
+        self.assertEqual(detect_format('_DEFAULT'), FORMAT_UNKNOWN)
+        self.assertEqual(detect_format('_DTORS'), FORMAT_UNKNOWN)
+        self.assertEqual(detect_format('_DTRACE'), FORMAT_UNKNOWN)
+        # Real D symbols still detected correctly
+        self.assertEqual(detect_format('_Dmain'), FORMAT_D)
+        self.assertEqual(detect_format('_D3foo3barFiZv'), FORMAT_D)
+
 
 class TestNormalizeName(unittest.TestCase):
     """Test name normalization."""
@@ -201,6 +214,17 @@ class TestStructuredOutput(unittest.TestCase):
         self.assertEqual(sym.format, FORMAT_UNKNOWN)
         self.assertEqual(sym.full_name, 'plain_symbol')
 
+    def test_original_mangled_preserved_with_version_suffix(self):
+        """original_mangled must preserve the true original, not the normalized form."""
+        sym = demangle('_ZN3foo3barEv@@GLIBC_2.4', structured=True)
+        self.assertEqual(sym.original_mangled, '_ZN3foo3barEv@@GLIBC_2.4')
+        self.assertEqual(sym.full_name, 'foo::bar()')
+
+    def test_original_mangled_preserved_plain(self):
+        """original_mangled must match input when no normalization occurs."""
+        sym = demangle('_ZN3foo3barEv', structured=True)
+        self.assertEqual(sym.original_mangled, '_ZN3foo3barEv')
+
     def test_demangled_symbol_str(self):
         """DemangledSymbol.__str__ should return full_name."""
         sym = DemangledSymbol(full_name='foo::bar()')
@@ -214,6 +238,33 @@ class TestStructuredOutput(unittest.TestCase):
         self.assertEqual(d['full_name'], 'foo()')
         self.assertIn('original_mangled', d)
         self.assertIn('parse_warnings', d)
+
+    def test_demangled_symbol_eq(self):
+        """DemangledSymbol.__eq__ should compare format and full_name."""
+        a = DemangledSymbol(format='itanium', full_name='foo()')
+        b = DemangledSymbol(format='itanium', full_name='foo()')
+        c = DemangledSymbol(format='msvc', full_name='foo()')
+        d = DemangledSymbol(format='itanium', full_name='bar()')
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(a, 'foo()')
+
+    def test_demangled_symbol_hash(self):
+        """DemangledSymbol.__hash__ should allow set/dict usage."""
+        a = DemangledSymbol(format='itanium', full_name='foo()')
+        b = DemangledSymbol(format='itanium', full_name='foo()')
+        s = {a, b}
+        self.assertEqual(len(s), 1)
+        d = {a: 'val'}
+        self.assertEqual(d[b], 'val')
+
+    def test_demangled_symbol_repr(self):
+        """DemangledSymbol.__repr__ should include format and full_name."""
+        sym = DemangledSymbol(format='itanium', full_name='foo()')
+        r = repr(sym)
+        self.assertIn('itanium', r)
+        self.assertIn('foo()', r)
 
 
 class TestItaniumDemangle(unittest.TestCase):

--- a/vivisect/tests/test_demangle_common.py
+++ b/vivisect/tests/test_demangle_common.py
@@ -1,0 +1,495 @@
+"""
+Comprehensive tests for the shared demangle infrastructure.
+
+Tests cover:
+- Format detection (all formats, edge cases, false positives)
+- Main dispatch (demangle() routing to correct handler)
+- Name normalization (@@VERSION, NUL, MSVC preservation)
+- DemangledSymbol (all attributes, methods, equality, hashing)
+- Symbol class (from_demangled_symbol, structured property, to_dict)
+- Graceful degradation (never crash on any input)
+- Force-format override
+- Structured vs string output
+"""
+
+import unittest
+
+from vivisect.demangle import (
+    demangle, detect_format,
+    DemangledSymbol, DemangleError,
+    FORMAT_ITANIUM, FORMAT_MSVC, FORMAT_RUST, FORMAT_D,
+    FORMAT_SWIFT, FORMAT_JNI, FORMAT_OBJC, FORMAT_UNKNOWN,
+)
+from vivisect.demangle.common import normalize_name
+from vivisect.demangle.symbol import Symbol
+
+
+class TestFormatDetection(unittest.TestCase):
+    """Comprehensive format detection tests."""
+
+    # --- Itanium ---
+    def test_itanium_z(self):
+        self.assertEqual(detect_format('_Z3foov'), FORMAT_ITANIUM)
+        self.assertEqual(detect_format('_ZN3foo3barEv'), FORMAT_ITANIUM)
+
+    def test_itanium_double_z(self):
+        self.assertEqual(detect_format('__Z3foov'), FORMAT_ITANIUM)
+
+    def test_itanium_vtable(self):
+        self.assertEqual(detect_format('_ZTV1A'), FORMAT_ITANIUM)
+
+    def test_itanium_typeinfo(self):
+        self.assertEqual(detect_format('_ZTI1A'), FORMAT_ITANIUM)
+
+    # --- MSVC ---
+    def test_msvc_question(self):
+        self.assertEqual(detect_format('?foo@@YAXH@Z'), FORMAT_MSVC)
+
+    def test_msvc_ctor(self):
+        self.assertEqual(detect_format('??0MyClass@@QAE@X@Z'), FORMAT_MSVC)
+
+    def test_msvc_dtor(self):
+        self.assertEqual(detect_format('??1MyClass@@UAE@X@Z'), FORMAT_MSVC)
+
+    def test_msvc_vtable(self):
+        self.assertEqual(detect_format('??_7MyClass@@6B@'), FORMAT_MSVC)
+
+    def test_msvc_operator(self):
+        self.assertEqual(detect_format('??2@YAPAXI@Z'), FORMAT_MSVC)
+
+    # --- Rust ---
+    def test_rust_v0(self):
+        self.assertEqual(detect_format('_RNvCs1234_4test3foo'), FORMAT_RUST)
+
+    # --- D ---
+    def test_d_with_digit(self):
+        self.assertEqual(detect_format('_D3foo3barFiZv'), FORMAT_D)
+
+    def test_d_main(self):
+        self.assertEqual(detect_format('_Dmain'), FORMAT_D)
+
+    # --- Swift ---
+    def test_swift_s(self):
+        self.assertEqual(detect_format('$s5Hello4testyyF'), FORMAT_SWIFT)
+
+    def test_swift_S(self):
+        self.assertEqual(detect_format('$S5Hello4testyyF'), FORMAT_SWIFT)
+
+    def test_swift_T0(self):
+        self.assertEqual(detect_format('_T05Hello4testyyF'), FORMAT_SWIFT)
+
+    # --- JNI ---
+    def test_jni_prefix(self):
+        self.assertEqual(detect_format('Java_pkg_Cls_f'), FORMAT_JNI)
+
+    def test_jni_overloaded(self):
+        self.assertEqual(detect_format('Java_pkg_Cls_f__ILjava_lang_String_2'),
+                         FORMAT_JNI)
+
+    # --- ObjC ---
+    def test_objc_class(self):
+        self.assertEqual(detect_format('_OBJC_CLASS_$_NSObject'), FORMAT_OBJC)
+
+    def test_objc_metaclass(self):
+        self.assertEqual(detect_format('_OBJC_METACLASS_$_NSObject'),
+                         FORMAT_OBJC)
+
+    def test_objc_ivar(self):
+        self.assertEqual(detect_format('_OBJC_IVAR_$_NSObject._isa'),
+                         FORMAT_OBJC)
+
+    def test_objc_class_method(self):
+        self.assertEqual(detect_format('+[NSObject alloc]'), FORMAT_OBJC)
+
+    def test_objc_instance_method(self):
+        self.assertEqual(detect_format('-[NSObject init]'), FORMAT_OBJC)
+
+    # --- Unknown ---
+    def test_unknown_plain(self):
+        self.assertEqual(detect_format('plain_symbol'), FORMAT_UNKNOWN)
+
+    def test_unknown_main(self):
+        self.assertEqual(detect_format('main'), FORMAT_UNKNOWN)
+
+    def test_unknown_empty(self):
+        self.assertEqual(detect_format(''), FORMAT_UNKNOWN)
+
+    def test_unknown_start(self):
+        self.assertEqual(detect_format('_start'), FORMAT_UNKNOWN)
+
+    # --- False positive prevention ---
+    def test_dynamic_not_d(self):
+        self.assertNotEqual(detect_format('_DYNAMIC'), FORMAT_D)
+
+    def test_data_not_d(self):
+        self.assertNotEqual(detect_format('_DATA'), FORMAT_D)
+
+    def test_dwarf_not_d(self):
+        self.assertNotEqual(detect_format('_DWARF'), FORMAT_D)
+
+    def test_global_not_d(self):
+        self.assertNotEqual(detect_format('_GLOBAL__sub_I_some_file'), FORMAT_D)
+
+
+class TestNormalization(unittest.TestCase):
+    """Test name normalization."""
+
+    def test_strip_glibc_suffix(self):
+        self.assertEqual(normalize_name('foo@@GLIBC_2.4'), 'foo')
+
+    def test_strip_glibc_217(self):
+        self.assertEqual(normalize_name('foo@@GLIBC_2.17'), 'foo')
+
+    def test_strip_itanium_with_suffix(self):
+        self.assertEqual(normalize_name('_Z3foo@@GLIBC_2.4'), '_Z3foo')
+
+    def test_msvc_atat_preserved(self):
+        """MSVC symbols use @@ as scope terminator, not version suffix."""
+        self.assertEqual(normalize_name('?foo@@YAXXZ'), '?foo@@YAXXZ')
+        self.assertEqual(normalize_name('??0MyClass@@QAE@H@Z'),
+                         '??0MyClass@@QAE@H@Z')
+
+    def test_strip_trailing_nul(self):
+        self.assertEqual(normalize_name('foo\x00'), 'foo')
+
+    def test_empty(self):
+        self.assertEqual(normalize_name(''), '')
+
+    def test_none(self):
+        self.assertIsNone(normalize_name(None))
+
+    def test_no_change(self):
+        self.assertEqual(normalize_name('plain_name'), 'plain_name')
+        self.assertEqual(normalize_name('_Z3foov'), '_Z3foov')
+
+    def test_no_version_suffix(self):
+        self.assertEqual(normalize_name('?foo@@YAXH@Z'), '?foo@@YAXH@Z')
+
+
+class TestDemangledSymbol(unittest.TestCase):
+    """Test DemangledSymbol class thoroughly."""
+
+    def test_default_construction(self):
+        sym = DemangledSymbol()
+        self.assertIsNone(sym.format)
+        self.assertEqual(sym.full_name, '')
+        self.assertEqual(sym.name, '')
+        self.assertEqual(sym.kind, 'unknown')
+        self.assertEqual(sym.scope, [])
+        self.assertEqual(sym.parameters, [])
+        self.assertEqual(sym.parse_warnings, [])
+        self.assertEqual(sym.template_args, [])
+        self.assertFalse(sym.is_template)
+        self.assertFalse(sym.is_member)
+        self.assertFalse(sym.is_static)
+        self.assertFalse(sym.is_virtual)
+
+    def test_full_construction(self):
+        sym = DemangledSymbol(
+            format='itanium',
+            full_name='foo::bar(int)',
+            name='bar(int)',
+            kind='function',
+            scope=['foo'],
+            is_template=True,
+            template_args=['int'],
+            is_member=True,
+            is_static=False,
+            is_virtual=True,
+            access='public',
+            calling_convention='cdecl',
+            return_type='void',
+            parameters=['int'],
+            cv_qualifiers='const',
+            ref_qualifier='&',
+            original_mangled='_ZN3foo3barEi',
+        )
+        self.assertEqual(sym.format, 'itanium')
+        self.assertEqual(sym.full_name, 'foo::bar(int)')
+        self.assertTrue(sym.is_template)
+        self.assertTrue(sym.is_virtual)
+        self.assertEqual(sym.access, 'public')
+
+    def test_str(self):
+        sym = DemangledSymbol(full_name='foo::bar()')
+        self.assertEqual(str(sym), 'foo::bar()')
+
+    def test_repr(self):
+        sym = DemangledSymbol(format='itanium', full_name='foo()')
+        r = repr(sym)
+        self.assertIn('itanium', r)
+        self.assertIn('foo()', r)
+
+    def test_eq_same(self):
+        a = DemangledSymbol(format='itanium', full_name='foo()')
+        b = DemangledSymbol(format='itanium', full_name='foo()')
+        self.assertEqual(a, b)
+
+    def test_eq_different_format(self):
+        a = DemangledSymbol(format='itanium', full_name='foo()')
+        b = DemangledSymbol(format='msvc', full_name='foo()')
+        self.assertNotEqual(a, b)
+
+    def test_eq_different_name(self):
+        a = DemangledSymbol(format='itanium', full_name='foo()')
+        b = DemangledSymbol(format='itanium', full_name='bar()')
+        self.assertNotEqual(a, b)
+
+    def test_eq_non_symbol(self):
+        a = DemangledSymbol(format='itanium', full_name='foo()')
+        self.assertNotEqual(a, 'foo()')
+        self.assertNotEqual(a, 42)
+
+    def test_hash(self):
+        a = DemangledSymbol(format='itanium', full_name='foo()')
+        b = DemangledSymbol(format='itanium', full_name='foo()')
+        s = {a, b}
+        self.assertEqual(len(s), 1)
+
+    def test_hash_in_dict(self):
+        a = DemangledSymbol(format='itanium', full_name='foo()')
+        b = DemangledSymbol(format='itanium', full_name='foo()')
+        d = {a: 'value'}
+        self.assertEqual(d[b], 'value')
+
+    def test_to_dict(self):
+        sym = DemangledSymbol(format='itanium', full_name='foo()')
+        d = sym.to_dict()
+        self.assertEqual(d['format'], 'itanium')
+        self.assertEqual(d['full_name'], 'foo()')
+        self.assertIn('original_mangled', d)
+        self.assertIn('parse_warnings', d)
+        self.assertIn('scope', d)
+        self.assertIn('parameters', d)
+
+    def test_all_slots_in_to_dict(self):
+        sym = DemangledSymbol(format='msvc', full_name='x')
+        d = sym.to_dict()
+        expected_keys = {
+            'format', 'full_name', 'kind', 'scope', 'name',
+            'is_template', 'template_args', 'is_member', 'is_static',
+            'is_virtual', 'access', 'calling_convention', 'return_type',
+            'parameters', 'cv_qualifiers', 'ref_qualifier',
+            'this_adjustment', 'abi_tags', 'storage_class',
+            'original_mangled', 'parse_warnings',
+        }
+        self.assertEqual(set(d.keys()), expected_keys)
+
+
+class TestSymbolClass(unittest.TestCase):
+    """Test the Symbol wrapper class."""
+
+    def test_construction(self):
+        sym = Symbol(original='_Z3foov', demangled='foo()',
+                     format='itanium', kind='function')
+        self.assertEqual(sym.original, '_Z3foov')
+        self.assertEqual(sym.demangled, 'foo()')
+        self.assertEqual(sym.format, 'itanium')
+        self.assertEqual(sym.kind, 'function')
+
+    def test_default_demangled_is_original(self):
+        sym = Symbol(original='plain')
+        self.assertEqual(sym.demangled, 'plain')
+
+    def test_str(self):
+        sym = Symbol(demangled='foo::bar()')
+        self.assertEqual(str(sym), 'foo::bar()')
+
+    def test_repr(self):
+        sym = Symbol(format='itanium', demangled='foo()')
+        r = repr(sym)
+        self.assertIn('itanium', r)
+        self.assertIn('foo()', r)
+
+    def test_eq(self):
+        a = Symbol(demangled='foo()', format='itanium')
+        b = Symbol(demangled='foo()', format='itanium')
+        self.assertEqual(a, b)
+
+    def test_eq_different(self):
+        a = Symbol(demangled='foo()', format='itanium')
+        b = Symbol(demangled='bar()', format='itanium')
+        self.assertNotEqual(a, b)
+
+    def test_hash(self):
+        a = Symbol(demangled='foo()', format='itanium')
+        b = Symbol(demangled='foo()', format='itanium')
+        self.assertEqual(len({a, b}), 1)
+
+    def test_to_dict(self):
+        sym = Symbol(original='orig', demangled='dem', format='itanium')
+        d = sym.to_dict()
+        self.assertEqual(d['original'], 'orig')
+        self.assertEqual(d['demangled'], 'dem')
+        self.assertEqual(d['format'], 'itanium')
+
+    def test_structured_property(self):
+        sym = Symbol(original='_Z3foov', demangled='foo()',
+                     format='itanium', kind='function')
+        dsym = sym.structured
+        self.assertIsInstance(dsym, DemangledSymbol)
+        self.assertEqual(dsym.format, 'itanium')
+        self.assertEqual(dsym.full_name, 'foo()')
+        self.assertEqual(dsym.kind, 'function')
+
+    def test_from_demangled_symbol(self):
+        dsym = DemangledSymbol(
+            format='msvc',
+            full_name='void __cdecl foo(int)',
+            kind='function',
+            original_mangled='?foo@@YAXH@Z',
+        )
+        sym = Symbol.from_demangled_symbol(dsym)
+        self.assertEqual(sym.format, 'msvc')
+        self.assertEqual(sym.demangled, 'void __cdecl foo(int)')
+        self.assertEqual(sym.original, '?foo@@YAXH@Z')
+
+    def test_from_demangled_symbol_with_stripped(self):
+        dsym = DemangledSymbol(format='itanium', full_name='foo()')
+        sym = Symbol.from_demangled_symbol(dsym, original='_Z3foov@@GLIBC_2.4',
+                                           stripped={'version_suffix': '@@GLIBC_2.4'})
+        self.assertEqual(sym.original, '_Z3foov@@GLIBC_2.4')
+        self.assertEqual(sym.stripped['version_suffix'], '@@GLIBC_2.4')
+
+
+class TestDispatch(unittest.TestCase):
+    """Test the main demangle() dispatch."""
+
+    def test_itanium_dispatch(self):
+        self.assertEqual(demangle('_ZN3foo3barEv'), 'foo::bar()')
+
+    def test_msvc_dispatch(self):
+        self.assertEqual(demangle('?foo@@YAXH@Z'),
+                         'void __cdecl foo(int)')
+
+    def test_jni_dispatch(self):
+        result = demangle('Java_pkg_Cls_f__ILjava_lang_String_2')
+        self.assertIsInstance(result, str)
+        self.assertIn('int', result)
+
+    def test_objc_dispatch(self):
+        self.assertEqual(demangle('_OBJC_CLASS_$_NSObject'), 'NSObject')
+
+    def test_unknown_returns_original(self):
+        self.assertEqual(demangle('plain_symbol'), 'plain_symbol')
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(demangle(''), '')
+
+    def test_force_format_itanium(self):
+        result = demangle('_Z3foov', fmt=FORMAT_ITANIUM)
+        self.assertEqual(result, 'foo()')
+
+    def test_force_format_msvc(self):
+        result = demangle('?foo@@YAXH@Z', fmt=FORMAT_MSVC)
+        self.assertEqual(result, 'void __cdecl foo(int)')
+
+    def test_version_suffix_stripped(self):
+        self.assertEqual(demangle('foo@@GLIBC_2.4'), 'foo')
+
+    def test_version_suffix_stripped_function(self):
+        self.assertEqual(demangle('_Z3foov@@GLIBC_2.4'), 'foo()')
+
+
+class TestStructuredDispatch(unittest.TestCase):
+    """Test structured output through the main dispatch."""
+
+    def test_itanium_structured(self):
+        sym = demangle('_ZN3foo3barEv', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, FORMAT_ITANIUM)
+        self.assertEqual(sym.full_name, 'foo::bar()')
+
+    def test_msvc_structured(self):
+        sym = demangle('?foo@@YAXH@Z', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, FORMAT_MSVC)
+
+    def test_unknown_structured(self):
+        sym = demangle('plain_symbol', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, FORMAT_UNKNOWN)
+
+    def test_original_preserved_with_version(self):
+        sym = demangle('_ZN3foo3barEv@@GLIBC_2.4', structured=True)
+        self.assertEqual(sym.original_mangled, '_ZN3foo3barEv@@GLIBC_2.4')
+        self.assertEqual(sym.full_name, 'foo::bar()')
+
+    def test_original_preserved_plain(self):
+        sym = demangle('_ZN3foo3barEv', structured=True)
+        self.assertEqual(sym.original_mangled, '_ZN3foo3barEv')
+
+
+class TestGracefulDegradation(unittest.TestCase):
+    """Test that demangle() never raises on any input."""
+
+    def test_truncated_itanium(self):
+        result = demangle('_Z')
+        self.assertIsInstance(result, str)
+
+    def test_invalid_char_itanium(self):
+        result = demangle('_Z!')
+        self.assertIsInstance(result, str)
+
+    def test_truncated_msvc(self):
+        result = demangle('?')
+        self.assertIsInstance(result, str)
+
+    def test_double_question_msvc(self):
+        result = demangle('???')
+        self.assertIsInstance(result, str)
+
+    def test_binary_garbage(self):
+        result = demangle('\x00\x01\x02\x03')
+        self.assertIsInstance(result, str)
+
+    def test_very_long_input(self):
+        result = demangle('a' * 10000)
+        self.assertIsInstance(result, str)
+
+    def test_null_bytes(self):
+        result = demangle('\x00\x00\x00')
+        self.assertIsInstance(result, str)
+
+    def test_unicode(self):
+        result = demangle('café_function')
+        self.assertIsInstance(result, str)
+
+    def test_mixed_prefixes(self):
+        # Inputs that look like they might match multiple formats
+        for inp in ['_Z?foo', '?_Zfoo', 'Java_?foo', '$s?foo']:
+            result = demangle(inp)
+            self.assertIsInstance(result, str,
+                                  'demangle(%r) crashed' % inp)
+
+    def test_no_crash_on_partial_mangled(self):
+        partials = [
+            '_Z3', '_ZN3', '_ZN3foo', '_ZTV', '_ZTI', '_ZTS',
+            '?foo', '?foo@', '?foo@@', '??0', '??1', '??_7',
+            '_R', '_D', '$s', '_T0', 'Java_',
+        ]
+        for inp in partials:
+            result = demangle(inp)
+            self.assertIsInstance(result, str,
+                                  'demangle(%r) crashed' % inp)
+
+
+class TestDemangleError(unittest.TestCase):
+    """Test DemangleError exception class."""
+
+    def test_is_exception(self):
+        self.assertTrue(issubclass(DemangleError, Exception))
+
+    def test_can_raise(self):
+        with self.assertRaises(DemangleError):
+            raise DemangleError('test error')
+
+    def test_has_message(self):
+        try:
+            raise DemangleError('test message')
+        except DemangleError as e:
+            self.assertIn('test message', str(e))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivisect/tests/test_demangle_d_swift.py
+++ b/vivisect/tests/test_demangle_d_swift.py
@@ -1,0 +1,288 @@
+"""
+Comprehensive tests for D language and Swift demangling.
+
+D tests cover:
+    - Basic functions with all primitive types
+    - Pointers, arrays, static arrays, references
+    - Function types with parameters and return types
+    - Type qualifiers (const, immutable, shared, wild)
+    - Delegate types
+    - Special names (main, __initZ, __vtblZ)
+    - Type/symbol back-references
+    - Structured output
+    - Graceful degradation
+
+Swift tests cover:
+    - Module + function name extraction
+    - Variable and class types
+    - Type suffix parsing (basic)
+    - Escape sequence decoding
+    - Structured output
+    - Graceful degradation
+"""
+
+import unittest
+
+from vivisect.demangle import demangle, detect_format
+from vivisect.demangle.dlang import demangle_d
+from vivisect.demangle.swift import demangle_swift
+from vivisect.demangle.common import DemangledSymbol
+
+
+# ===== D LANGUAGE TESTS =====
+
+class TestDBasicFunctions(unittest.TestCase):
+    """Test basic D function demangling."""
+
+    def test_simple_function(self):
+        self.assertEqual(demangle_d('_D3foo3barFiZv'), 'foo.bar(int) void')
+
+    def test_main(self):
+        self.assertEqual(demangle_d('_Dmain'), 'D main')
+
+    def test_multiple_params(self):
+        self.assertEqual(demangle_d('_D3foo3barFiiZi'), 'foo.bar(int, int) int')
+
+    def test_void_params(self):
+        self.assertEqual(demangle_d('_D3foo3barFvZv'), 'foo.bar(void) void')
+
+    def test_returns_str(self):
+        result = demangle_d('_D3foo3barFiZv')
+        self.assertIsInstance(result, str)
+
+    def test_qualified_name(self):
+        result = demangle_d('_D3foo3bar4bazFiZv')
+        self.assertIn('foo', result)
+        self.assertIn('bar', result)
+
+
+class TestDPrimitiveTypes(unittest.TestCase):
+    """Test all D primitive type codes."""
+
+    def test_int(self):
+        self.assertIn('int', demangle_d('_D3foo3barFiZv'))
+
+    def test_void(self):
+        self.assertIn('void', demangle_d('_D3foo3barFvZv'))
+
+    def test_bool(self):
+        self.assertIn('bool', demangle_d('_D3foo3barFbZv'))
+
+    def test_long(self):
+        self.assertIn('long', demangle_d('_D3foo3barFkZv'))
+
+    def test_float(self):
+        self.assertIn('float', demangle_d('_D3foo3barFfZv'))
+
+    def test_double(self):
+        self.assertIn('double', demangle_d('_D3foo3barFdZv'))
+
+    def test_char(self):
+        self.assertIn('char', demangle_d('_D3foo3barFaZv'))
+
+    def test_wchar(self):
+        self.assertIn('wchar', demangle_d('_D3foo3barFuZv'))
+
+    def test_dchar(self):
+        self.assertIn('dchar', demangle_d('_D3foo3barFwZv'))
+
+
+class TestDCompositeTypes(unittest.TestCase):
+    """Test D pointer, array, and composite types."""
+
+    def test_pointer(self):
+        self.assertIn('int*', demangle_d('_D3foo3barFPiZv'))
+
+    def test_pointer_to_pointer(self):
+        self.assertIn('int**', demangle_d('_D3foo3barFPPiZv'))
+
+    def test_dynamic_array(self):
+        self.assertIn('int[]', demangle_d('_D3foo3barFAiZv'))
+
+    def test_static_array(self):
+        self.assertIn('int[3]', demangle_d('_D3foo3barG3iZv'))
+
+    def test_array_of_arrays(self):
+        self.assertIn('int[][]', demangle_d('_D3foo3barFAAiZv'))
+
+
+class TestDFunctionTypes(unittest.TestCase):
+    """Test D function type parsing."""
+
+    def test_function_with_return(self):
+        self.assertEqual(demangle_d('_D3foo3barFiZi'), 'foo.bar(int) int')
+
+    def test_function_pointer_param(self):
+        result = demangle_d('_D3foo3barFPiZv')
+        self.assertIn('int*', result)
+
+    def test_multiple_param_types(self):
+        result = demangle_d('_D3foo3barFikfZv')
+        self.assertIn('int', result)
+        self.assertIn('long', result)
+        self.assertIn('float', result)
+
+
+class TestDSpecialNames(unittest.TestCase):
+    """Test D special name suffixes."""
+
+    def test_main(self):
+        self.assertEqual(demangle_d('_Dmain'), 'D main')
+
+    def test_init(self):
+        result = demangle_d('_D3foo6__initZ')
+        self.assertIn('__init', result)
+
+    def test_vtbl(self):
+        result = demangle_d('_D3foo6__vtblZ')
+        self.assertIn('vtbl', result)
+
+
+class TestDStructuredOutput(unittest.TestCase):
+    """Test D structured output."""
+
+    def test_returns_demangled_symbol(self):
+        sym = demangle_d('_D3foo3barFiZv', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'd')
+
+    def test_preserves_original(self):
+        orig = '_D3foo3barFiZv'
+        sym = demangle_d(orig, structured=True)
+        self.assertEqual(sym.original_mangled, orig)
+
+    def test_scope_and_name(self):
+        sym = demangle_d('_D3foo3barFiZv', structured=True)
+        self.assertIn('foo', sym.scope)
+        self.assertIn('bar', sym.name)
+
+
+class TestDGracefulDegradation(unittest.TestCase):
+    """Test D graceful degradation."""
+
+    def test_non_d_returns_original(self):
+        self.assertEqual(demangle_d('plain_function'), 'plain_function')
+
+    def test_empty_string(self):
+        self.assertEqual(demangle_d(''), '')
+
+    def test_just_prefix(self):
+        result = demangle_d('_D')
+        self.assertIsInstance(result, str)
+
+    def test_no_crash_on_garbage(self):
+        result = demangle_d('_D\x00\x01\x02')
+        self.assertIsInstance(result, str)
+
+
+class TestDFormatDetection(unittest.TestCase):
+    """Test D format detection."""
+
+    def test_detect_d(self):
+        self.assertEqual(detect_format('_D3foo3barFiZv'), 'd')
+
+    def test_detect_d_main(self):
+        self.assertEqual(detect_format('_Dmain'), 'd')
+
+    def test_not_d_dynamic(self):
+        self.assertNotEqual(detect_format('_DYNAMIC'), 'd')
+
+
+# ===== SWIFT TESTS =====
+
+class TestSwiftFormatDetection(unittest.TestCase):
+    """Test Swift format detection."""
+
+    def test_detect_s(self):
+        self.assertEqual(detect_format('$s5Hello4testyyF'), 'swift')
+
+    def test_detect_S(self):
+        self.assertEqual(detect_format('$S5Hello4testyyF'), 'swift')
+
+    def test_detect_T0(self):
+        self.assertEqual(detect_format('_T05Hello4testyyF'), 'swift')
+
+
+class TestSwiftDemangle(unittest.TestCase):
+    """Test Swift demangling."""
+
+    def test_basic_module_function(self):
+        result = demangle_swift('$s5Hello4testyyF')
+        self.assertIsInstance(result, str)
+        self.assertIn('Hello', result)
+        self.assertIn('test', result)
+
+    def test_returns_str(self):
+        self.assertIsInstance(demangle_swift('$s5Hello4testyyF'), str)
+
+    def test_underscore_module(self):
+        result = demangle_swift('$s6my_app4mainyyF')
+        self.assertIn('my_app', result)
+
+    def test_class_type(self):
+        result = demangle_swift('$s5Hello5WorldC')
+        self.assertIn('Hello', result)
+        self.assertIn('World', result)
+
+
+class TestSwiftStructuredOutput(unittest.TestCase):
+    """Test Swift structured output."""
+
+    def test_structured(self):
+        sym = demangle_swift('$s5Hello4testyyF', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'swift')
+
+    def test_structured_original(self):
+        orig = '$s5Hello4testyyF'
+        sym = demangle_swift(orig, structured=True)
+        self.assertEqual(sym.original_mangled, orig)
+
+
+class TestSwiftGracefulDegradation(unittest.TestCase):
+    """Test Swift graceful degradation."""
+
+    def test_non_swift_returns_original(self):
+        self.assertEqual(demangle_swift('plain_function'), 'plain_function')
+
+    def test_empty_string(self):
+        self.assertEqual(demangle_swift(''), '')
+
+    def test_invalid_swift(self):
+        result = demangle_swift('$s')
+        self.assertIsInstance(result, str)
+
+    def test_no_crash_on_garbage(self):
+        result = demangle_swift('$s\x00\x01\x02')
+        self.assertIsInstance(result, str)
+
+
+# ===== DISPATCH TESTS =====
+
+class TestDAndSwiftDispatch(unittest.TestCase):
+    """Test D and Swift through the main demangle() dispatch."""
+
+    def test_d_dispatch(self):
+        result = demangle('_D3foo3barFiZv')
+        self.assertIsInstance(result, str)
+
+    def test_swift_dispatch(self):
+        result = demangle('$s5Hello4testyyF')
+        self.assertIsInstance(result, str)
+
+    def test_d_structured(self):
+        sym = demangle('_D3foo3barFiZv', structured=True)
+        self.assertEqual(sym.format, 'd')
+
+    def test_swift_structured(self):
+        sym = demangle('$s5Hello4testyyF', structured=True)
+        self.assertEqual(sym.format, 'swift')
+
+    def test_never_raises(self):
+        for inp in ['_D', '$s', '_T0', '$S', '_D\x00', '$s\x00']:
+            result = demangle(inp)
+            self.assertIsInstance(result, str, 'demangle(%r) crashed' % inp)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivisect/tests/test_demangle_itanium.py
+++ b/vivisect/tests/test_demangle_itanium.py
@@ -1,0 +1,640 @@
+"""
+Comprehensive tests for the Itanium C++ ABI demangling module.
+
+Tests cover:
+- Simple functions with various return types and parameters
+- Nested names (namespaces, classes)
+- Templates and template arguments
+- Special names (vtable, typeinfo, VTT, guard variables)
+- Constructors and destructors
+- Operators (all categories)
+- CV qualifiers (const, volatile, restrict)
+- Reference types (lvalue, rvalue)
+- Pointers and arrays
+- Substitutions and back-references
+- Standard substitutions (std::, std::string, etc.)
+- Pointer-to-member types
+- Function types with CV/ref qualifiers
+- Version suffix stripping
+- Structured output (DemangledSymbol)
+- Graceful degradation on invalid input
+- Edge cases (empty, truncated, binary garbage)
+"""
+
+import unittest
+
+from vivisect.demangle import demangle, detect_format, DemangledSymbol
+from vivisect.demangle.itanium import demangle_itanium, demangle_itanium_symbol
+from vivisect.demangle.itanium.parser import ItaniumParser, ParseError
+from vivisect.demangle.itanium.renderer import render
+from vivisect.demangle.itanium import ast_nodes as ast
+from vivisect.demangle.itanium import grammar
+
+
+class TestItaniumBasicFunctions(unittest.TestCase):
+    """Test basic Itanium function demangling."""
+
+    def test_void_function_no_params(self):
+        self.assertEqual(demangle_itanium('_Z3foov'), 'foo()')
+
+    def test_void_function_void_param(self):
+        # _Z3foo v — v is void, meaning no parameters
+        self.assertEqual(demangle_itanium('_Z3foov'), 'foo()')
+
+    def test_int_function_int_param(self):
+        self.assertEqual(demangle_itanium('_Z3fooii'), 'foo(int, int)')
+
+    def test_simple_name_no_encoding(self):
+        # _Z3foo is just a name (no function type)
+        self.assertEqual(demangle_itanium('_Z3foo'), 'foo')
+
+    def test_double_return(self):
+        result = demangle_itanium('_Z3food')
+        self.assertIn('double', result)
+
+    def test_float_param(self):
+        result = demangle_itanium('_Z3foof')
+        self.assertIn('float', result)
+
+    def test_char_param(self):
+        result = demangle_itanium('_Z3fooc')
+        self.assertIn('char', result)
+
+    def test_bool_param(self):
+        result = demangle_itanium('_Z3foob')
+        self.assertIn('bool', result)
+
+    def test_long_param(self):
+        result = demangle_itanium('_Z3fool')
+        self.assertIn('long', result)
+
+    def test_unsigned_int_param(self):
+        result = demangle_itanium('_Z3fooj')
+        self.assertIn('unsigned int', result)
+
+    def test_unsigned_long_param(self):
+        result = demangle_itanium('_Z3foom')
+        self.assertIn('unsigned long', result)
+
+    def test_long_long_param(self):
+        result = demangle_itanium('_Z3foox')
+        self.assertIn('long long', result)
+
+    def test_short_param(self):
+        result = demangle_itanium('_Z3foos')
+        self.assertIn('short', result)
+
+    def test_wchar_t_param(self):
+        result = demangle_itanium('_Z3foow')
+        self.assertIn('wchar_t', result)
+
+    def test_ellipsis_param(self):
+        result = demangle_itanium('_Z3foozi')
+        self.assertIn('...', result)
+
+    def test_multiple_params(self):
+        result = demangle_itanium('_Z3fooibdc')
+        # Should contain int, bool, double, char
+        self.assertIn('int', result)
+        self.assertIn('bool', result)
+        self.assertIn('double', result)
+        self.assertIn('char', result)
+
+
+class TestItaniumBuiltinTypes(unittest.TestCase):
+    """Test all builtin type codes."""
+
+    def test_signed_char(self):
+        result = demangle_itanium('_Z3fooa')
+        self.assertIn('signed char', result)
+
+    def test_unsigned_char(self):
+        result = demangle_itanium('_Z3fooh')
+        self.assertIn('unsigned char', result)
+
+    def test_long_double(self):
+        result = demangle_itanium('_Z3fooe')
+        self.assertIn('long double', result)
+
+    def test_float128(self):
+        result = demangle_itanium('_Z3foog')
+        self.assertIn('__float128', result)
+
+    def test_int128(self):
+        result = demangle_itanium('_Z3foon')
+        self.assertIn('__int128', result)
+
+    def test_unsigned_int128(self):
+        result = demangle_itanium('_Z3fooo')
+        self.assertIn('unsigned __int128', result)
+
+    def test_unsigned_short(self):
+        result = demangle_itanium('_Z3foot')
+        self.assertIn('unsigned short', result)
+
+    def test_unsigned_long_long(self):
+        result = demangle_itanium('_Z3fooy')
+        self.assertIn('unsigned long long', result)
+
+    def test_extended_decimal64(self):
+        result = demangle_itanium('_Z3fooDd')
+        self.assertIn('decimal64', result)
+
+    def test_extended_decimal128(self):
+        result = demangle_itanium('_Z3fooDe')
+        self.assertIn('decimal128', result)
+
+    def test_extended_char32_t(self):
+        result = demangle_itanium('_Z3fooDi')
+        self.assertIn('char32_t', result)
+
+    def test_extended_char16_t(self):
+        result = demangle_itanium('_Z3fooDs')
+        self.assertIn('char16_t', result)
+
+    def test_extended_char8_t(self):
+        result = demangle_itanium('_Z3fooDu')
+        self.assertIn('char8_t', result)
+
+    def test_extended_auto(self):
+        result = demangle_itanium('_Z3fooDa')
+        self.assertIn('auto', result)
+
+
+class TestItaniumNestedNames(unittest.TestCase):
+    """Test nested names (namespaces, classes)."""
+
+    def test_single_namespace(self):
+        self.assertEqual(demangle_itanium('_ZN3foo3barEv'),
+                         'foo::bar()')
+
+    def test_double_namespace(self):
+        self.assertEqual(demangle_itanium('_ZN3foo3bar3bazEv'),
+                         'foo::bar::baz()')
+
+    def test_deep_namespace(self):
+        result = demangle_itanium('_ZN2ns12nested_class4funcEv')
+        self.assertIn('ns', result)
+        self.assertIn('nested_class', result)
+        self.assertIn('func', result)
+
+    def test_std_namespace(self):
+        result = demangle_itanium('_ZSt5state')
+        self.assertIn('std', result)
+
+
+class TestItaniumSpecialNames(unittest.TestCase):
+    """Test special name demangling (vtable, typeinfo, etc.)."""
+
+    def test_vtable(self):
+        self.assertEqual(demangle_itanium('_ZTV1A'), 'vtable for A')
+
+    def test_typeinfo(self):
+        self.assertEqual(demangle_itanium('_ZTI1A'), 'typeinfo for A')
+
+    def test_typeinfo_name(self):
+        self.assertEqual(demangle_itanium('_ZTS1A'), 'typeinfo name for A')
+
+    def test_vtt(self):
+        result = demangle_itanium('_ZTT1A')
+        self.assertIn('VTT', result)
+        self.assertIn('A', result)
+
+    def test_guard_variable(self):
+        result = demangle_itanium('_ZGV1A')
+        self.assertIn('guard', result)
+
+
+class TestItaniumConstructorsDestructors(unittest.TestCase):
+    """Test constructor and destructor demangling."""
+
+    def test_complete_constructor(self):
+        result = demangle_itanium('_ZN1AC1Ev')
+        self.assertIn('A', result)
+
+    def test_base_constructor(self):
+        result = demangle_itanium('_ZN1AC2Ev')
+        self.assertIn('A', result)
+
+    def test_deleting_destructor(self):
+        result = demangle_itanium('_ZN1AD0Ev')
+        self.assertIn('~A', result)
+
+    def test_complete_destructor(self):
+        result = demangle_itanium('_ZN1AD1Ev')
+        self.assertIn('~A', result)
+
+    def test_base_destructor(self):
+        result = demangle_itanium('_ZN1AD2Ev')
+        self.assertIn('~A', result)
+
+
+class TestItaniumOperators(unittest.TestCase):
+    """Test operator demangling."""
+
+    def test_operator_plus(self):
+        result = demangle_itanium('_ZN1aplEi')
+        self.assertIn('operator+', result)
+
+    def test_operator_minus(self):
+        result = demangle_itanium('_ZN1amiEi')
+        self.assertIn('operator-', result)
+
+    def test_operator_assign(self):
+        result = demangle_itanium('_ZN1aaSEi')
+        self.assertIn('operator=', result)
+
+    def test_operator_call(self):
+        result = demangle_itanium('_ZN1aclEv')
+        self.assertIn('operator()', result)
+
+    def test_operator_subscript(self):
+        result = demangle_itanium('_ZN1aixEi')
+        self.assertIn('operator[]', result)
+
+    def test_operator_new(self):
+        result = demangle_itanium('_Znwm')
+        self.assertIn('operator', result)
+        self.assertIn('new', result)
+
+    def test_operator_delete(self):
+        result = demangle_itanium('_ZdlPv')
+        self.assertIn('operator', result)
+        self.assertIn('delete', result)
+
+    def test_operator_shift_left(self):
+        result = demangle_itanium('_ZN1alsEi')
+        self.assertIn('operator<<', result)
+
+    def test_operator_shift_right(self):
+        result = demangle_itanium('_ZN1arsEi')
+        self.assertIn('operator>>', result)
+
+    def test_operator_equals(self):
+        result = demangle_itanium('_ZN1aeqEi')
+        self.assertIn('operator==', result)
+
+    def test_operator_not_equals(self):
+        result = demangle_itanium('_ZN1aneEi')
+        self.assertIn('operator!=', result)
+
+    def test_operator_less(self):
+        result = demangle_itanium('_ZN1altEi')
+        self.assertIn('operator<', result)
+
+    def test_operator_greater(self):
+        result = demangle_itanium('_ZN1agtEi')
+        self.assertIn('operator>', result)
+
+    def test_operator_arrow(self):
+        result = demangle_itanium('_ZN1aptEi')
+        self.assertIn('operator->', result)
+
+
+class TestItaniumPointersReferences(unittest.TestCase):
+    """Test pointer, reference, and CV-qualified types."""
+
+    def test_pointer_to_int(self):
+        result = demangle_itanium('_Z3fooPi')
+        self.assertIn('int', result)
+        self.assertIn('*', result)
+
+    def test_pointer_to_char(self):
+        result = demangle_itanium('_Z3fooPc')
+        self.assertIn('char', result)
+        self.assertIn('*', result)
+
+    def test_double_pointer(self):
+        result = demangle_itanium('_Z3fooPPi')
+        self.assertIn('int', result)
+        self.assertIn('*', result)
+
+    def test_lvalue_reference(self):
+        result = demangle_itanium('_Z3fooRi')
+        self.assertIn('int', result)
+        self.assertIn('&', result)
+
+    def test_rvalue_reference(self):
+        result = demangle_itanium('_Z3fooOi')
+        self.assertIn('int', result)
+        self.assertIn('&&', result)
+
+    def test_const_int(self):
+        result = demangle_itanium('_Z3fooKi')
+        self.assertIn('const', result)
+        self.assertIn('int', result)
+
+    def test_volatile_int(self):
+        result = demangle_itanium('_Z3fooVi')
+        self.assertIn('volatile', result)
+        self.assertIn('int', result)
+
+    def test_const_pointer(self):
+        result = demangle_itanium('_Z3fooPKi')
+        self.assertIn('const', result)
+        self.assertIn('int', result)
+        self.assertIn('*', result)
+
+    def test_pointer_to_const(self):
+        result = demangle_itanium('_Z3fooPKi')
+        # PKi = pointer to const int (Itanium renders as "int const*")
+        self.assertIn('const', result)
+        self.assertIn('int', result)
+        self.assertIn('*', result)
+
+
+class TestItaniumTemplates(unittest.TestCase):
+    """Test template demangling."""
+
+    def test_simple_template(self):
+        result = demangle_itanium('_ZN1N1TIiiE2mfES0_IddE')
+        self.assertIn('N::T', result)
+
+    def test_template_args(self):
+        result = demangle_itanium('_Z3fooIiEvT_')
+        # foo<int>(int)
+        self.assertIn('foo', result)
+
+
+class TestItaniumPointerToMember(unittest.TestCase):
+    """Test pointer-to-member types."""
+
+    def test_ptr_to_member_data(self):
+        result = demangle_itanium('_Z1fM1Ai')
+        self.assertIn('A::*', result)
+        self.assertIn('int', result)
+
+    def test_ptr_to_member_function_const_ref(self):
+        self.assertEqual(demangle_itanium('_Z1fM1AKFvvRE'),
+                         'f(void (A::*)() const &)')
+
+    def test_ptr_to_member_function_const(self):
+        self.assertEqual(demangle_itanium('_Z1fM1AKFvvE'),
+                         'f(void (A::*)() const)')
+
+    def test_ptr_to_member_function_plain(self):
+        self.assertEqual(demangle_itanium('_Z1fM1AFvvE'),
+                         'f(void (A::*)())')
+
+    def test_ptr_to_member_function_ref(self):
+        self.assertEqual(demangle_itanium('_Z1fM1AFvvRE'),
+                         'f(void (A::*)() &)')
+
+    def test_ptr_to_member_function_const_rvalue(self):
+        self.assertEqual(demangle_itanium('_Z1fM1AKFvvOE'),
+                         'f(void (A::*)() const &&)')
+
+
+class TestItaniumSubstitutions(unittest.TestCase):
+    """Test substitution and back-reference handling."""
+
+    def test_std_substitution(self):
+        result = demangle_itanium('_ZSt5state')
+        self.assertIn('std', result)
+
+    def test_std_string_substitution(self):
+        result = demangle_itanium('_ZSs')
+        # Ss = std::string
+        self.assertIn('std', result)
+
+    def test_substitution_backref(self):
+        # _Z3fooPiS_ — S_ refers to the first substitution (int*)
+        result = demangle_itanium('_Z3fooPiS_')
+        self.assertIn('int', result)
+        self.assertIn('*', result)
+
+
+class TestItaniumVersionSuffix(unittest.TestCase):
+    """Test @@VERSION suffix handling."""
+
+    def test_strip_glibc_suffix(self):
+        self.assertEqual(demangle_itanium('_Z3foo@@GLIBC_2.4'), 'foo')
+
+    def test_strip_glibc_suffix_function(self):
+        self.assertEqual(demangle_itanium('_Z3foov@@GLIBC_2.4'), 'foo()')
+
+    def test_strip_long_version(self):
+        result = demangle_itanium('_Z3foo@@GLIBC_2.17')
+        self.assertEqual(result, 'foo')
+
+
+class TestItaniumStructuredOutput(unittest.TestCase):
+    """Test structured DemangledSymbol output."""
+
+    def test_structured_function(self):
+        sym = demangle_itanium('_ZN3foo3barEv', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'itanium')
+        self.assertEqual(sym.full_name, 'foo::bar()')
+        self.assertEqual(sym.original_mangled, '_ZN3foo3barEv')
+
+    def test_structured_vtable(self):
+        sym = demangle_itanium('_ZTV1A', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.kind, 'vtable')
+        self.assertEqual(sym.name, 'A')
+
+    def test_structured_typeinfo(self):
+        sym = demangle_itanium('_ZTI1A', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.kind, 'typeinfo')
+
+    def test_structured_typeinfo_name(self):
+        sym = demangle_itanium('_ZTS1A', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.kind, 'typeinfo_name')
+
+    def test_symbol_object(self):
+        sym = demangle_itanium_symbol('_ZN3foo3barEv')
+        self.assertIsNotNone(sym)
+        self.assertEqual(sym.format, 'itanium')
+        self.assertEqual(sym.demangled, 'foo::bar()')
+
+    def test_symbol_original_preserved(self):
+        sym = demangle_itanium_symbol('_ZN3foo3barEv@@GLIBC_2.4')
+        self.assertEqual(sym.original, '_ZN3foo3barEv@@GLIBC_2.4')
+        self.assertEqual(sym.demangled, 'foo::bar()')
+
+
+class TestItaniumGracefulDegradation(unittest.TestCase):
+    """Test graceful degradation on invalid input."""
+
+    def test_truncated_input(self):
+        result = demangle_itanium('_Z')
+        self.assertIsInstance(result, str)
+
+    def test_invalid_char(self):
+        result = demangle_itanium('_Z!')
+        self.assertIsInstance(result, str)
+
+    def test_empty_string(self):
+        result = demangle_itanium('')
+        self.assertEqual(result, '')
+
+    def test_non_mangled(self):
+        result = demangle_itanium('plain_function')
+        self.assertEqual(result, 'plain_function')
+
+    def test_garbage_input(self):
+        result = demangle_itanium('\x00\x01\x02\x03')
+        self.assertIsInstance(result, str)
+
+    def test_long_input(self):
+        result = demangle_itanium('a' * 1000)
+        self.assertIsInstance(result, str)
+
+    def test_no_crash_on_partial(self):
+        # Partial mangled names should not crash
+        for partial in ['_Z3', '_ZN3', '_ZN3foo', '_ZTV', '_ZTI']:
+            result = demangle_itanium(partial)
+            self.assertIsInstance(result, str,
+                                  'demangle_itanium(%r) crashed' % partial)
+
+
+class TestItaniumParserDirect(unittest.TestCase):
+    """Test the parser directly (AST-level tests)."""
+
+    def test_parser_returns_ast(self):
+        parser = ItaniumParser('_ZN3foo3barEv')
+        node = parser.parse()
+        self.assertIsNotNone(node)
+
+    def test_parser_simple_function(self):
+        parser = ItaniumParser('_Z3foov')
+        node = parser.parse()
+        self.assertIsInstance(node, ast.Name)
+
+    def test_parser_vtable(self):
+        parser = ItaniumParser('_ZTV1A')
+        node = parser.parse()
+        self.assertIsInstance(node, ast.SpecialName)
+        self.assertEqual(node.kind, 'vtable')
+
+    def test_parser_typeinfo(self):
+        parser = ItaniumParser('_ZTI1A')
+        node = parser.parse()
+        self.assertIsInstance(node, ast.SpecialName)
+        self.assertEqual(node.kind, 'typeinfo')
+
+    def test_parser_raises_on_empty(self):
+        parser = ItaniumParser('')
+        with self.assertRaises(ParseError):
+            parser.parse()
+
+    def test_renderer_renders_ast(self):
+        parser = ItaniumParser('_ZN3foo3barEv')
+        node = parser.parse()
+        result = render(node, subs=parser.subs)
+        self.assertEqual(result, 'foo::bar()')
+
+    def test_substitutions_populated(self):
+        parser = ItaniumParser('_ZN3foo3barEv')
+        parser.parse()
+        # After parsing a nested name, there should be substitutions
+        self.assertIsInstance(parser.subs, list)
+
+
+class TestItaniumGrammarConstants(unittest.TestCase):
+    """Test that grammar lookup tables are properly populated."""
+
+    def test_builtin_types_has_int(self):
+        self.assertIn('i', grammar.BUILTIN_TYPES)
+        self.assertEqual(grammar.BUILTIN_TYPES['i'], 'int')
+
+    def test_builtin_types_has_void(self):
+        self.assertIn('v', grammar.BUILTIN_TYPES)
+        self.assertEqual(grammar.BUILTIN_TYPES['v'], 'void')
+
+    def test_builtin_types_has_double(self):
+        self.assertIn('d', grammar.BUILTIN_TYPES)
+        self.assertEqual(grammar.BUILTIN_TYPES['d'], 'double')
+
+    def test_operators_has_plus(self):
+        self.assertIn('pl', grammar.OPERATORS)
+        symbol, num_args = grammar.OPERATORS['pl']
+        self.assertEqual(symbol, '+')
+        self.assertEqual(num_args, 2)
+
+    def test_operators_has_new(self):
+        self.assertIn('nw', grammar.OPERATORS)
+
+    def test_operators_has_delete(self):
+        self.assertIn('dl', grammar.OPERATORS)
+
+    def test_ctor_kinds(self):
+        self.assertIn('C1', grammar.CTOR_KINDS)
+        self.assertEqual(grammar.CTOR_KINDS['C1'], 'complete')
+
+    def test_dtor_kinds(self):
+        self.assertIn('D0', grammar.DTOR_KINDS)
+        self.assertEqual(grammar.DTOR_KINDS['D0'], 'deleting')
+
+    def test_std_subs(self):
+        self.assertIn('t', grammar.STD_SUBS)
+        self.assertEqual(grammar.STD_SUBS['t'], 'std')
+
+    def test_special_names_vtable(self):
+        self.assertIn('TV', grammar.SPECIAL_NAMES)
+        self.assertEqual(grammar.SPECIAL_NAMES['TV'], 'vtable')
+
+    def test_special_names_typeinfo(self):
+        self.assertIn('TI', grammar.SPECIAL_NAMES)
+        self.assertEqual(grammar.SPECIAL_NAMES['TI'], 'typeinfo')
+
+
+class TestItaniumASTNodes(unittest.TestCase):
+    """Test AST node classes."""
+
+    def test_node_repr(self):
+        node = ast.Node()
+        self.assertIn('Node', repr(node))
+
+    def test_source_name(self):
+        node = ast.SourceName('foo')
+        self.assertEqual(node.name, 'foo')
+
+    def test_builtin_type(self):
+        node = ast.BuiltinType('int', 'i')
+        self.assertEqual(node.name, 'int')
+        self.assertEqual(node.code, 'i')
+
+    def test_pointer_type(self):
+        target = ast.BuiltinType('int', 'i')
+        ptr = ast.PointerType(target)
+        self.assertIs(ptr.target, target)
+        self.assertEqual(ptr.children(), [target])
+
+    def test_nested_name(self):
+        prefix = [ast.SourceName('foo')]
+        unq = ast.UnqualifiedName('source', ast.SourceName('bar'))
+        nn = ast.NestedName(prefix, unq)
+        self.assertEqual(len(nn.prefix), 1)
+        self.assertIs(nn.unqualified_name, unq)
+
+    def test_template_args(self):
+        arg1 = ast.BuiltinType('int', 'i')
+        args = ast.TemplateArgs([arg1])
+        self.assertEqual(len(args.args), 1)
+        self.assertEqual(args.children(), [arg1])
+
+    def test_special_name(self):
+        target = ast.BuiltinType('int', 'i')
+        sn = ast.SpecialName('vtable', target)
+        self.assertEqual(sn.kind, 'vtable')
+        self.assertIs(sn.target, target)
+        self.assertEqual(sn.children(), [target])
+
+    def test_special_name_no_target(self):
+        sn = ast.SpecialName('guard')
+        self.assertIsNone(sn.target)
+        self.assertEqual(sn.children(), [])
+
+    def test_pointer_to_member(self):
+        cls = ast.BuiltinType('A', 'i')
+        member = ast.BuiltinType('int', 'i')
+        ptm = ast.PointerToMember(cls, member)
+        self.assertEqual(len(ptm.children()), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivisect/tests/test_demangle_jni.py
+++ b/vivisect/tests/test_demangle_jni.py
@@ -1,0 +1,217 @@
+"""
+Comprehensive tests for the JNI (Java Native Interface) demangling module.
+
+Tests cover:
+- Simple (non-overloaded) method names
+- Overloaded method names with type signatures
+- All JNI primitive type descriptors
+- Object types (L<class>;)
+- Array types (multi-dimensional)
+- Escape sequences (_1, _2, _3, _00024, _0xxxx)
+- Class/method name splitting
+- Structured output
+- Graceful degradation
+"""
+
+import unittest
+
+from vivisect.demangle import demangle, detect_format
+from vivisect.demangle.jni import demangle_jni, _unmangle_jni_string, _parse_jni_signature
+from vivisect.demangle.common import DemangledSymbol
+
+
+class TestJNIFunctionDemangle(unittest.TestCase):
+    """Test JNI method name demangling."""
+
+    def test_simple_method(self):
+        result = demangle_jni('Java_pkg_Cls_f')
+        self.assertIn('pkg', result)
+        self.assertIn('Cls', result)
+        self.assertIn('f', result)
+
+    def test_deep_package(self):
+        result = demangle_jni('Java_com_example_deep_pkg_Cls_method')
+        self.assertIn('com', result)
+        self.assertIn('example', result)
+        self.assertIn('method', result)
+
+    def test_overloaded_method_int_string(self):
+        result = demangle_jni('Java_pkg_Cls_f__ILjava_lang_String_2')
+        self.assertIn('int', result)
+        self.assertIn('java.lang.String', result)
+
+    def test_overloaded_method_multiple_types(self):
+        result = demangle_jni('Java_pkg_Cls_g__IJFDZB')
+        self.assertIn('int', result)
+        self.assertIn('long', result)
+        self.assertIn('float', result)
+        self.assertIn('double', result)
+        self.assertIn('boolean', result)
+        self.assertIn('byte', result)
+
+
+class TestJNIPrimitiveTypes(unittest.TestCase):
+    """Test all JNI primitive type descriptors."""
+
+    def test_int(self):
+        params = _parse_jni_signature('I')
+        self.assertEqual(params, ['int'])
+
+    def test_boolean(self):
+        params = _parse_jni_signature('Z')
+        self.assertEqual(params, ['boolean'])
+
+    def test_byte(self):
+        params = _parse_jni_signature('B')
+        self.assertEqual(params, ['byte'])
+
+    def test_char(self):
+        params = _parse_jni_signature('C')
+        self.assertEqual(params, ['char'])
+
+    def test_short(self):
+        params = _parse_jni_signature('S')
+        self.assertEqual(params, ['short'])
+
+    def test_long(self):
+        params = _parse_jni_signature('J')
+        self.assertEqual(params, ['long'])
+
+    def test_float(self):
+        params = _parse_jni_signature('F')
+        self.assertEqual(params, ['float'])
+
+    def test_double(self):
+        params = _parse_jni_signature('D')
+        self.assertEqual(params, ['double'])
+
+    def test_void(self):
+        params = _parse_jni_signature('V')
+        self.assertEqual(params, ['void'])
+
+
+class TestJNIObjectTypes(unittest.TestCase):
+    """Test JNI object type descriptors (L<class>;)."""
+
+    def test_simple_object(self):
+        params = _parse_jni_signature('Ljava/lang/String;')
+        self.assertEqual(params, ['java.lang.String'])
+
+    def test_object_with_package(self):
+        params = _parse_jni_signature('Lcom/example/MyClass;')
+        self.assertEqual(params, ['com.example.MyClass'])
+
+    def test_multiple_objects(self):
+        params = _parse_jni_signature('Ljava/lang/String;Ljava/util/List;')
+        self.assertEqual(params, ['java.lang.String', 'java.util.List'])
+
+
+class TestJNIArrayTypes(unittest.TestCase):
+    """Test JNI array type descriptors."""
+
+    def test_int_array(self):
+        params = _parse_jni_signature('[I')
+        self.assertEqual(params, ['int[]'])
+
+    def test_object_array(self):
+        params = _parse_jni_signature('[Ljava/lang/String;')
+        self.assertEqual(params, ['java.lang.String[]'])
+
+    def test_multi_dim_array(self):
+        params = _parse_jni_signature('[[I')
+        self.assertEqual(params, ['int[][]'])
+
+    def test_three_dim_array(self):
+        params = _parse_jni_signature('[[[D')
+        self.assertEqual(params, ['double[][][]'])
+
+
+class TestJNIEscapes(unittest.TestCase):
+    """Test JNI escape sequence decoding."""
+
+    def test_underscore_escape(self):
+        # _1 → _
+        result = _unmangle_jni_string('foo_1bar')
+        self.assertEqual(result, 'foo_bar')
+
+    def test_semicolon_escape(self):
+        # _2 → ;
+        result = _unmangle_jni_string('foo_2bar')
+        self.assertEqual(result, 'foo;bar')
+
+    def test_bracket_escape(self):
+        # _3 → [
+        result = _unmangle_jni_string('foo_3bar')
+        self.assertEqual(result, 'foo[bar')
+
+    def test_class_separator(self):
+        # _ → . (default class separator)
+        result = _unmangle_jni_string('pkg_Cls')
+        self.assertEqual(result, 'pkg.Cls')
+
+    def test_slash_separator(self):
+        # _ → / when class_sep='/'
+        result = _unmangle_jni_string('java_lang', class_sep='/')
+        self.assertEqual(result, 'java/lang')
+
+
+class TestJNIStructuredOutput(unittest.TestCase):
+    """Test structured DemangledSymbol output for JNI."""
+
+    def test_structured_function(self):
+        sym = demangle_jni('Java_pkg_Cls_f__ILjava_lang_String_2', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'jni')
+        self.assertEqual(sym.kind, 'function')
+        self.assertIn('int', sym.parameters)
+        self.assertIn('java.lang.String', sym.parameters)
+
+    def test_structured_scope(self):
+        sym = demangle_jni('Java_pkg_Cls_f', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertIn('pkg', sym.scope)
+
+    def test_structured_original(self):
+        orig = 'Java_pkg_Cls_f__ILjava_lang_String_2'
+        sym = demangle_jni(orig, structured=True)
+        self.assertEqual(sym.original_mangled, orig)
+
+
+class TestJNIGracefulDegradation(unittest.TestCase):
+    """Test graceful degradation for invalid JNI names."""
+
+    def test_non_jni_returns_original(self):
+        result = demangle_jni('plain_function')
+        self.assertEqual(result, 'plain_function')
+
+    def test_empty_string(self):
+        result = demangle_jni('')
+        self.assertEqual(result, '')
+
+    def test_non_jni_structured(self):
+        sym = demangle_jni('plain_function', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertTrue(sym.parse_warnings)
+
+
+class TestJNIDispatch(unittest.TestCase):
+    """Test JNI through the main demangle() dispatch."""
+
+    def test_detect_jni(self):
+        self.assertEqual(detect_format('Java_pkg_Cls_f'), 'jni')
+
+    def test_detect_overloaded(self):
+        self.assertEqual(detect_format('Java_pkg_Cls_f__ILjava_lang_String_2'), 'jni')
+
+    def test_demangle_dispatch(self):
+        result = demangle('Java_pkg_Cls_f__ILjava_lang_String_2')
+        self.assertIsInstance(result, str)
+        self.assertIn('int', result)
+
+    def test_demangle_structured(self):
+        sym = demangle('Java_pkg_Cls_f__ILjava_lang_String_2', structured=True)
+        self.assertEqual(sym.format, 'jni')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivisect/tests/test_demangle_msvc.py
+++ b/vivisect/tests/test_demangle_msvc.py
@@ -1,0 +1,221 @@
+"""
+Tests for the MSVC C++ demangling module.
+
+Tests cover:
+- Simple functions (non-member)
+- Member functions (virtual, static, public, private, protected)
+- Constructors and destructors
+- vtable symbols
+- Variables (global and static)
+- Primitive types (int, double, char, unsigned int, long, etc.)
+- Pointer and reference types
+- User-defined types (struct, class, enum, union)
+- Namespace and nested class scope
+- Operators (new, delete)
+"""
+
+import unittest
+
+from vivisect.demangle import demangle, detect_format
+from vivisect.demangle.msvc import demangle_msvc
+from vivisect.demangle.common import DemangledSymbol
+
+
+class TestMSVCDispatch(unittest.TestCase):
+    """Test MSVC format detection and dispatch."""
+
+    def test_detect_msvc(self):
+        self.assertEqual(detect_format('?foo@@YAXH@Z'), 'msvc')
+
+    def test_detect_vtable(self):
+        self.assertEqual(detect_format('??_7MyClass@@6B@'), 'msvc')
+
+    def test_detect_constructor(self):
+        self.assertEqual(detect_format('??0MyClass@@QAE@X@Z'), 'msvc')
+
+    def test_detect_operator(self):
+        self.assertEqual(detect_format('??2@YAPAXI@Z'), 'msvc')
+
+    def test_demangle_dispatch(self):
+        result = demangle('?foo@@YAXH@Z')
+        self.assertEqual(result, 'void __cdecl foo(int)')
+
+
+class TestMSVCNonMemberFunctions(unittest.TestCase):
+    """Test non-member (free) function demangling."""
+
+    def test_simple_void_int(self):
+        self.assertEqual(demangle_msvc('?foo@@YAXH@Z'),
+                         'void __cdecl foo(int)')
+
+    def test_int_return_int_param(self):
+        self.assertEqual(demangle_msvc('?func@@YAHH@Z'),
+                         'int __cdecl func(int)')
+
+    def test_double_return_void(self):
+        self.assertEqual(demangle_msvc('?func2@@YANX@Z'),
+                         'double __cdecl func2(void)')
+
+    def test_reference_param(self):
+        self.assertEqual(demangle_msvc('?func3@@YAXABH@Z'),
+                         'void __cdecl func3(int&)')
+
+    def test_pointer_param(self):
+        self.assertEqual(demangle_msvc('?func4@@YAXPAH@Z'),
+                         'void __cdecl func4(int*)')
+
+    def test_const_pointer_param(self):
+        self.assertEqual(demangle_msvc('?pfunc@@YAXPBH@Z'),
+                         'void __cdecl pfunc(const int*)')
+
+    def test_multiple_params(self):
+        self.assertEqual(demangle_msvc('?multi@@YAHHH@Z'),
+                         'int __cdecl multi(int, int)')
+
+    def test_char_param(self):
+        self.assertEqual(demangle_msvc('?cfunc@@YAXD@Z'),
+                         'void __cdecl cfunc(char)')
+
+    def test_unsigned_int_param(self):
+        self.assertEqual(demangle_msvc('?ufunc@@YAXI@Z'),
+                         'void __cdecl ufunc(unsigned int)')
+
+    def test_long_param(self):
+        self.assertEqual(demangle_msvc('?lfunc@@YAXJ@Z'),
+                         'void __cdecl lfunc(long)')
+
+
+class TestMSVCMemberFunctions(unittest.TestCase):
+    """Test member function demangling."""
+
+    def test_public_virtual(self):
+        self.assertEqual(demangle_msvc('?bar@MyClass@@UAEXH@Z'),
+                         'public: virtual void __thiscall MyClass::bar(int)')
+
+    def test_public_static(self):
+        self.assertEqual(demangle_msvc('?baz@MyClass@@SGXH@Z'),
+                         'public: static void __stdcall MyClass::baz(int)')
+
+    def test_private_member(self):
+        self.assertEqual(demangle_msvc('?priv@MyClass@@AAEXH@Z'),
+                         'private: void __thiscall MyClass::priv(int)')
+
+    def test_protected_member(self):
+        self.assertEqual(demangle_msvc('?prot@MyClass@@IAEXH@Z'),
+                         'protected: void __thiscall MyClass::prot(int)')
+
+
+class TestMSVCSpecialNames(unittest.TestCase):
+    """Test constructor, destructor, vtable, operator demangling."""
+
+    def test_constructor(self):
+        self.assertEqual(demangle_msvc('??0MyClass@@QAE@X@Z'),
+                         'public: __thiscall MyClass::MyClass(void)')
+
+    def test_destructor(self):
+        self.assertEqual(demangle_msvc('??1MyClass@@UAE@X@Z'),
+                         'public: virtual __thiscall MyClass::~MyClass(void)')
+
+    def test_vtable(self):
+        self.assertEqual(demangle_msvc('??_7MyClass@@6B@'),
+                         "const MyClass::`vftable'")
+
+    def test_operator_new(self):
+        self.assertEqual(demangle_msvc('??2@YAPAXI@Z'),
+                         'void* __cdecl operator new(unsigned int)')
+
+    def test_operator_delete(self):
+        self.assertEqual(demangle_msvc('??3@YAXPAX@Z'),
+                         'void __cdecl operator delete(void*)')
+
+
+class TestMSVCVariables(unittest.TestCase):
+    """Test variable demangling."""
+
+    def test_global_int(self):
+        self.assertEqual(demangle_msvc('?myvar@@3HA'),
+                         'int myvar')
+
+    def test_static_member_int(self):
+        self.assertEqual(demangle_msvc('?svar@MyClass@@2HA'),
+                         'public: static int MyClass::svar')
+
+
+class TestMSVCUserDefinedTypes(unittest.TestCase):
+    """Test user-defined type demangling."""
+
+    def test_struct_param(self):
+        self.assertEqual(demangle_msvc('?sfunc@@YAXUMyStruct@@@Z'),
+                         'void __cdecl sfunc(struct MyStruct)')
+
+    def test_class_param(self):
+        self.assertEqual(demangle_msvc('?cfunc2@@YAXVMyClass@@@Z'),
+                         'void __cdecl cfunc2(class MyClass)')
+
+    def test_enum_param(self):
+        self.assertEqual(demangle_msvc('?efunc@@YAXW4MyEnum@@@Z'),
+                         'void __cdecl efunc(enum MyEnum)')
+
+
+class TestMSVCScope(unittest.TestCase):
+    """Test namespace and nested class scope."""
+
+    def test_namespace(self):
+        self.assertEqual(demangle_msvc('?func@ns@@YAXH@Z'),
+                         'void __cdecl ns::func(int)')
+
+    def test_nested_class(self):
+        self.assertEqual(demangle_msvc('?method@Inner@Outer@@UAEXH@Z'),
+                         'public: virtual void __thiscall Outer::Inner::method(int)')
+
+
+class TestMSVCStructuredOutput(unittest.TestCase):
+    """Test structured DemangledSymbol output."""
+
+    def test_structured_function(self):
+        sym = demangle_msvc('?foo@@YAXH@Z', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'msvc')
+        self.assertEqual(sym.full_name, 'void __cdecl foo(int)')
+        self.assertEqual(sym.original_mangled, '?foo@@YAXH@Z')
+
+    def test_structured_member_function(self):
+        sym = demangle_msvc('?bar@MyClass@@UAEXH@Z', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'msvc')
+        self.assertEqual(sym.full_name, 'public: virtual void __thiscall MyClass::bar(int)')
+
+    def test_structured_constructor(self):
+        sym = demangle_msvc('??0MyClass@@QAE@X@Z', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.full_name, 'public: __thiscall MyClass::MyClass(void)')
+
+    def test_structured_vtable(self):
+        sym = demangle_msvc('??_7MyClass@@6B@', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'msvc')
+
+
+class TestMSVCGracefulDegradation(unittest.TestCase):
+    """Test graceful degradation for invalid or unsupported symbols."""
+
+    def test_invalid_symbol_returns_original(self):
+        result = demangle_msvc('?invalid@@@')
+        # Should not crash — returns original or partial result
+        self.assertIsInstance(result, str)
+
+    def test_non_msvc_returns_original(self):
+        result = demangle_msvc('plain_function_name')
+        self.assertEqual(result, 'plain_function_name')
+
+    def test_empty_string(self):
+        result = demangle_msvc('')
+        self.assertEqual(result, '')
+
+    def test_hashed_object_returns_original(self):
+        result = demangle_msvc('??@ABC123@')
+        self.assertEqual(result, '??@ABC123@')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivisect/tests/test_demangle_msvc.py
+++ b/vivisect/tests/test_demangle_msvc.py
@@ -1,60 +1,83 @@
 """
-Tests for the MSVC C++ demangling module.
+Comprehensive tests for the MSVC C++ demangling module.
 
 Tests cover:
-- Simple functions (non-member)
+- Format detection and dispatch
+- Non-member functions (all calling conventions, return types, params)
 - Member functions (virtual, static, public, private, protected)
-- Constructors and destructors
-- vtable symbols
-- Variables (global and static)
-- Primitive types (int, double, char, unsigned int, long, etc.)
-- Pointer and reference types
+- Constructors and destructors (with structor return type encoding)
+- Vtables and vbtibles
+- Operators (all categories: new, delete, arithmetic, comparison, etc.)
+- Variables (global, static member, with access levels)
+- Primitive types (all MSVC type codes)
+- Extended primitive types (_D through _W)
+- Pointer types (with CV modifiers)
+- Reference types (lvalue and rvalue)
 - User-defined types (struct, class, enum, union)
 - Namespace and nested class scope
-- Operators (new, delete)
+- Structured output (DemangledSymbol)
+- AST node tests
+- Parser direct tests
+- Graceful degradation on invalid input
+- Edge cases (empty, truncated, hashed objects)
 """
 
 import unittest
 
 from vivisect.demangle import demangle, detect_format
 from vivisect.demangle.msvc import demangle_msvc
+from vivisect.demangle.msvc.parser import MSVCParser, ParseError
+from vivisect.demangle.msvc.renderer import render
+from vivisect.demangle.msvc import ast_nodes as ast
 from vivisect.demangle.common import DemangledSymbol
 
 
-class TestMSVCDispatch(unittest.TestCase):
-    """Test MSVC format detection and dispatch."""
+class TestMSVCFormatDetection(unittest.TestCase):
+    """Test MSVC format detection from symbol prefix."""
 
-    def test_detect_msvc(self):
+    def test_simple_question(self):
         self.assertEqual(detect_format('?foo@@YAXH@Z'), 'msvc')
 
-    def test_detect_vtable(self):
-        self.assertEqual(detect_format('??_7MyClass@@6B@'), 'msvc')
-
-    def test_detect_constructor(self):
+    def test_double_question_ctor(self):
         self.assertEqual(detect_format('??0MyClass@@QAE@X@Z'), 'msvc')
 
-    def test_detect_operator(self):
+    def test_double_question_dtor(self):
+        self.assertEqual(detect_format('??1MyClass@@UAE@X@Z'), 'msvc')
+
+    def test_vtable_prefix(self):
+        self.assertEqual(detect_format('??_7MyClass@@6B@'), 'msvc')
+
+    def test_operator_new_prefix(self):
         self.assertEqual(detect_format('??2@YAPAXI@Z'), 'msvc')
 
-    def test_demangle_dispatch(self):
-        result = demangle('?foo@@YAXH@Z')
-        self.assertEqual(result, 'void __cdecl foo(int)')
+    def test_operator_delete_prefix(self):
+        self.assertEqual(detect_format('??3@YAXPAX@Z'), 'msvc')
+
+    def test_not_msvc(self):
+        self.assertNotEqual(detect_format('_Z3foov'), 'msvc')
+        self.assertNotEqual(detect_format('Java_pkg_Cls_f'), 'msvc')
+        self.assertNotEqual(detect_format('plain_name'), 'msvc')
 
 
 class TestMSVCNonMemberFunctions(unittest.TestCase):
     """Test non-member (free) function demangling."""
 
-    def test_simple_void_int(self):
+    def test_void_cdecl_int(self):
         self.assertEqual(demangle_msvc('?foo@@YAXH@Z'),
                          'void __cdecl foo(int)')
 
-    def test_int_return_int_param(self):
+    def test_int_cdecl_int(self):
         self.assertEqual(demangle_msvc('?func@@YAHH@Z'),
                          'int __cdecl func(int)')
 
-    def test_double_return_void(self):
+    def test_double_cdecl_void(self):
         self.assertEqual(demangle_msvc('?func2@@YANX@Z'),
                          'double __cdecl func2(void)')
+
+    def test_void_cdecl_no_params(self):
+        # X after calling convention means void return + no args
+        result = demangle_msvc('?foo@@YAXXZ')
+        self.assertIsInstance(result, str)
 
     def test_reference_param(self):
         self.assertEqual(demangle_msvc('?func3@@YAXABH@Z'),
@@ -68,9 +91,14 @@ class TestMSVCNonMemberFunctions(unittest.TestCase):
         self.assertEqual(demangle_msvc('?pfunc@@YAXPBH@Z'),
                          'void __cdecl pfunc(const int*)')
 
-    def test_multiple_params(self):
+    def test_multiple_int_params(self):
         self.assertEqual(demangle_msvc('?multi@@YAHHH@Z'),
                          'int __cdecl multi(int, int)')
+
+    def test_three_params(self):
+        result = demangle_msvc('?three@@YAHHHI@Z')
+        self.assertIn('int', result)
+        self.assertIn('unsigned int', result)
 
     def test_char_param(self):
         self.assertEqual(demangle_msvc('?cfunc@@YAXD@Z'),
@@ -84,41 +112,90 @@ class TestMSVCNonMemberFunctions(unittest.TestCase):
         self.assertEqual(demangle_msvc('?lfunc@@YAXJ@Z'),
                          'void __cdecl lfunc(long)')
 
+    def test_unsigned_long_param(self):
+        result = demangle_msvc('?ulfunc@@YAXK@Z')
+        self.assertIn('unsigned long', result)
+
+    def test_short_param(self):
+        result = demangle_msvc('?sfunc@@YAXF@Z')
+        self.assertIn('short', result)
+
+    def test_unsigned_short_param(self):
+        result = demangle_msvc('?usfunc@@YAXG@Z')
+        self.assertIn('unsigned short', result)
+
+    def test_float_param(self):
+        result = demangle_msvc('?ffunc@@YAXM@Z')
+        self.assertIn('float', result)
+
+    def test_double_param(self):
+        result = demangle_msvc('?dfunc@@YAXN@Z')
+        self.assertIn('double', result)
+
 
 class TestMSVCMemberFunctions(unittest.TestCase):
-    """Test member function demangling."""
+    """Test member function demangling with access levels."""
 
-    def test_public_virtual(self):
+    def test_public_virtual_thiscall(self):
         self.assertEqual(demangle_msvc('?bar@MyClass@@UAEXH@Z'),
                          'public: virtual void __thiscall MyClass::bar(int)')
 
-    def test_public_static(self):
+    def test_public_static_stdcall(self):
         self.assertEqual(demangle_msvc('?baz@MyClass@@SGXH@Z'),
                          'public: static void __stdcall MyClass::baz(int)')
 
-    def test_private_member(self):
+    def test_private_thiscall(self):
         self.assertEqual(demangle_msvc('?priv@MyClass@@AAEXH@Z'),
                          'private: void __thiscall MyClass::priv(int)')
 
-    def test_protected_member(self):
+    def test_protected_thiscall(self):
         self.assertEqual(demangle_msvc('?prot@MyClass@@IAEXH@Z'),
                          'protected: void __thiscall MyClass::prot(int)')
 
+    def test_public_member_thiscall(self):
+        # Q = public, non-virtual, non-static
+        result = demangle_msvc('?method@MyClass@@QAEXH@Z')
+        self.assertIn('public:', result)
+        self.assertIn('__thiscall', result)
+        self.assertIn('MyClass::method', result)
 
-class TestMSVCSpecialNames(unittest.TestCase):
-    """Test constructor, destructor, vtable, operator demangling."""
 
-    def test_constructor(self):
+class TestMSVCConstructorsDestructors(unittest.TestCase):
+    """Test constructor and destructor demangling."""
+
+    def test_constructor_public(self):
         self.assertEqual(demangle_msvc('??0MyClass@@QAE@X@Z'),
                          'public: __thiscall MyClass::MyClass(void)')
 
-    def test_destructor(self):
+    def test_destructor_public_virtual(self):
         self.assertEqual(demangle_msvc('??1MyClass@@UAE@X@Z'),
                          'public: virtual __thiscall MyClass::~MyClass(void)')
+
+    def test_constructor_no_args(self):
+        result = demangle_msvc('??0MyClass@@QAE@X@Z')
+        self.assertIn('MyClass::MyClass', result)
+        self.assertIn('void', result)
+
+    def test_destructor_tilde(self):
+        result = demangle_msvc('??1MyClass@@UAE@X@Z')
+        self.assertIn('~MyClass', result)
+
+
+class TestMSVCVtables(unittest.TestCase):
+    """Test vtable and vbtable demangling."""
 
     def test_vtable(self):
         self.assertEqual(demangle_msvc('??_7MyClass@@6B@'),
                          "const MyClass::`vftable'")
+
+    def test_vtable_simple_class(self):
+        result = demangle_msvc('??_7Foo@@6B@')
+        self.assertIn('vftable', result)
+        self.assertIn('Foo', result)
+
+
+class TestMSVCOperators(unittest.TestCase):
+    """Test operator demangling."""
 
     def test_operator_new(self):
         self.assertEqual(demangle_msvc('??2@YAPAXI@Z'),
@@ -136,13 +213,20 @@ class TestMSVCVariables(unittest.TestCase):
         self.assertEqual(demangle_msvc('?myvar@@3HA'),
                          'int myvar')
 
-    def test_static_member_int(self):
+    def test_public_static_member_int(self):
         self.assertEqual(demangle_msvc('?svar@MyClass@@2HA'),
                          'public: static int MyClass::svar')
 
+    def test_private_static_member_int(self):
+        # 0 = private static
+        result = demangle_msvc('?psvar@MyClass@@0HA')
+        self.assertIn('private:', result)
+        self.assertIn('static', result)
+        self.assertIn('int', result)
+
 
 class TestMSVCUserDefinedTypes(unittest.TestCase):
-    """Test user-defined type demangling."""
+    """Test user-defined type demangling in parameters."""
 
     def test_struct_param(self):
         self.assertEqual(demangle_msvc('?sfunc@@YAXUMyStruct@@@Z'),
@@ -156,6 +240,11 @@ class TestMSVCUserDefinedTypes(unittest.TestCase):
         self.assertEqual(demangle_msvc('?efunc@@YAXW4MyEnum@@@Z'),
                          'void __cdecl efunc(enum MyEnum)')
 
+    def test_union_param(self):
+        result = demangle_msvc('?ufunc2@@YAXTMyUnion@@@Z')
+        self.assertIn('union', result)
+        self.assertIn('MyUnion', result)
+
 
 class TestMSVCScope(unittest.TestCase):
     """Test namespace and nested class scope."""
@@ -168,9 +257,45 @@ class TestMSVCScope(unittest.TestCase):
         self.assertEqual(demangle_msvc('?method@Inner@Outer@@UAEXH@Z'),
                          'public: virtual void __thiscall Outer::Inner::method(int)')
 
+    def test_deep_namespace(self):
+        result = demangle_msvc('?func@a@b@c@@YAXH@Z')
+        self.assertIn('c::b::a', result)
+
+
+class TestMSVCExtendedTypes(unittest.TestCase):
+    """Test extended primitive types (_ prefix)."""
+
+    def test_int8(self):
+        result = demangle_msvc('?f@@YAX_D@Z')
+        self.assertIn('signed char', result)
+
+    def test_uint8(self):
+        result = demangle_msvc('?f@@YAX_E@Z')
+        self.assertIn('unsigned char', result)
+
+    def test_int16(self):
+        result = demangle_msvc('?f@@YAX_F@Z')
+        self.assertIn('short', result)
+
+    def test_int32(self):
+        result = demangle_msvc('?f@@YAX_H@Z')
+        self.assertIn('int', result)
+
+    def test_int64(self):
+        result = demangle_msvc('?f@@YAX_J@Z')
+        self.assertIn('__int64', result)
+
+    def test_bool(self):
+        result = demangle_msvc('?f@@YAX_N@Z')
+        self.assertIn('bool', result)
+
+    def test_wchar_t(self):
+        result = demangle_msvc('?f@@YAX_W@Z')
+        self.assertIn('wchar_t', result)
+
 
 class TestMSVCStructuredOutput(unittest.TestCase):
-    """Test structured DemangledSymbol output."""
+    """Test structured DemangledSymbol output for MSVC."""
 
     def test_structured_function(self):
         sym = demangle_msvc('?foo@@YAXH@Z', structured=True)
@@ -183,25 +308,204 @@ class TestMSVCStructuredOutput(unittest.TestCase):
         sym = demangle_msvc('?bar@MyClass@@UAEXH@Z', structured=True)
         self.assertIsInstance(sym, DemangledSymbol)
         self.assertEqual(sym.format, 'msvc')
-        self.assertEqual(sym.full_name, 'public: virtual void __thiscall MyClass::bar(int)')
+        self.assertEqual(sym.full_name,
+                         'public: virtual void __thiscall MyClass::bar(int)')
 
     def test_structured_constructor(self):
         sym = demangle_msvc('??0MyClass@@QAE@X@Z', structured=True)
         self.assertIsInstance(sym, DemangledSymbol)
-        self.assertEqual(sym.full_name, 'public: __thiscall MyClass::MyClass(void)')
+        self.assertEqual(sym.full_name,
+                         'public: __thiscall MyClass::MyClass(void)')
+
+    def test_structured_destructor(self):
+        sym = demangle_msvc('??1MyClass@@UAE@X@Z', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.full_name,
+                         'public: virtual __thiscall MyClass::~MyClass(void)')
 
     def test_structured_vtable(self):
         sym = demangle_msvc('??_7MyClass@@6B@', structured=True)
         self.assertIsInstance(sym, DemangledSymbol)
         self.assertEqual(sym.format, 'msvc')
 
+    def test_structured_operator_new(self):
+        sym = demangle_msvc('??2@YAPAXI@Z', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'msvc')
+
+    def test_structured_variable(self):
+        sym = demangle_msvc('?myvar@@3HA', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'msvc')
+
+    def test_structured_to_dict(self):
+        sym = demangle_msvc('?foo@@YAXH@Z', structured=True)
+        d = sym.to_dict()
+        self.assertEqual(d['format'], 'msvc')
+        self.assertEqual(d['full_name'], 'void __cdecl foo(int)')
+
+    def test_structured_str(self):
+        sym = demangle_msvc('?foo@@YAXH@Z', structured=True)
+        self.assertEqual(str(sym), 'void __cdecl foo(int)')
+
+    def test_structured_repr(self):
+        sym = demangle_msvc('?foo@@YAXH@Z', structured=True)
+        r = repr(sym)
+        self.assertIn('msvc', r)
+        self.assertIn('void __cdecl foo(int)', r)
+
+    def test_structured_eq(self):
+        a = demangle_msvc('?foo@@YAXH@Z', structured=True)
+        b = demangle_msvc('?foo@@YAXH@Z', structured=True)
+        self.assertEqual(a, b)
+
+    def test_structured_hash(self):
+        a = demangle_msvc('?foo@@YAXH@Z', structured=True)
+        b = demangle_msvc('?foo@@YAXH@Z', structured=True)
+        self.assertEqual(len({a, b}), 1)
+
+
+class TestMSVCParserDirect(unittest.TestCase):
+    """Test the MSVC parser directly (AST-level tests)."""
+
+    def test_parser_returns_symbol(self):
+        parser = MSVCParser('?foo@@YAXH@Z')
+        sym = parser.parse()
+        self.assertIsInstance(sym, ast.MSVCSymbol)
+
+    def test_parser_function(self):
+        parser = MSVCParser('?foo@@YAXH@Z')
+        sym = parser.parse()
+        self.assertIsInstance(sym.type_info, ast.FunctionType)
+        self.assertEqual(sym.type_info.calling_convention, '__cdecl')
+        self.assertEqual(sym.type_info.return_type, 'void')
+        self.assertEqual(sym.type_info.parameters, ['int'])
+
+    def test_parser_member_function(self):
+        parser = MSVCParser('?bar@MyClass@@UAEXH@Z')
+        sym = parser.parse()
+        self.assertIsInstance(sym.type_info, ast.FunctionType)
+        self.assertEqual(sym.type_info.access, 'public')
+        self.assertTrue(sym.type_info.is_virtual)
+        self.assertEqual(sym.type_info.calling_convention, '__thiscall')
+
+    def test_parser_constructor(self):
+        parser = MSVCParser('??0MyClass@@QAE@X@Z')
+        sym = parser.parse()
+        self.assertIsInstance(sym.qualified_name.basic_name, ast.SpecialName)
+        self.assertTrue(sym.qualified_name.basic_name.is_ctor)
+
+    def test_parser_destructor(self):
+        parser = MSVCParser('??1MyClass@@UAE@X@Z')
+        sym = parser.parse()
+        self.assertIsInstance(sym.qualified_name.basic_name, ast.SpecialName)
+        self.assertTrue(sym.qualified_name.basic_name.is_dtor)
+
+    def test_parser_vtable(self):
+        parser = MSVCParser('??_7MyClass@@6B@')
+        sym = parser.parse()
+        self.assertEqual(sym.kind, 'vtable')
+
+    def test_parser_raises_on_non_msvc(self):
+        parser = MSVCParser('plain_name')
+        with self.assertRaises(ParseError):
+            parser.parse()
+
+    def test_parser_raises_on_empty(self):
+        parser = MSVCParser('')
+        with self.assertRaises(ParseError):
+            parser.parse()
+
+    def test_parser_raises_on_hashed(self):
+        parser = MSVCParser('??@ABC123@')
+        with self.assertRaises(ParseError):
+            parser.parse()
+
+    def test_parser_warnings_list(self):
+        parser = MSVCParser('?foo@@YAXH@Z')
+        parser.parse()
+        self.assertIsInstance(parser.warnings, list)
+
+    def test_renderer_renders(self):
+        parser = MSVCParser('?foo@@YAXH@Z')
+        sym = parser.parse()
+        result = render(sym)
+        self.assertEqual(result, 'void __cdecl foo(int)')
+
+
+class TestMSVCASTNodes(unittest.TestCase):
+    """Test MSVC AST node classes."""
+
+    def test_fragment_name(self):
+        node = ast.FragmentName('foo')
+        self.assertEqual(node.name, 'foo')
+        self.assertIn('foo', repr(node))
+
+    def test_special_name_ctor(self):
+        node = ast.SpecialName('', kind='ctor', is_ctor=True)
+        self.assertTrue(node.is_ctor)
+        self.assertFalse(node.is_dtor)
+
+    def test_special_name_dtor(self):
+        node = ast.SpecialName('~Foo', kind='dtor', is_dtor=True)
+        self.assertTrue(node.is_dtor)
+        self.assertFalse(node.is_ctor)
+
+    def test_special_name_operator(self):
+        node = ast.SpecialName('operator+', kind='operator', is_operator=True)
+        self.assertTrue(node.is_operator)
+        self.assertEqual(node.name, 'operator+')
+
+    def test_qualified_name(self):
+        scope = [ast.FragmentName('MyClass')]
+        basic = ast.FragmentName('method')
+        qn = ast.QualifiedName(scope, basic)
+        self.assertEqual(len(qn.scope), 1)
+        self.assertIs(qn.basic_name, basic)
+
+    def test_primitive_type(self):
+        node = ast.PrimitiveType('int')
+        self.assertEqual(node.name, 'int')
+
+    def test_pointer_type(self):
+        pt = ast.PointerType('int', is_const=True)
+        self.assertEqual(pt.pointee, 'int')
+        self.assertTrue(pt.is_const)
+
+    def test_function_type(self):
+        ft = ast.FunctionType(
+            calling_convention='__cdecl',
+            return_type='void',
+            parameters=['int'],
+            is_member=False,
+        )
+        self.assertEqual(ft.calling_convention, '__cdecl')
+        self.assertEqual(ft.return_type, 'void')
+        self.assertEqual(ft.parameters, ['int'])
+        self.assertFalse(ft.is_member)
+
+    def test_variable_info(self):
+        vi = ast.VariableInfo(access='public', is_static=True, var_type='int')
+        self.assertEqual(vi.access, 'public')
+        self.assertTrue(vi.is_static)
+        self.assertEqual(vi.var_type, 'int')
+
+    def test_vftable(self):
+        vft = ast.VFTable(scope=None)
+        self.assertIsNone(vft.scope)
+
+    def test_msvc_symbol(self):
+        qn = ast.QualifiedName([], ast.FragmentName('foo'))
+        sym = ast.MSVCSymbol(qualified_name=qn, kind='function')
+        self.assertIs(sym.qualified_name, qn)
+        self.assertEqual(sym.kind, 'function')
+
 
 class TestMSVCGracefulDegradation(unittest.TestCase):
     """Test graceful degradation for invalid or unsupported symbols."""
 
-    def test_invalid_symbol_returns_original(self):
+    def test_invalid_symbol_returns_str(self):
         result = demangle_msvc('?invalid@@@')
-        # Should not crash — returns original or partial result
         self.assertIsInstance(result, str)
 
     def test_non_msvc_returns_original(self):
@@ -215,6 +519,57 @@ class TestMSVCGracefulDegradation(unittest.TestCase):
     def test_hashed_object_returns_original(self):
         result = demangle_msvc('??@ABC123@')
         self.assertEqual(result, '??@ABC123@')
+
+    def test_truncated_question(self):
+        result = demangle_msvc('?')
+        self.assertIsInstance(result, str)
+
+    def test_truncated_double_question(self):
+        result = demangle_msvc('??')
+        self.assertIsInstance(result, str)
+
+    def test_binary_garbage(self):
+        result = demangle_msvc('\x00\x01\x02\x03')
+        self.assertIsInstance(result, str)
+
+    def test_long_input(self):
+        result = demangle_msvc('?' + 'a' * 1000)
+        self.assertIsInstance(result, str)
+
+    def test_no_crash_on_various_bad(self):
+        bad_inputs = [
+            '?@', '??@', '???', '????',
+            '?foo', '?foo@', '?foo@@',
+            '??0', '??1', '??_7', '??_0',
+        ]
+        for inp in bad_inputs:
+            result = demangle_msvc(inp)
+            self.assertIsInstance(result, str,
+                                  'demangle_msvc(%r) crashed' % inp)
+
+
+class TestMSVCDispatch(unittest.TestCase):
+    """Test MSVC through the main demangle() dispatch."""
+
+    def test_demangle_dispatch(self):
+        result = demangle('?foo@@YAXH@Z')
+        self.assertEqual(result, 'void __cdecl foo(int)')
+
+    def test_demangle_structured(self):
+        sym = demangle('?foo@@YAXH@Z', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'msvc')
+
+    def test_demangle_force_msvc(self):
+        result = demangle('?foo@@YAXH@Z', fmt='msvc')
+        self.assertEqual(result, 'void __cdecl foo(int)')
+
+    def test_demangle_never_raises(self):
+        bad_inputs = ['?', '??', '???', '?????', '?@@@', '\x00\x01']
+        for inp in bad_inputs:
+            result = demangle(inp)
+            self.assertIsInstance(result, str,
+                                  'demangle(%r) crashed' % inp)
 
 
 if __name__ == '__main__':

--- a/vivisect/tests/test_demangle_objc.py
+++ b/vivisect/tests/test_demangle_objc.py
@@ -1,0 +1,162 @@
+"""
+Comprehensive tests for the Objective-C demangling module.
+
+Tests cover:
+- Class references (_OBJC_CLASS_$_)
+- Metaclass references (_OBJC_METACLASS_$_)
+- Instance variables (_OBJC_IVAR_$_)
+- Exception types (_OBJC_EHTYPE_$_)
+- Category symbols
+- Class method syntax (+[Class method])
+- Instance method syntax (-[Class method])
+- Structured output
+- Graceful degradation
+"""
+
+import unittest
+
+from vivisect.demangle import demangle, detect_format
+from vivisect.demangle.objc import demangle_objc
+from vivisect.demangle.common import DemangledSymbol
+
+
+class TestObjCClassRef(unittest.TestCase):
+    """Test _OBJC_CLASS_$_ symbol demangling."""
+
+    def test_simple_class(self):
+        self.assertEqual(demangle_objc('_OBJC_CLASS_$_NSObject'), 'NSObject')
+
+    def test_custom_class(self):
+        self.assertEqual(demangle_objc('_OBJC_CLASS_$_MyViewController'),
+                         'MyViewController')
+
+
+class TestObjCMetaclassRef(unittest.TestCase):
+    """Test _OBJC_METACLASS_$_ symbol demangling."""
+
+    def test_metaclass(self):
+        self.assertEqual(demangle_objc('_OBJC_METACLASS_$_NSObject'),
+                         'NSObject')
+
+    def test_custom_metaclass(self):
+        self.assertEqual(demangle_objc('_OBJC_METACLASS_$_MyClass'),
+                         'MyClass')
+
+
+class TestObjCIVar(unittest.TestCase):
+    """Test _OBJC_IVAR_$_ symbol demangling."""
+
+    def test_ivar(self):
+        result = demangle_objc('_OBJC_IVAR_$_NSObject._isa')
+        self.assertIn('NSObject', result)
+        self.assertIn('_isa', result)
+
+    def test_custom_ivar(self):
+        result = demangle_objc('_OBJC_IVAR_$_MyClass._myField')
+        self.assertIn('MyClass', result)
+        self.assertIn('_myField', result)
+
+
+class TestObjCExceptionType(unittest.TestCase):
+    """Test _OBJC_EHTYPE_$_ symbol demangling."""
+
+    def test_exception_type(self):
+        result = demangle_objc('_OBJC_EHTYPE_$_MyException')
+        self.assertEqual(result, 'MyException')
+
+
+class TestObjCMethodSyntax(unittest.TestCase):
+    """Test +[Class method] / -[Class method] syntax."""
+
+    def test_class_method_alloc(self):
+        self.assertEqual(demangle_objc('+[NSObject alloc]'),
+                         '+[NSObject alloc]')
+
+    def test_instance_method_init(self):
+        self.assertEqual(demangle_objc('-[NSObject init]'),
+                         '-[NSObject init]')
+
+    def test_class_method_custom(self):
+        self.assertEqual(demangle_objc('+[MyClass sharedInstance]'),
+                         '+[MyClass sharedInstance]')
+
+    def test_instance_method_with_args(self):
+        self.assertEqual(demangle_objc('-[NSObject setValue:forKey:]'),
+                         '-[NSObject setValue:forKey:]')
+
+
+class TestObjCStructuredOutput(unittest.TestCase):
+    """Test structured DemangledSymbol output for ObjC."""
+
+    def test_structured_class_ref(self):
+        sym = demangle_objc('_OBJC_CLASS_$_NSObject', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'objc')
+        self.assertEqual(sym.kind, 'class_ref')
+        self.assertEqual(sym.name, 'NSObject')
+
+    def test_structured_metaclass(self):
+        sym = demangle_objc('_OBJC_METACLASS_$_NSObject', structured=True)
+        self.assertEqual(sym.kind, 'metaclass_ref')
+
+    def test_structured_ivar(self):
+        sym = demangle_objc('_OBJC_IVAR_$_NSObject._isa', structured=True)
+        self.assertEqual(sym.kind, 'ivar')
+        self.assertIn('NSObject', sym.scope)
+
+    def test_structured_method(self):
+        sym = demangle_objc('+[NSObject alloc]', structured=True)
+        self.assertEqual(sym.kind, 'method')
+
+    def test_structured_original(self):
+        orig = '_OBJC_CLASS_$_NSObject'
+        sym = demangle_objc(orig, structured=True)
+        self.assertEqual(sym.original_mangled, orig)
+
+
+class TestObjCGracefulDegradation(unittest.TestCase):
+    """Test graceful degradation for invalid ObjC symbols."""
+
+    def test_non_objc_returns_original(self):
+        result = demangle_objc('plain_function')
+        self.assertEqual(result, 'plain_function')
+
+    def test_empty_string(self):
+        result = demangle_objc('')
+        self.assertEqual(result, '')
+
+    def test_non_objc_structured(self):
+        sym = demangle_objc('plain_function', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertTrue(sym.parse_warnings)
+
+
+class TestObjCDispatch(unittest.TestCase):
+    """Test ObjC through the main demangle() dispatch."""
+
+    def test_detect_class_ref(self):
+        self.assertEqual(detect_format('_OBJC_CLASS_$_NSObject'), 'objc')
+
+    def test_detect_metaclass(self):
+        self.assertEqual(detect_format('_OBJC_METACLASS_$_NSObject'), 'objc')
+
+    def test_detect_ivar(self):
+        self.assertEqual(detect_format('_OBJC_IVAR_$_NSObject._isa'), 'objc')
+
+    def test_detect_class_method(self):
+        self.assertEqual(detect_format('+[NSObject alloc]'), 'objc')
+
+    def test_detect_instance_method(self):
+        self.assertEqual(detect_format('-[NSObject init]'), 'objc')
+
+    def test_demangle_dispatch(self):
+        result = demangle('_OBJC_CLASS_$_NSObject')
+        self.assertEqual(result, 'NSObject')
+
+    def test_demangle_structured(self):
+        sym = demangle('_OBJC_CLASS_$_NSObject', structured=True)
+        self.assertEqual(sym.format, 'objc')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivisect/tests/test_demangle_rust_d_swift.py
+++ b/vivisect/tests/test_demangle_rust_d_swift.py
@@ -1,0 +1,262 @@
+"""
+Comprehensive tests for the Rust, D, and Swift demangling modules.
+
+Tests cover:
+- Rust v0 (_R prefix) basic demangling
+- Rust legacy (_Z prefix with $ escapes)
+- D language (_D prefix) basic demangling
+- Swift ($s/_T0 prefix) basic demangling
+- Structured output for all three
+- Graceful degradation
+- Format detection
+"""
+
+import unittest
+
+from vivisect.demangle import demangle, detect_format
+from vivisect.demangle.rust import demangle_rust
+from vivisect.demangle.dlang import demangle_d
+from vivisect.demangle.swift import demangle_swift
+from vivisect.demangle.common import DemangledSymbol
+
+
+# ===== RUST TESTS =====
+
+class TestRustFormatDetection(unittest.TestCase):
+    """Test Rust format detection."""
+
+    def test_detect_v0(self):
+        self.assertEqual(detect_format('_RNvCs1234_4test3foo'), 'rust')
+
+    def test_detect_v0_nested(self):
+        self.assertEqual(detect_format('_RNvNtCs1234_7mycrate3foo3bar'), 'rust')
+
+
+class TestRustV0Demangle(unittest.TestCase):
+    """Test Rust v0 demangling."""
+
+    def test_basic_crate_function(self):
+        result = demangle_rust('_RNvCs1234_4test3foo')
+        self.assertIsInstance(result, str)
+
+    def test_v0_returns_str(self):
+        result = demangle_rust('_RNvCs1234_4test3foo')
+        self.assertIsInstance(result, str)
+
+    def test_v0_with_suffix(self):
+        # v0 symbols can have .llvm.<hash> suffix
+        result = demangle_rust('_RNvCs1234_4test3foo.llvm.abc123')
+        self.assertIsInstance(result, str)
+
+
+class TestRustLegacyDemangle(unittest.TestCase):
+    """Test Rust legacy (_Z prefix) demangling."""
+
+    def test_legacy_returns_str(self):
+        result = demangle_rust('_ZN3foo3barEv')
+        self.assertIsInstance(result, str)
+
+    def test_legacy_escape_decoding(self):
+        # Legacy Rust uses $XX escapes
+        # $RF$ = &, $BP$ = *, $LT$ = <, $GT$ = >
+        result = demangle_rust('_ZN3foo$RF$3barEv')
+        self.assertIsInstance(result, str)
+
+
+class TestRustStructuredOutput(unittest.TestCase):
+    """Test structured output for Rust."""
+
+    def test_structured_v0(self):
+        sym = demangle_rust('_RNvCs1234_4test3foo', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'rust')
+
+    def test_structured_original(self):
+        orig = '_RNvCs1234_4test3foo'
+        sym = demangle_rust(orig, structured=True)
+        self.assertEqual(sym.original_mangled, orig)
+
+
+class TestRustGracefulDegradation(unittest.TestCase):
+    """Test graceful degradation for Rust."""
+
+    def test_non_rust_returns_original(self):
+        result = demangle_rust('plain_function')
+        self.assertEqual(result, 'plain_function')
+
+    def test_empty_string(self):
+        result = demangle_rust('')
+        self.assertEqual(result, '')
+
+    def test_invalid_v0(self):
+        result = demangle_rust('_R')
+        self.assertIsInstance(result, str)
+
+    def test_no_crash_on_garbage(self):
+        result = demangle_rust('_R\x00\x01\x02')
+        self.assertIsInstance(result, str)
+
+
+# ===== D LANGUAGE TESTS =====
+
+class TestDFormatDetection(unittest.TestCase):
+    """Test D language format detection."""
+
+    def test_detect_d(self):
+        self.assertEqual(detect_format('_D3foo3barFiZv'), 'd')
+
+    def test_detect_d_main(self):
+        self.assertEqual(detect_format('_Dmain'), 'd')
+
+    def test_not_d_dynamic(self):
+        self.assertNotEqual(detect_format('_DYNAMIC'), 'd')
+
+    def test_not_d_data(self):
+        self.assertNotEqual(detect_format('_DATA'), 'd')
+
+
+class TestDDemangle(unittest.TestCase):
+    """Test D language demangling."""
+
+    def test_basic_function(self):
+        result = demangle_d('_D3foo3barFiZv')
+        self.assertIsInstance(result, str)
+        self.assertIn('foo', result)
+
+    def test_d_main(self):
+        result = demangle_d('_Dmain')
+        self.assertIsInstance(result, str)
+
+    def test_returns_str(self):
+        result = demangle_d('_D3foo3barFiZv')
+        self.assertIsInstance(result, str)
+
+
+class TestDStructuredOutput(unittest.TestCase):
+    """Test structured output for D."""
+
+    def test_structured(self):
+        sym = demangle_d('_D3foo3barFiZv', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'd')
+
+    def test_structured_original(self):
+        orig = '_D3foo3barFiZv'
+        sym = demangle_d(orig, structured=True)
+        self.assertEqual(sym.original_mangled, orig)
+
+
+class TestDGracefulDegradation(unittest.TestCase):
+    """Test graceful degradation for D."""
+
+    def test_non_d_returns_original(self):
+        result = demangle_d('plain_function')
+        self.assertEqual(result, 'plain_function')
+
+    def test_empty_string(self):
+        result = demangle_d('')
+        self.assertEqual(result, '')
+
+    def test_invalid_d(self):
+        result = demangle_d('_D')
+        self.assertIsInstance(result, str)
+
+
+# ===== SWIFT TESTS =====
+
+class TestSwiftFormatDetection(unittest.TestCase):
+    """Test Swift format detection."""
+
+    def test_detect_s(self):
+        self.assertEqual(detect_format('$s5Hello4testyyF'), 'swift')
+
+    def test_detect_S(self):
+        self.assertEqual(detect_format('$S5Hello4testyyF'), 'swift')
+
+    def test_detect_T0(self):
+        self.assertEqual(detect_format('_T05Hello4testyyF'), 'swift')
+
+
+class TestSwiftDemangle(unittest.TestCase):
+    """Test Swift demangling."""
+
+    def test_basic_module_function(self):
+        result = demangle_swift('$s5Hello4testyyF')
+        self.assertIsInstance(result, str)
+
+    def test_returns_str(self):
+        result = demangle_swift('$s5Hello4testyyF')
+        self.assertIsInstance(result, str)
+
+
+class TestSwiftStructuredOutput(unittest.TestCase):
+    """Test structured output for Swift."""
+
+    def test_structured(self):
+        sym = demangle_swift('$s5Hello4testyyF', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'swift')
+
+    def test_structured_original(self):
+        orig = '$s5Hello4testyyF'
+        sym = demangle_swift(orig, structured=True)
+        self.assertEqual(sym.original_mangled, orig)
+
+
+class TestSwiftGracefulDegradation(unittest.TestCase):
+    """Test graceful degradation for Swift."""
+
+    def test_non_swift_returns_original(self):
+        result = demangle_swift('plain_function')
+        self.assertEqual(result, 'plain_function')
+
+    def test_empty_string(self):
+        result = demangle_swift('')
+        self.assertEqual(result, '')
+
+    def test_invalid_swift(self):
+        result = demangle_swift('$s')
+        self.assertIsInstance(result, str)
+
+    def test_no_crash_on_garbage(self):
+        result = demangle_swift('$s\x00\x01\x02')
+        self.assertIsInstance(result, str)
+
+
+# ===== DISPATCH TESTS =====
+
+class TestRustDDispatch(unittest.TestCase):
+    """Test Rust/D/Swift through the main demangle() dispatch."""
+
+    def test_rust_dispatch(self):
+        result = demangle('_RNvCs1234_4test3foo')
+        self.assertIsInstance(result, str)
+
+    def test_d_dispatch(self):
+        result = demangle('_D3foo3barFiZv')
+        self.assertIsInstance(result, str)
+
+    def test_swift_dispatch(self):
+        result = demangle('$s5Hello4testyyF')
+        self.assertIsInstance(result, str)
+
+    def test_rust_structured(self):
+        sym = demangle('_RNvCs1234_4test3foo', structured=True)
+        self.assertEqual(sym.format, 'rust')
+
+    def test_d_structured(self):
+        sym = demangle('_D3foo3barFiZv', structured=True)
+        self.assertEqual(sym.format, 'd')
+
+    def test_swift_structured(self):
+        sym = demangle('$s5Hello4testyyF', structured=True)
+        self.assertEqual(sym.format, 'swift')
+
+    def test_never_raises(self):
+        for inp in ['_R', '_D', '$s', '_T0', '$S', '_R\x00', '_D\x00']:
+            result = demangle(inp)
+            self.assertIsInstance(result, str, 'demangle(%r) crashed' % inp)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivisect/tests/test_demangle_rust_v0.py
+++ b/vivisect/tests/test_demangle_rust_v0.py
@@ -1,0 +1,463 @@
+"""
+Comprehensive tests for Rust v0 demangling (RFC 2603).
+
+Tests cover all RFC 2603 grammar features:
+- Paths: crate (C), nested (N), impl (M), trait impl (X), trait def (Y), generic (I)
+- Namespaces: type (lowercase), value/closure (C), shim (S)
+- Types: basic, references, pointers, arrays, slices, tuples, fn types, dyn traits
+- Generic args: types, lifetimes (L), const generics (K)
+- Const generics: bool, char, signed/uint, placeholder
+- Lifetimes: anonymous, named, for<> binders, de Bruijn indexing
+- Function types: unsafe, extern ABI, params, return type
+- Dyn traits: trait bounds, associated types, lifetime
+- Back-references (B)
+- Punycode (RFC 3492) identifier decoding
+- Vendor suffix stripping
+- Legacy _Z demangling with $ escape decoding
+- Structured output
+- Graceful degradation
+"""
+
+import unittest
+
+from vivisect.demangle import demangle, detect_format
+from vivisect.demangle.rust import demangle_rust, _RustV0Parser
+from vivisect.demangle.common import DemangledSymbol
+
+
+class TestRustV0BasicPaths(unittest.TestCase):
+    """Test basic path types (RFC 2603 §2.1)."""
+
+    def test_crate_function(self):
+        self.assertEqual(demangle_rust('_RNvCs1234_4test3foo'), 'test::foo')
+
+    def test_crate_with_short_disambiguator(self):
+        self.assertEqual(demangle_rust('_RNvCs1_4test3foo'), 'test::foo')
+
+    def test_nested_type_namespace(self):
+        # Nt = nested type namespace (lowercase t = type namespace)
+        self.assertEqual(demangle_rust('_RNvNtCs1234_7mycrate3foo3bar'), 'mycrate::foo::bar')
+
+    def test_deeply_nested_type_namespace(self):
+        # Nt Nt C -> crate::foo::bar::baz
+        self.assertEqual(demangle_rust('_RNvNtNtCs1234_7mycrate3foo3bar3baz'), 'mycrate::foo::bar::baz')
+
+    def test_closure_no_name(self):
+        # NC = closure namespace (uppercase C = value namespace)
+        # NC Nt Cs1234_ 4test 4main 0 -> test::main::{closure#0}
+        self.assertEqual(demangle_rust('_RNvNCNtCs1234_4test4main0E'), 'test::main::{closure#0}')
+
+    def test_closure_with_name(self):
+        # NC with a name: test::main::{closure:my_closure#0}
+        result = demangle_rust('_RNvNCNtCs1234_4test4main10my_closureE')
+        self.assertIn('closure', result)
+        self.assertIn('my_closure', result)
+
+    def test_shim_namespace(self):
+        # NS = shim namespace
+        result = demangle_rust('_RNvNSNtCs1234_4test4main0E')
+        self.assertIn('shim', result)
+
+    def test_crate_with_long_name(self):
+        result = demangle_rust('_RNvCs1234_13my_crate_name11my_function')
+        self.assertEqual(result, 'my_crate_name::my_function')
+
+
+class TestRustV0GenericArgs(unittest.TestCase):
+    """Test generic arguments (RFC 2603 §2.2)."""
+
+    def test_single_type_arg(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3foojE'), 'test::foo::<usize>')
+
+    def test_multiple_type_args(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3foojlbE'), 'test::foo::<usize, i32, bool>')
+
+    def test_generic_with_reference_type(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooRyE'), 'test::foo::<&u64>')
+
+    def test_generic_with_mutable_reference(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooQyE'), 'test::foo::<&mut u64>')
+
+    def test_generic_with_pointer(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooPyE'), 'test::foo::<*const u64>')
+
+    def test_generic_with_mut_pointer(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooOyE'), 'test::foo::<*mut u64>')
+
+    def test_generic_with_slice(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooSyE'), 'test::foo::<[u64]>')
+
+    def test_generic_with_tuple(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooTylEE'), 'test::foo::<(u64, i32)>')
+
+    def test_generic_with_single_tuple(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooTyEE'), 'test::foo::<(u64,)>')
+
+
+class TestRustV0ConstGenerics(unittest.TestCase):
+    """Test const generic values (RFC 2603 §2.2.K)."""
+
+    def test_const_uint(self):
+        # Kh2a_ -> unsigned const with hex value 2a = 42
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooKh2a_E'), 'test::foo::<42>')
+
+    def test_const_bool_true(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooKb1_E'), 'test::foo::<true>')
+
+    def test_const_bool_false(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooKb0_E'), 'test::foo::<false>')
+
+    def test_const_negative_int(self):
+        # Kln2a_ -> signed const with negative sign, hex 2a = -42
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooKln2a_E'), 'test::foo::<-42>')
+
+    def test_const_char(self):
+        # Kc41_ -> char const with hex 41 = 'A'
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooKc41_E'), "test::foo::<'A'>")
+
+    def test_const_placeholder(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooKpE'), 'test::foo::<_>')
+
+    def test_const_zero(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooKh0_E'), 'test::foo::<0>')
+
+    def test_const_large_uint(self):
+        # Large value > 16 hex digits shows as 0x...
+        large_hex = 'f' * 17
+        result = demangle_rust('_RINvCs1234_4test3fooKh%s_E' % large_hex)
+        self.assertIn('0x', result)
+
+
+class TestRustV0FunctionTypes(unittest.TestCase):
+    """Test function type parsing (RFC 2603 §2.3.F)."""
+
+    def test_fn_unit_return(self):
+        # FyEu -> fn(u64) -> ()
+        p = _RustV0Parser('FyEu')
+        self.assertEqual(p._parse_type(), 'fn(u64)')
+
+    def test_fn_with_return(self):
+        # FyEj -> fn(u64) -> usize
+        p = _RustV0Parser('FyEj')
+        self.assertEqual(p._parse_type(), 'fn(u64) -> usize')
+
+    def test_fn_no_params(self):
+        # FEu -> fn() -> ()
+        p = _RustV0Parser('FEu')
+        self.assertEqual(p._parse_type(), 'fn()')
+
+    def test_fn_multiple_params(self):
+        # FljEu -> fn(i32, usize) -> ()
+        p = _RustV0Parser('FljEu')
+        self.assertEqual(p._parse_type(), 'fn(i32, usize)')
+
+    def test_unsafe_fn(self):
+        # FUyEu -> unsafe fn(u64) -> ()
+        p = _RustV0Parser('FUyEu')
+        self.assertEqual(p._parse_type(), 'unsafe fn(u64)')
+
+    def test_extern_c_fn(self):
+        # FKCyEu -> extern "C" fn(u64) -> ()
+        p = _RustV0Parser('FKCyEu')
+        self.assertEqual(p._parse_type(), 'extern "C" fn(u64)')
+
+    def test_unsafe_extern_c_fn(self):
+        # FUKCyEu -> unsafe extern "C" fn(u64) -> ()
+        p = _RustV0Parser('FUKCyEu')
+        self.assertEqual(p._parse_type(), 'unsafe extern "C" fn(u64)')
+
+    def test_fn_in_generic_args(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooFyEuE'), 'test::foo::<fn(u64)>')
+
+    def test_fn_with_fn_param(self):
+        # F FyEu Eu -> fn(fn(u64)) -> ()
+        p = _RustV0Parser('FFyEuEu')
+        self.assertEqual(p._parse_type(), 'fn(fn(u64))')
+
+    def test_unsafe_fn_in_generic(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooFUyEuE'), 'test::foo::<unsafe fn(u64)>')
+
+    def test_extern_c_fn_in_generic(self):
+        self.assertEqual(demangle_rust('_RINvCs1234_4test3fooFKCyEuE'), 'test::foo::<extern "C" fn(u64)>')
+
+
+class TestRustV0Lifetimes(unittest.TestCase):
+    """Test lifetime parsing (RFC 2603 §2.3)."""
+
+    def test_reference_no_lifetime(self):
+        # Re -> &str
+        p = _RustV0Parser('Re')
+        self.assertEqual(p._parse_type(), '&str')
+
+    def test_reference_anonymous_lifetime(self):
+        # RL_e -> &str (anonymous lifetime not shown)
+        p = _RustV0Parser('RL_e')
+        self.assertEqual(p._parse_type(), '&str')
+
+    def test_fn_with_binder_single_lifetime(self):
+        # FG_RL0_eEu -> for<'a> fn(&'a str) -> ()
+        p = _RustV0Parser('FG_RL0_eEu')
+        self.assertEqual(p._parse_type(), "for<'a> fn(&'a str)")
+
+    def test_fn_with_two_bound_lifetimes(self):
+        # FG0_RL0_eRL1_eEu -> for<'a, 'b> fn(&'b str, &'a str)
+        p = _RustV0Parser('FG0_RL0_eRL1_eEu')
+        self.assertEqual(p._parse_type(), "for<'a, 'b> fn(&'b str, &'a str)")
+
+    def test_fn_with_named_lifetime_in_for(self):
+        # for<'a> fn() -> for<'a> fn()
+        p = _RustV0Parser('FG_Eu')
+        self.assertEqual(p._parse_type(), "for<'a> fn()")
+
+
+class TestRustV0DynTraits(unittest.TestCase):
+    """Test dyn trait type parsing (RFC 2603 §2.3.D)."""
+
+    def test_dyn_trait_simple(self):
+        # D NvCs1234_4test7MyTrait E L_ -> dyn test::MyTrait
+        p = _RustV0Parser('DNvCs1234_4test7MyTraitEL_')
+        self.assertEqual(p._parse_type(), 'dyn test::MyTrait')
+
+    def test_dyn_trait_with_lifetime(self):
+        # D NvCs1234_4test7MyTrait E L0_ -> dyn test::MyTrait + '_
+        p = _RustV0Parser('DNvCs1234_4test7MyTraitEL0_')
+        self.assertEqual(p._parse_type(), "dyn test::MyTrait + '_")
+
+    def test_dyn_trait_in_generic_args(self):
+        result = demangle_rust('_RINvCs1234_4test3fooDNvCs1234_4test7MyTraitEL_EE')
+        self.assertEqual(result, 'test::foo::<dyn test::MyTrait>')
+
+    def test_dyn_trait_for_binder(self):
+        # D G_ NvCs1234_4test7MyTrait E L0_ E
+        # for<'a> dyn test::MyTrait + 'a
+        p = _RustV0Parser('DG_NvCs1234_4test7MyTraitEL0_')
+        result = p._parse_type()
+        self.assertIn('for<', result)
+        self.assertIn('dyn', result)
+        self.assertIn('MyTrait', result)
+
+
+class TestRustV0ImplPaths(unittest.TestCase):
+    """Test impl path types (RFC 2603 §2.1.M, X, Y)."""
+
+    def test_inherent_impl(self):
+        # M s0_ Cs1234_4test NtCs1234_4test3Foo 3bar
+        # <test::Foo>::bar
+        result = demangle_rust('_RNvMs0_Cs1234_4testNtCs1234_4test3Foo3bar')
+        self.assertEqual(result, '<test::Foo>::bar')
+
+    def test_impl_path_returns_str(self):
+        result = demangle_rust('_RNvMs0_Cs1234_4testNtCs1234_4test3Foo3bar')
+        self.assertIsInstance(result, str)
+
+
+class TestRustV0BackReferences(unittest.TestCase):
+    """Test back-reference parsing (RFC 2603 §2.1.B)."""
+
+    def test_backref_to_type(self):
+        # INvCs1234_4test3fooyBi_E
+        # y is at position 19, B is at position 20
+        # Bi_ -> integer_62('i_') = 18+1 = 19 -> offset 19 -> 'y' -> u64
+        p = _RustV0Parser('INvCs1234_4test3fooyBi_E')
+        result = p._parse_path(in_value=True)
+        self.assertEqual(result, 'test::foo::<u64, u64>')
+
+    def test_no_backref_duplicate_types(self):
+        # Same thing without backref
+        p = _RustV0Parser('INvCs1234_4test3fooyyE')
+        result = p._parse_path(in_value=True)
+        self.assertEqual(result, 'test::foo::<u64, u64>')
+
+
+class TestRustV0AllBasicTypes(unittest.TestCase):
+    """Test all basic type mappings (RFC 2603 §2.3)."""
+
+    def test_all_basic_types(self):
+        expected = {
+            'a': 'i8', 'b': 'bool', 'c': 'char', 'd': 'f64',
+            'e': 'str', 'f': 'f32', 'h': 'u8', 'i': 'isize',
+            'j': 'usize', 'l': 'i32', 'm': 'u32', 'n': 'i128',
+            'o': 'u128', 's': 'i16', 't': 'u16', 'u': '()',
+            'v': '...', 'x': 'i64', 'y': 'u64', 'z': '!',
+            'p': '_',
+        }
+        for tag, expected_name in expected.items():
+            p = _RustV0Parser(tag)
+            result = p._parse_type()
+            self.assertEqual(result, expected_name, 'type tag %r' % tag)
+
+
+class TestRustV0Arrays(unittest.TestCase):
+    """Test array type parsing (RFC 2603 §2.3.A).
+
+    Note: In array context, the const length does NOT have a K prefix.
+    The K prefix is only used in generic-arg context to distinguish
+    const from type arguments.
+    """
+
+    def test_array_with_const_length(self):
+        # A y h2a_ -> [u64; 42]
+        p = _RustV0Parser('Ayh2a_')
+        self.assertEqual(p._parse_type(), '[u64; 42]')
+
+    def test_array_in_generic(self):
+        # _R I Nv Cs1234_ 4test 3foo A y h2a_ E
+        result = demangle_rust('_RINvCs1234_4test3fooAyh2a_E')
+        self.assertEqual(result, 'test::foo::<[u64; 42]>')
+
+    def test_array_with_zero(self):
+        p = _RustV0Parser('Ayh0_')
+        self.assertEqual(p._parse_type(), '[u64; 0]')
+
+
+class TestRustV0Punycode(unittest.TestCase):
+    """Test Punycode (RFC 3492) identifier decoding."""
+
+    def test_ascii_only_ident(self):
+        # No 'u' prefix, no Punycode
+        self.assertEqual(demangle_rust('_RNvCs1234_4test3foo'), 'test::foo')
+
+    def test_punycode_munich(self):
+        # Test the Punycode decoder directly
+        from vivisect.demangle.rust import _punycode_decode_ident
+        result = _punycode_decode_ident('mnchen_3ya')
+        self.assertEqual(result, 'münchen')
+
+    def test_punycode_all_ascii(self):
+        # All-ASCII with no Punycode suffix
+        from vivisect.demangle.rust import _punycode_decode
+        self.assertEqual(_punycode_decode('hello', ''), 'hello')
+
+
+class TestRustV0VendorSuffix(unittest.TestCase):
+    """Test vendor suffix stripping."""
+
+    def test_llvm_suffix(self):
+        result = demangle_rust('_RNvCs1234_4test3foo.llvm.abc123')
+        self.assertEqual(result, 'test::foo')
+
+    def test_dot_suffix(self):
+        result = demangle_rust('_RNvCs1234_4test3foo.example')
+        self.assertEqual(result, 'test::foo')
+
+
+class TestRustV0StructuredOutput(unittest.TestCase):
+    """Test structured output for Rust v0."""
+
+    def test_structured_returns_demangled_symbol(self):
+        sym = demangle_rust('_RNvCs1234_4test3foo', structured=True)
+        self.assertIsInstance(sym, DemangledSymbol)
+        self.assertEqual(sym.format, 'rust')
+        self.assertEqual(sym.full_name, 'test::foo')
+        self.assertEqual(sym.original_mangled, '_RNvCs1234_4test3foo')
+
+    def test_structured_scope_and_name(self):
+        sym = demangle_rust('_RNvCs1234_4test3foo', structured=True)
+        self.assertEqual(sym.name, 'foo')
+        self.assertIn('test', sym.scope)
+
+    def test_structured_nested(self):
+        sym = demangle_rust('_RNvNtCs1234_7mycrate3foo3bar', structured=True)
+        self.assertEqual(sym.name, 'bar')
+        self.assertIn('mycrate', sym.scope)
+        self.assertIn('foo', sym.scope)
+
+    def test_structured_with_generics(self):
+        sym = demangle_rust('_RINvCs1234_4test3foojE', structured=True)
+        self.assertTrue(sym.is_template)
+
+
+class TestRustV0GracefulDegradation(unittest.TestCase):
+    """Test graceful degradation for invalid input."""
+
+    def test_empty_string(self):
+        self.assertEqual(demangle_rust(''), '')
+
+    def test_non_rust_prefix(self):
+        self.assertEqual(demangle_rust('plain_function'), 'plain_function')
+
+    def test_just_prefix(self):
+        result = demangle_rust('_R')
+        self.assertIsInstance(result, str)
+
+    def test_garbage_after_prefix(self):
+        result = demangle_rust('_R\x00\x01\x02')
+        self.assertIsInstance(result, str)
+
+    def test_truncated_path(self):
+        result = demangle_rust('_RN')
+        self.assertIsInstance(result, str)
+
+    def test_truncated_generic(self):
+        result = demangle_rust('_RI')
+        self.assertIsInstance(result, str)
+
+    def test_invalid_path_tag(self):
+        result = demangle_rust('_R9')
+        self.assertIsInstance(result, str)
+
+    def test_truncated_fn_type(self):
+        result = demangle_rust('_RF')
+        self.assertIsInstance(result, str)
+
+    def test_never_raises(self):
+        inputs = [
+            '_R', '_R\x00', '_RN', '_RI', '_RB',
+            '_RNv', '_RNvC', '_RNvCs', '_RNvCs1_',
+            '_RINv', '_RINvCs1_',
+        ]
+        for inp in inputs:
+            result = demangle_rust(inp)
+            self.assertIsInstance(result, str, 'demangle(%r) should return str' % inp)
+
+
+class TestRustLegacyDemangle(unittest.TestCase):
+    """Test legacy Rust (_Z prefix) demangling."""
+
+    def test_basic_legacy(self):
+        result = demangle_rust('_ZN3foo3barEv')
+        self.assertIsInstance(result, str)
+
+    def test_legacy_escape_decoding(self):
+        result = demangle_rust('_ZN3foo$RF$3barEv')
+        self.assertIsInstance(result, str)
+
+    def test_legacy_with_dot_suffix(self):
+        result = demangle_rust('_ZN3foo3barEv.h1234')
+        self.assertIsInstance(result, str)
+
+
+class TestRustFormatDetection(unittest.TestCase):
+    """Test Rust format detection."""
+
+    def test_detect_v0(self):
+        self.assertEqual(detect_format('_RNvCs1234_4test3foo'), 'rust')
+
+    def test_detect_v0_nested(self):
+        self.assertEqual(detect_format('_RNvNtCs1234_7mycrate3foo3bar'), 'rust')
+
+    def test_detect_legacy(self):
+        # Legacy Rust uses _Z prefix, detected as itanium but dispatched to rust
+        # when called through demangle_rust directly
+        self.assertEqual(detect_format('_ZN3foo3barEv'), 'itanium')
+
+
+class TestRustDispatch(unittest.TestCase):
+    """Test Rust through the main demangle() dispatch."""
+
+    def test_v0_dispatch(self):
+        result = demangle('_RNvCs1234_4test3foo')
+        self.assertIsInstance(result, str)
+
+    def test_v0_structured_dispatch(self):
+        sym = demangle('_RNvCs1234_4test3foo', structured=True)
+        self.assertEqual(sym.format, 'rust')
+
+    def test_never_raises(self):
+        for inp in ['_R', '_R\x00', '_RN', '_RNv', '_RNvC']:
+            result = demangle(inp)
+            self.assertIsInstance(result, str)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vstruct/defs/macho/__init__.py
+++ b/vstruct/defs/macho/__init__.py
@@ -30,22 +30,37 @@ class mach_o(vstruct.VStruct):
         return self.mach_header.vsGetMeta('psize')
 
     def getSymbols(self):
+        '''
+        Parse the symbol table and return a list of (name, value, type, sect, desc)
+        tuples.  Uses nlist64 for 64-bit Mach-O and nlist for 32-bit.
+        '''
         if self._symbols is not None:
             return self._symbols
 
         self._symbols = []
+        psize = self.getPointerSize()
+        is_64 = (psize == 8)
+        bigend = self.vsGetEndian()
+
         for fname, vs in self.load_commands:
             if vs.cmd != LC_SYMTAB:
                 continue
             strbytes = self._raw_bytes[vs.stroff:vs.stroff+vs.strsize]
-            strtab = strbytes.split('\x00')
             offset = vs.symoff
             for i in range(vs.nsyms):
-                n = nlist() # FIXME 64!
+                if is_64:
+                    n = nlist64()
+                else:
+                    n = nlist()
                 offset = n.vsParse(self._raw_bytes, offset)
-                #symstr = strtab[n.n_strx]
-                # FIXME this is slow!
-                symstr = strbytes[n.n_strx:].split('\x00', 1)[0]
+                # Extract the symbol name from the string table at n_strx
+                if n.n_strx < len(strbytes):
+                    symstr = strbytes[n.n_strx:].split('\x00', 1)[0]
+                else:
+                    symstr = ''
+                self._symbols.append((symstr, n.n_value, n.n_type, n.n_sect, n.n_desc))
+
+        return self._symbols
 
     def getEntryPoints(self):
         if self._entrypoints is not None:

--- a/vstruct/defs/macho/__init__.py
+++ b/vstruct/defs/macho/__init__.py
@@ -40,7 +40,6 @@ class mach_o(vstruct.VStruct):
         self._symbols = []
         psize = self.getPointerSize()
         is_64 = (psize == 8)
-        bigend = self.vsGetEndian()
 
         for fname, vs in self.load_commands:
             if vs.cmd != LC_SYMTAB:


### PR DESCRIPTION
## Summary

A comprehensive, pure-Python symbol demangling library that replaces the previous `cxxfilt`-only approach and the VivisectION HTTP-to-demangler.com method. Works fully offline with no external dependencies.

Supports all major compiler mangling formats:

| Format | Prefix | Status |
|--------|--------|--------|
| Itanium (GCC/Clang/ICC) | `_Z` | Full |
| MSVC (Visual C++) | `?` | Full |
| Rust v0 (RFC 2603) | `_R` | Basic |
| Rust legacy | `_Z` | Full (via Itanium + `$` escapes) |
| D language | `_D` | Basic |
| Swift | `$s`/`_T0` | Basic |
| Java/JNI | `Java_` | Full |
| Objective-C | `_OBJC_` | Full |

## Integration

Already wired into all three binary parsers:
- **ELF** (`vivisect/parsers/elf.py`) — demangles symbol table entries and relocations
- **PE** (`vivisect/parsers/pe.py`) — demangles MSVC export names (previously passed through raw)
- **Mach-O** (`vivisect/parsers/macho.py`) — demangles symbol table entries

Workspace API:
- `vw.demangle(name, structured=False)` — on-demand demangling
- `vw.demangleNameAtVa(va, apply=True)` — demangle and apply name at a VA

Graceful degradation: never crashes on unparseable input, returns the original name.

## Test suite

**471 tests, all passing.** 7 test files covering format detection, all format handlers, AST/parser unit tests, structured output, and graceful degradation.

```
python3 -m pytest vivisect/tests/test_demangle*.py -v
```

## Files

- `vivisect/demangle/` — the library (18 files, ~8,000 lines)
- `vivisect/tests/test_demangle*.py` — 7 test files, ~2,170 lines
- Parser integration in `elf.py`, `pe.py`, `macho.py`, `__init__.py`

References: Ghidra MicrosoftDmang, LLVM MicrosoftDemangle.cpp, GNU libiberty cp-demangle.c, RFC 2603.