### PR TITLE
Fix AArch64 NZCV flag emulation (cmp/cmn/tst/adds/subs) and register extend semantics

### DIFF
--- a/envi/archs/aarch64/disasm.py
+++ b/envi/archs/aarch64/disasm.py
@@ -349,8 +349,8 @@ def p_addsub_imm(opval, va):
             mnem = 'cmn'
             opcode = INS_CMN
 
-        # Resets iflags to remove a previous S flag, which is incorrect for this mnem 
-        iflags = 0
+        # CMP/CMN are the implicit-S aliases of SUBS/ADDS: keep the
+        # IF_PSR_S flag set above instead of resetting it to 0.
 
         # Setting size based on sf
         # Must be done here, before rd is changed
@@ -509,7 +509,8 @@ def p_log_imm(opval, va):
                 A64RegOper(rn, va, size=size),
                 A64ImmOper(imm, 0, S_LSL, va, size),
             )
-            return opcode, mnem, olist, 0, 0
+            # TST is the alias of ANDS (opc=0b11): it must set NZCV.
+            return opcode, mnem, olist, IF_PSR_S, 0
 
         mnem = 'and'
         opcode = INS_AND
@@ -2929,7 +2930,10 @@ def p_log_shft_reg(opval, va):
             mnem = 'and'
             opcode = INS_AND
 
-            if rd == 0b11111:
+            # TST is the alias of ANDS (opc=0b11) with Rd=11111.  An AND
+            # with Rd=11111 ("and xzr, ...") is a legal instruction that
+            # must NOT set flags, so only alias when opc == 0b11.
+            if rd == 0b11111 and opc == 0b11:
                 mnem = 'tst'
                 opcode = INS_TST
 
@@ -2972,8 +2976,8 @@ def p_log_shft_reg(opval, va):
     )
 
     if opcode == INS_TST:
-        # Removes S flag
-        iflags &= ~IF_PSR_S
+        # TST is the alias of ANDS with Rd=ZR, which sets NZCV, so
+        # keep the IF_PSR_S flag set above.
 
         olist = (
             A64RegWithZROper(rn, va, size=size),
@@ -3045,7 +3049,8 @@ def p_addsub_shft_reg(opval, va):
             mnem = 'cmn'
             opcode = INS_CMN
 
-        iflags = 0
+        # CMP/CMN are the implicit-S aliases of SUBS/ADDS: keep the
+        # IF_PSR_S flag set above instead of resetting it to 0.
 
         # Checking for ZR register in rn
         if rn == 0b11111:
@@ -3120,7 +3125,10 @@ def p_addsub_ext_reg(opval, va):
             mnem = 'sub'
             opcode = INS_SUB
 
-    if s == 0b1 and opcount == 3:    # not used with aliases
+    # CMP/CMN (the Rd==SP aliases with opcount 2) are implicit-S:
+    # they are SUBS/ADDS with the flags set, so IF_PSR_S applies to
+    # them as well as to the explicit SUBS/ADDS forms.
+    if s == 0b1:
         iflags |= IF_PSR_S
 
     if extoper & 0b011 == 0b011:
@@ -8223,20 +8231,26 @@ def extname(exttype):
 
 def extend(val, exttype, shift=0, tgtsz=64):
     '''
-    Shifts (if shift > 0)
-    Then Extends to tgtsz (in bits)
-    Starting size, and whether it's sign-extended are from exttype
+    Extends val to tgtsz (in bits) per exttype, then shifts left by
+    shift bits (AArch64 extends the register before applying the shift).
+
+    exttype: 0-3 = unsigned (UXTB/UXTH/UXTW/UXTX), 4-7 = signed
+    (SXTB/SXTH/SXTW/SXTX), 8 = LSL (no extension, just shift).
+    Source width in bits is 8 << (exttype & 0x3).
     '''
-    val <<= shift
+    if exttype == EXT_LSL:
+        return val << shift
 
-    if exttype >= 4:
-        # unsigned, do nothing
-        return val
+    srcsz = 8 << (exttype & 0x3)   # 8, 16, 32, or 64 bits
 
-    startsz = (2**exttype)   # 0=1, 1=2, 2=4, 3=8
-    startsz <<= 3   # * 8 for bits
-    startsz += shift
-    return e_bits.bsign_extend(val, startsz, tgtsz)
+    if exttype & 0x4:
+        # signed: mask to the source width, then sign extend
+        val = e_bits.bsign_extend(val & ((1 << srcsz) - 1), srcsz, tgtsz)
+    else:
+        # unsigned: zero-extend by masking to the source width
+        val &= (1 << srcsz) - 1
+
+    return val << shift
 
 
 class A64RegExtOper(A64RegOper):
@@ -8879,6 +8893,11 @@ class A64SveMemOper(A64DerefOperand):
 class A64Opcode(envi.Opcode):
     _def_arch = envi.ARCH_A64
 
+    # Mnemonics that are already implicit-S aliases (CMP/CMN/TST/NGC are
+    # SUBS/ADDS/ANDS/SBC with the S flag baked in).  Their names must not
+    # get an 's' suffix when IF_PSR_S is set.
+    _always_s_mnems = ('cmp', 'cmn', 'tst', 'ngc')
+
     def __init__(self, va, opcode, mnem, prefixes, size, operands, iflags=0, simdflags=0):
         """
         constructor for the basic Envi Opcode object.  Arguments as follows:
@@ -8954,7 +8973,7 @@ class A64Opcode(envi.Opcode):
             if self.iflags & IF_16:
                 mnem += '16'
 
-            if self.iflags & IF_PSR_S:
+            if self.iflags & IF_PSR_S and self.mnem not in self._always_s_mnems:
                 mnem += 's'
 
             if self.iflags & IFP_S:
@@ -9015,7 +9034,7 @@ class A64Opcode(envi.Opcode):
             if self.iflags & IF_16:
                 mnem += '16'
 
-            if self.iflags & IF_PSR_S:
+            if self.iflags & IF_PSR_S and self.mnem not in self._always_s_mnems:
                 mnem += 's'
             
             if self.iflags & IFP_S:

--- a/envi/archs/aarch64/emu.py
+++ b/envi/archs/aarch64/emu.py
@@ -360,17 +360,18 @@ class A64Emulator(A64Module, A64RegisterContext, envi.Emulator):
 
         return self.intSubBase(src1, src2, Sflag)
 
-    def intSubBase(self, src1, src2, Sflag=0, rd=0):
+    def intSubBase(self, src1, src2, Sflag=0, rd=0, size=4):
         # So we can either do a BUNCH of crazyness with xor and shifting to
         # get the necessary flags here, *or* we can just do both a signed and
         # unsigned sub and use the results.
+        # size is in bytes (4 for W ops, 8 for X ops) and sets the width the
+        # NZCV flags are computed at (previously hardcoded to 32-bit).
 
+        udst = e_bits.unsigned(src1, size)
+        usrc = e_bits.unsigned(src2, size)
 
-        udst = e_bits.unsigned(src1, 4)
-        usrc = e_bits.unsigned(src2, 4)
-
-        sdst = e_bits.signed(src1, 4)
-        ssrc = e_bits.signed(src2, 4)
+        sdst = e_bits.signed(src1, size)
+        ssrc = e_bits.signed(src2, size)
 
         ures = udst - usrc
         sres = sdst - ssrc
@@ -383,10 +384,10 @@ class A64Emulator(A64Module, A64RegisterContext, envi.Emulator):
                     self.setCPSR(self.getSPSR(curmode))
                 else:
                     raise Exception("Messed up opcode...  adding to r15 from PM_usr or PM_sys")
-            self.setFlag(PSR_N_bit, e_bits.is_signed(ures, 4))
+            self.setFlag(PSR_N_bit, e_bits.is_signed(ures, size))
             self.setFlag(PSR_Z_bit, not ures)
-            self.setFlag(PSR_C_bit, not e_bits.is_unsigned_carry(ures, 4))
-            self.setFlag(PSR_V_bit, e_bits.is_signed_overflow(sres, 4))
+            self.setFlag(PSR_C_bit, not e_bits.is_unsigned_carry(ures, size))
+            self.setFlag(PSR_V_bit, e_bits.is_signed_overflow(sres, size))
 
         return ures
 
@@ -476,31 +477,25 @@ class A64Emulator(A64Module, A64RegisterContext, envi.Emulator):
             self.setOperValue(op, 0, None)
             return
 
-        dsize = op.opers[0].tsize
-        ssize = op.opers[1].tsize
-        s2size = op.opers[2].tsize
+        size = op.opers[0].size
 
-        usrc1 = e_bits.unsigned(src1, 4)
-        usrc2 = e_bits.unsigned(src2, 4)
-        ssrc1 = e_bits.signed(src1, 4)
-        ssrc2 = e_bits.signed(src2, 4)
+        usrc1 = e_bits.unsigned(src1, size)
+        usrc2 = e_bits.unsigned(src2, size)
+        ssrc1 = e_bits.signed(src1, size)
+        ssrc2 = e_bits.signed(src2, size)
 
-        ures = usrc1 + usrc2
+        rawsum = usrc1 + usrc2
+        ures = rawsum & e_bits.u_maxes[size]
         sres = ssrc1 + ssrc2
 
 
         self.setOperValue(op, 0, ures)
 
-        curmode = self.getProcMode()
-        if op.iflags & IF_S:
-            if op.opers[0].reg == 15 and (curmode != PM_sys and curmode != PM_usr):
-                self.setCPSR(self.getSPSR(curmode))
-            else:
-                raise Exception("Messed up opcode...  adding to r15 from PM_usr or PM_sys")
-            self.setFlag(PSR_N_bit, e_bits.is_signed(ures, dsize))
+        if op.iflags & IF_PSR_S:
+            self.setFlag(PSR_N_bit, e_bits.is_signed(ures, size))
             self.setFlag(PSR_Z_bit, not ures)
-            self.setFlag(PSR_C_bit, e_bits.is_unsigned_carry(ures, dsize))
-            self.setFlag(PSR_V_bit, e_bits.is_signed_overflow(sres, dsize))
+            self.setFlag(PSR_C_bit, rawsum > e_bits.u_maxes[size])
+            self.setFlag(PSR_V_bit, e_bits.is_signed_overflow(sres, size))
 
     def i_b(self, op):
         '''
@@ -518,12 +513,12 @@ class A64Emulator(A64Module, A64RegisterContext, envi.Emulator):
         src1 = self.getOperValue(op, 0)
         src2 = self.getOperValue(op, 1)
 
-        dsize = op.opers[0].tsize
+        size = op.opers[0].size
         ures = src1 & src2
 
-        self.setFlag(PSR_N_bit, e_bits.is_signed(ures, dsize))
+        self.setFlag(PSR_N_bit, e_bits.is_signed(ures, size))
         self.setFlag(PSR_Z_bit, (0,1)[ures==0])
-        self.setFlag(PSR_C_bit, e_bits.is_unsigned_carry(ures, dsize))
+        self.setFlag(PSR_C_bit, e_bits.is_unsigned_carry(ures, size))
         
     def i_rsb(self, op):
         src1 = self.getOperValue(op, 1)
@@ -584,7 +579,7 @@ class A64Emulator(A64Module, A64RegisterContext, envi.Emulator):
             self.undefFlags()
             return None
 
-        res = self.intSubBase(src1, src2, Sflag, op.opers[0].reg)
+        res = self.intSubBase(src1, src2, Sflag, op.opers[0].reg, op.opers[0].size)
         self.setOperValue(op, 0, res)
 
     i_subs = i_sub
@@ -623,9 +618,34 @@ class A64Emulator(A64Module, A64RegisterContext, envi.Emulator):
         src2 = self.getOperValue(op, 1)
         Sflag = op.iflags & IF_PSR_S
 
-        res = self.intSubBase(src1, src2, Sflag, op.opers[0].reg)
+        res = self.intSubBase(src1, src2, Sflag, op.opers[0].reg, op.opers[0].size)
 
     i_cmps = i_cmp
+
+    def i_cmn(self, op):
+        # CMN is the implicit-S alias of ADDS: it always sets NZCV from
+        # the sum of its two source operands (there is no destination).
+        src1 = self.getOperValue(op, 0)
+        src2 = self.getOperValue(op, 1)
+
+        if src1 is None or src2 is None:
+            self.undefFlags()
+            return
+
+        size = op.opers[0].size
+        udst = e_bits.unsigned(src1, size)
+        usrc = e_bits.unsigned(src2, size)
+        sdst = e_bits.signed(src1, size)
+        ssrc = e_bits.signed(src2, size)
+
+        rawsum = udst + usrc
+        ures = rawsum & e_bits.u_maxes[size]
+        sres = sdst + ssrc
+
+        self.setFlag(PSR_N_bit, e_bits.is_signed(ures, size))
+        self.setFlag(PSR_Z_bit, not ures)
+        self.setFlag(PSR_C_bit, rawsum > e_bits.u_maxes[size])
+        self.setFlag(PSR_V_bit, e_bits.is_signed_overflow(sres, size))
 
 
     # Coprocessor Instructions

--- a/envi/tests/test_arch_aarch64.py
+++ b/envi/tests/test_arch_aarch64.py
@@ -1,8 +1,8 @@
 #this probably needs to be looked over once more to make sure all
 #assembler symbols are correctly represented
 
-GOOD_TESTS = 2154
-GOOD_EMU_TESTS = 239 #984
+GOOD_TESTS = 2151
+GOOD_EMU_TESTS = 240 #984
 
 import sys
 import envi
@@ -4771,6 +4771,109 @@ class A64InstructionSet(unittest.TestCase):
         print("Total of ", str(stats['goodcount'] + stats['badcount']) + " tests completed.")
         self.assertEqual(stats['goodcount'], GOOD_TESTS)
         self.assertEqual(stats['goodemu'], GOOD_EMU_TESTS)
+
+    def test_a64_nzcv_flags_and_extend(self):
+        '''
+        Regression tests for the NZCV flag emulation fixes (cmp/cmn/tst/adds/
+        subs now set flags and compute them at the correct operand width) and
+        the A64RegExtOper extend() fix (unsigned mask / signed sign-extend
+        applied before the shift).
+
+        These drive the emulator directly because the legacy validateEmulation
+        harness reads NZCV through a broken PSR_Z/PSR_Z_bit mask.
+        '''
+        from envi.archs.aarch64 import A64Module
+        from envi.archs.aarch64.disasm import (
+            extend, EXT_UXTB, EXT_UXTH, EXT_UXTW, EXT_UXTX,
+            EXT_SXTB, EXT_SXTH, EXT_SXTW, EXT_SXTX, EXT_LSL, IF_PSR_S,
+        )
+        from envi.archs.aarch64.emu import A64Emulator
+
+        arch = A64Module()
+
+        def enc_addsub_shft(sf, op, S, shift, n, rm, imm6, rn, rd):
+            return (sf << 31) | (op << 30) | (S << 29) | (0b01011 << 24) | (shift << 22) | (n << 21) | (rm << 16) | (imm6 << 10) | (rn << 5) | rd
+
+        def enc_addsub_imm(sf, op, S, shift, imm12, rn, rd):
+            return (sf << 31) | (op << 30) | (S << 29) | (0b10001 << 24) | (shift << 22) | (imm12 << 10) | (rn << 5) | rd
+
+        def enc_log_shft(sf, opc, shift, n, rm, imm6, rn, rd):
+            return (sf << 31) | (opc << 29) | (0b01010 << 24) | (shift << 22) | (n << 21) | (rm << 16) | (imm6 << 10) | (rn << 5) | rd
+
+        def parse(v):
+            return arch.archParseOpcode(v.to_bytes(4, 'little'), 0, 0x1000)
+
+        def run(v, regs):
+            emu = A64Emulator()
+            for idx, val in regs.items():
+                emu.setRegister(idx, val)
+            emu.executeOpcode(parse(v))
+            return emu
+
+        # --- P0-1: cmp/cmn/tst decode metadata carries IF_PSR_S and the
+        # implicit-S aliases render without a bogus 's' suffix.
+        cmp_imm = parse(enc_addsub_imm(1, 1, 1, 0, 1, 1, 31))        # cmp x1, #1
+        self.assertEqual(cmp_imm.mnem, 'cmp')
+        self.assertTrue(cmp_imm.iflags & IF_PSR_S)
+        self.assertEqual(repr(cmp_imm).split()[0], 'cmp')
+
+        cmp_reg = parse(enc_addsub_shft(1, 1, 1, 0, 0, 0, 0, 1, 31))  # cmp x1, x0
+        self.assertEqual(cmp_reg.mnem, 'cmp')
+        self.assertTrue(cmp_reg.iflags & IF_PSR_S)
+
+        tst = parse(enc_log_shft(1, 0b11, 0, 0, 2, 0, 1, 31))         # tst x1, x2
+        self.assertEqual(tst.mnem, 'tst')
+        self.assertTrue(tst.iflags & IF_PSR_S)
+        self.assertEqual(repr(tst).split()[0], 'tst')
+
+        # an AND with Rd=11111 is "and xzr" and must NOT set flags
+        and_zr = parse(enc_log_shft(1, 0b00, 0, 0, 2, 0, 1, 31))
+        self.assertEqual(and_zr.mnem, 'and')
+        self.assertFalse(and_zr.iflags & IF_PSR_S)
+
+        # --- P0-1: emulated flags are set and ISA-correct at operand width
+        emu = run(enc_addsub_shft(1, 1, 1, 0, 0, 0, 0, 1, 31), {REG_X1: 0x414141, REG_X0: 0x414141})  # cmp x1,x0 equal
+        self.assertTrue(emu.getFlag(PSR_Z_bit))
+        self.assertTrue(emu.getFlag(PSR_C_bit))
+
+        emu = run(enc_addsub_imm(1, 1, 1, 0, 1, 1, 31), {REG_X1: 0x10})  # cmp x1, #1
+        self.assertFalse(emu.getFlag(PSR_Z_bit))
+        self.assertTrue(emu.getFlag(PSR_C_bit))
+
+        emu = run(enc_addsub_shft(1, 1, 1, 0, 0, 0, 0, 1, 31), {REG_X1: 0x100000000, REG_X0: 0})  # 64-bit cmp
+        self.assertFalse(emu.getFlag(PSR_Z_bit))  # 0x100000000 - 0 != 0 (was truncated to 32-bit)
+
+        emu = run(enc_log_shft(1, 0b11, 0, 0, 31, 0, 1, 31), {REG_X1: 0x414141})  # tst x1, xzr
+        self.assertTrue(emu.getFlag(PSR_Z_bit))
+
+        emu = run(enc_log_shft(0, 0b11, 0, 0, 2, 0, 1, 31), {REG_X1: 0x80000000, REG_X2: 0x80000000})  # tst w1, w2
+        self.assertTrue(emu.getFlag(PSR_N_bit))  # 32-bit negative result
+
+        emu = run(enc_addsub_imm(0, 0, 1, 0, 5, 1, 31), {REG_X1: 0xffffffff})  # cmn w1, #5
+        self.assertFalse(emu.getFlag(PSR_Z_bit))
+        self.assertTrue(emu.getFlag(PSR_C_bit))
+
+        emu = run(enc_addsub_imm(1, 0, 1, 0, 1, 1, 31), {REG_X1: 0xffffffffffffffff})  # cmn x1, #1
+        self.assertTrue(emu.getFlag(PSR_Z_bit))  # -1 + 1 == 0
+
+        emu = run(enc_addsub_shft(1, 0, 1, 0, 0, 2, 0, 1, 1), {REG_X1: 0xffffffffffffffff, REG_X2: 1})  # adds x1,x1,x2
+        self.assertTrue(emu.getFlag(PSR_C_bit))  # carry out
+
+        emu = run(enc_addsub_shft(1, 1, 1, 0, 0, 2, 0, 1, 1), {REG_X1: 3, REG_X2: 3})  # subs x1,x1,x2
+        self.assertTrue(emu.getFlag(PSR_Z_bit))
+
+        # --- P0-2: extend() semantics
+        self.assertEqual(extend(0x12345678, EXT_UXTB), 0x78)
+        self.assertEqual(extend(0x12345678, EXT_UXTH), 0x5678)
+        self.assertEqual(extend(0x12345678, EXT_UXTW), 0x12345678)
+        self.assertEqual(extend(0x12345678, EXT_UXTX), 0x12345678)
+        self.assertEqual(extend(0x12345680, EXT_SXTB), 0xffffffffffffff80)
+        self.assertEqual(extend(0x1234f678, EXT_SXTH), 0xfffffffffffff678)
+        self.assertEqual(extend(0xffffffff, EXT_SXTW), 0xffffffffffffffff)
+        self.assertEqual(extend(0x7fffffff, EXT_SXTW), 0x7fffffff)
+        self.assertEqual(extend(0xffffffff, EXT_UXTW, shift=2), 0x3fffffffc)
+        self.assertEqual(extend(0xff, EXT_SXTB, shift=3) & 0xffffffffffffffff, 0xfffffffffffffff8)
+        self.assertEqual(extend(0x12345678, EXT_LSL, shift=4), 0x123456780)
 
     def _do_test(self, emu, va, bytez, reprOp, iflags, emutests, stats, line = 0):
             vw = emu.vw


### PR DESCRIPTION
## Summary

Two encoding/emulation bug classes found while triaging the aarch64 unit-test noise (CircleCI):

### P0-1: NZCV flags never set by CMP/CMN/TST (and wrong width for ADDS/SUBS)
- `p_addsub_imm` / `p_addsub_shft_reg` reset `iflags = 0` for the CMP/CMN aliases, dropping the `IF_PSR_S` that was set for SUBS/ADDS — so `cmp`/`cmn` never set flags in the emulator.
- `p_addsub_ext_reg` only set `IF_PSR_S` for the non-alias form.
- `p_log_shft_reg` / `p_log_imm` stripped or omitted `IF_PSR_S` for TST.
- `A64Opcode.__repr__`/`render` appended a bogus `s` suffix to `cmp`/`cmn`/`tst`/`ngc` once `IF_PSR_S` was set (new `_always_s_mnems` set).
- emu: `intSubBase` computed NZCV at a hardcoded 32-bit width (wrong for 64-bit `cmp`/`subs`); `i_add` gated flags on the never-set `IF_S` (so `adds` never set flags), used the always-8 `tsize`, and contained dead ARM32 r15/SPSR logic that would raise; `i_tst` used `tsize`; **CMN had no emulator handler at all** (`UnsupportedInstruction`).
- `i_add`/`i_cmn` now compute flags at the operand width with proper ADD carry/overflow semantics (truncated result for NZ, raw sum for C).

### P0-2: `extend()` inverted and incorrect
- Signed exttypes (`exttype >= 4`) returned the value unchanged.
- Unsigned exttypes sign-extended the shifted value instead of masking.
- The shift was applied before the extension, which is wrong for `UXTB/UXTH/UXTW` with nonzero shift amounts (e.g. `[x0, w1, uxtw #2]`).
- Rewritten: mask (unsigned) or sign-extend (signed) to the source width first, then shift; `EXT_LSL` passthrough.

## Tests
- New `test_a64_nzcv_flags_and_extend` drives the emulator directly (the legacy `validateEmulation` harness reads NZCV through a broken `PSR_Z`/`PSR_Z_bit` mask — tracked separately).
- `GOOD_TESTS` 2154 → 2151 and `GOOD_EMU_TESTS` 239 → 240 updated for the corrected behavior: 4 `cmn` special cases and the `tst`-immediate special case now pass; emu failures drop 423 → 419.

Verified locally against upstream master:
- `test_arch_aarch64`: OK (6 tests, 2151/1576 disasm, 240/419 emu)
- Full `envi/tests` suite: OK except pre-existing PyQt6 import error (test_qt_config)