### PR TITLE
docs: fix typo paramter -> parameter

### DIFF
--- a/docs/vivisect/devguides/workspaces.rst
+++ b/docs/vivisect/devguides/workspaces.rst
@@ -50,7 +50,7 @@ To retrieve all of the cross references in the workspace::
 
     vw.getXrefs()
 
-Which also takes an optional type paramter if you're only interested in certain types of cross references::
+Which also takes an optional type parameter if you're only interested in certain types of cross references::
 
     import vivisect.const as v_const
     vw.getXrefs(rtype=v_const.REF_CODE)


### PR DESCRIPTION
Corrects the misspelling `paramter` -> `parameter` in `docs/vivisect/devguides/workspaces.rst`.

Documentation only, no behaviour change.