### PR TITLE
fix: guard aarch64 .reg operand access and add A64NameOper.getOperValue

### DIFF
--- a/envi/archs/aarch64/disasm.py
+++ b/envi/archs/aarch64/disasm.py
@@ -8621,6 +8621,13 @@ class A64NameOper(A64Operand):
     def render(self, mcanv, op, idx):
         mcanv.addText(self.mnem)
 
+    def getOperValue(self, op, emu=None):
+        # A64NameOper carries a system-register/alias index in ``self.val``
+        # (e.g. for AT, DC, IC, TLBI, DSB, ISB, DBG operations).  Resolve it
+        # without an emulator so it never raises NotImplementedError during
+        # emulation or extended analysis.
+        return self.val
+
 
 prfm_types = (
         'PLD',

--- a/envi/tests/test_arch_aarch64.py
+++ b/envi/tests/test_arch_aarch64.py
@@ -4416,6 +4416,17 @@ class A64InstructionSet(unittest.TestCase):
         op = am.archParseOpcode(unhexlify('d3f021e3'))
         self.assertEqual('msr CPSR_c, #0xd3', repr(op))
 
+    def test_a64nameoper_getopervalue(self):
+        # A64NameOper should resolve its value without an emulator instead
+        # of raising NotImplementedError (upstream #732).
+        import envi.archs.aarch64.disasm as a64_disasm
+        for instype, val in ((a64_disasm.INS_IC, 1),
+                             (a64_disasm.INS_DSB, 4),
+                             (a64_disasm.INS_SYS, 7)):
+            oper = a64_disasm.A64NameOper(instype, val)
+            # must not raise
+            self.assertEqual(oper.getOperValue(None), val)
+
     def test_BigEndian(self):       #FIXME: revamp for Aarch64
         return
         am = aarch64.A64Module()

--- a/vivisect/analysis/aarch64/emulation.py
+++ b/vivisect/analysis/aarch64/emulation.py
@@ -68,7 +68,7 @@ class AnalysisMonitor(viv_monitor.AnalysisMonitor):
                         if isinstance(oper1, e_a64.A64RegOper) and oper1.reg == REG_PC:
                             self.last_lr_pc = starteip
 
-            elif op.opcode == INS_ADD and op.opers[0].reg == REG_PC:
+            elif op.opcode == INS_ADD and isinstance(op.opers[0], e_a64.A64RegOper) and op.opers[0].reg == REG_PC:
                 # simple branch code
                 if emu.vw.getVaSetRow('SwitchCases', op.va) is None:
                     base, tbl = analyzeADDPC(emu, op, starteip, self)
@@ -330,7 +330,11 @@ def analyzeTB(emu, op, starteip, amon):
 def analyzeADDPC(emu, op, starteip, emumon):
     count = None
 
-    reg = op.opers[-1].reg
+    # opers: [xd, pc, #imm] — the switch-case comparison register is xd (oper[0]).
+    # oper[-1] is the immediate offset and has no '.reg', so guard the access.
+    if not isinstance(op.opers[0], e_a64.A64RegOper):
+        return None, None
+    reg = op.opers[0].reg
     cb = emu.vw.getCodeBlock(op.va)
     if cb is None:
         return None, None
@@ -365,12 +369,11 @@ def analyzeADDPC(emu, op, starteip, emumon):
     tbl = []
     for x in range(count):
         base = op.opers[-2].getOperValue(op, emu)
-        base_reg = op.opers[-1].reg
-        emu.setRegister(base_reg, x)
-        idx = op.opers[-1].getOperValue(op, emu)
-        nexttgt = base + idx
-        #logger.debug("x=%x, base=%x, idx=%x (%x)  %r %r  %d" % (x,base,idx, nexttgt, op, op.opers, emu.getRegister(op.opers[-1].reg)))
-        tbl.append((base+idx, x))
+        # opers[-1] is the immediate offset (no '.reg'); the loop index
+        # register is xd (oper[0]) set above in ``reg``.
+        emu.setRegister(reg, x)
+        nexttgt = base + x
+        tbl.append((base+x, x))
         emu.vw.makeCode(nexttgt)
         emu.vw.addXref(starteip, nexttgt, REF_CODE)
 
@@ -392,7 +395,9 @@ def analyzeSUBPC(emu, op, starteip, emumon):
         return None, None
 
     off = 0
-    reg = op.opers[1].reg
+    if not isinstance(op.opers[0], e_a64.A64RegOper):
+        return None, None
+    reg = op.opers[0].reg
     cbva, cbsz, cbfva = cb
     while off < cbsz:
         top = emu.vw.parseOpcode(cbva+off)
@@ -422,14 +427,11 @@ def analyzeSUBPC(emu, op, starteip, emumon):
     tbl = []
 
     base = op.opers[-2].getOperValue(op, emu)
-    base_reg = op.opers[1].reg
 
     for x in range(count):
-        emu.setRegister(base_reg, x)
-        idx = op.opers[-1].getOperValue(op, emu)
-        nexttgt = base - idx
-        #logger.debug("x=%x, base=%x, idx=%x (%x)  %r %r  %d" % (x,base,idx, nexttgt, op, op.opers, emu.getRegister(op.opers[-1].reg)))
-        tbl.append((base+idx, x))
+        emu.setRegister(reg, x)
+        nexttgt = base - x
+        tbl.append((base+x, x))
         emu.vw.makeCode(nexttgt)
         emu.vw.addXref(starteip, nexttgt, REF_CODE)
 


### PR DESCRIPTION
## Summary
Fixes two AArch64 operand crashes from upstream issues:

- **#731** — `'A64ImmOper' object has no attribute 'reg'` when analyzing
  `add x15, x15, #2992`.  The aarch64 analysis module accessed `.reg` on
  operand positions that hold immediates.  Operand access is now guarded
  with `isinstance(..., A64RegOper)`, and the ADDPC/SUBPC switch-case
  helpers use the destination register (`oper[0]`) for the table loop index
  instead of the trailing immediate offset operand.
- **#732** — `A64NameOper needs to implement getOperValue!` during extended
  analysis.  Implements `A64NameOper.getOperValue()` so SYS/AT/DC/IC/TLBI/
  DSB/ISB name operands resolve their value instead of raising
  `NotImplementedError`.

## Files
- `envi/archs/aarch64/disasm.py` — add `A64NameOper.getOperValue()`
- `vivisect/analysis/aarch64/emulation.py` — guard `.reg` access, fix ADDPC/SUBPC loop index reg
- `envi/tests/test_arch_aarch64.py` — unit test for `A64NameOper.getOperValue`

## Test Plan
- `python3 -m unittest envi.tests.test_arch_aarch64.A64InstructionSet.test_a64nameoper_getopervalue` passes
- aarch64 emulation module imports cleanly

Closes #731, #732
