### PR TITLE
BugFix: loader off-by-one error

### DIFF
--- a/envi/memory.py
+++ b/envi/memory.py
@@ -515,7 +515,7 @@ class MemoryObject(IMemory):
                     # we ran into a memory map.  adjust.
                     good = False
                     tmpva = mmendva
-                    tmpva += map_align_nmask
+                    tmpva += map_align_nmask + 1
                     tmpva &= map_align_mask
                     break
 


### PR DESCRIPTION
fix an off-by-one in the loader for the rare case where a map is 1 byte in size, during multi-file loading.